### PR TITLE
Us003 view collection exercise details

### DIFF
--- a/response_operations_ui/controllers/collection_exercise_controllers.py
+++ b/response_operations_ui/controllers/collection_exercise_controllers.py
@@ -1,0 +1,23 @@
+import json
+import logging
+
+import requests
+from structlog import wrap_logger
+
+from response_operations_ui import app
+from response_operations_ui.exceptions.exceptions import ApiError
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def get_collection_exercise(short_name, period):
+    logger.debug('Retrieving collection exercise details', short_name=short_name, period=period)
+    url = f'{app.config["BACKSTAGE_API_URL"]}/collection-exercise/{short_name}/{period}'
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise ApiError(response)
+
+    logger.debug('Successfully retrieved collection exercise details',
+                 short_name=short_name, period=period)
+    return json.loads(response.text)

--- a/response_operations_ui/static/scss/base.scss
+++ b/response_operations_ui/static/scss/base.scss
@@ -104,6 +104,18 @@ img {
     padding-left: 1rem;
 }
 
+.col-1\@l {
+    width: calc(100% / 12);
+}
+
+.col-5\@l {
+    width: calc(100% / 2.4);
+}
+
+.col-6\@l {
+    width: calc(100% / 2);
+}
+
 .col-8\@l {
     width: calc(100% / 1.5);
 }
@@ -114,6 +126,12 @@ img {
 
 .saturn {
     font-size: 1.55556rem;
+}
+
+.venus {
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.4;
 }
 
 .jupiter {

--- a/response_operations_ui/static/scss/components/collection-exercise-table.scss
+++ b/response_operations_ui/static/scss/components/collection-exercise-table.scss
@@ -1,0 +1,3 @@
+.ce-section h2 {
+    border-bottom: 2px solid #222;
+}

--- a/response_operations_ui/static/scss/components/table.scss
+++ b/response_operations_ui/static/scss/components/table.scss
@@ -35,5 +35,5 @@ table > thead {
 }
 
 .table--cell {
-    padding: 0.5rem 0 0.5rem 1rem;
+    padding: 0.8rem 0 0.8rem 1rem;
 }

--- a/response_operations_ui/static/scss/components/table.scss
+++ b/response_operations_ui/static/scss/components/table.scss
@@ -17,10 +17,6 @@ th, td {
     border-bottom: thin solid #e4e8eb;
 }
 
-.table__dense {
-    font-size: 81.25%;
-}
-
 table > thead {
     border-bottom: 2px solid #595959;
 }

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -1,0 +1,44 @@
+{% extends "layouts/base.html" %}
+{% block page_title %}{{ce.shortName}} {{period}}{% endblock %}
+
+{% block main %}
+<div class="container page__container">
+  <div role="main" id="main" class="page__main">
+    <br/>
+    <h1 class="jupiter">{{ce.shortName}} {{period}}</h1>
+
+    <div class="grid">
+      <div class="grid__col col-5@l"></div>
+      <div class="grid__col col-1@l"></div>
+
+      <div class="grid__col col-6@l">
+        <div class="ce-section ce-details">
+          <h2 class="venus u-pt-m">Reference information for this collection exercise</h2>
+
+          <table class="table table__dense" summary="Collection exercise details">
+            <tbody>
+              <tr class="table--row">
+                <td class="table--cell tbl-ce-label">
+                  Survey ID / Abbreviation / Title
+                </td>
+                <td class="table--cell tbl-ce-value">
+                  {{ce.surveyRef}} - {{ce.longName}} ({{ce.shortName}})
+                </td>
+              </tr>
+
+              <tr class="table--row">
+                <td class="table--cell tbl-ce-">
+                  Period
+                </td>
+                <td class="table--cell tbl-ce-">
+                  {{period}}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -21,7 +21,7 @@
                 <td class="table--cell tbl-ce-label">
                   Survey ID / Abbreviation / Title
                 </td>
-                <td class="table--cell tbl-ce-value">
+                <td class="table--cell tbl-ce-value" name="survey-info">
                   {{survey.surveyRef}} - {{survey.longName}} ({{survey.shortName}})
                 </td>
               </tr>
@@ -30,7 +30,7 @@
                 <td class="table--cell tbl-ce-">
                   Period
                 </td>
-                <td class="table--cell tbl-ce-">
+                <td class="table--cell tbl-ce-" name="period">
                   {{ce.name}}
                 </td>
               </tr>
@@ -39,7 +39,7 @@
                 <td class="table--cell tbl-ce-">
                   Shown to respondent as
                 </td>
-                <td class="table--cell tbl-ce-">
+                <td class="table--cell tbl-ce-" name="user-description">
                   {{ce.userDescription}}
                 </td>
               </tr>

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -5,7 +5,7 @@
 <div class="container page__container">
   <div role="main" id="main" class="page__main">
     <br/>
-    <h1 class="jupiter">{{ce.shortName}} {{period}}</h1>
+    <h1 class="jupiter">{{survey.shortName}} {{ce.name}}</h1>
 
     <div class="grid">
       <div class="grid__col col-5@l"></div>
@@ -22,7 +22,7 @@
                   Survey ID / Abbreviation / Title
                 </td>
                 <td class="table--cell tbl-ce-value">
-                  {{ce.surveyRef}} - {{ce.longName}} ({{ce.shortName}})
+                  {{survey.surveyRef}} - {{survey.longName}} ({{survey.shortName}})
                 </td>
               </tr>
 
@@ -31,7 +31,16 @@
                   Period
                 </td>
                 <td class="table--cell tbl-ce-">
-                  {{period}}
+                  {{ce.name}}
+                </td>
+              </tr>
+
+              <tr class="table--row">
+                <td class="table--cell tbl-ce-">
+                  Shown to respondent as
+                </td>
+                <td class="table--cell tbl-ce-">
+                  {{ce.userDescription}}
                 </td>
               </tr>
             </tbody>

--- a/response_operations_ui/views/surveys.py
+++ b/response_operations_ui/views/surveys.py
@@ -27,4 +27,5 @@ def view_survey(short_name):
 @app.route('/surveys/<short_name>/<period>', methods=['GET'])
 def view_collection_exercise(short_name, period):
     ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
-    return render_template('collection-exercise.html', ce=ce_details, period=period)
+    return render_template('collection-exercise.html',
+                           survey=ce_details['survey'], ce=ce_details['collection_exercise'])

--- a/response_operations_ui/views/surveys.py
+++ b/response_operations_ui/views/surveys.py
@@ -4,7 +4,7 @@ from flask import render_template
 from structlog import wrap_logger
 
 from response_operations_ui import app
-from response_operations_ui.controllers import survey_controllers
+from response_operations_ui.controllers import collection_exercise_controllers, survey_controllers
 
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -22,3 +22,9 @@ def view_survey(short_name):
     return render_template('survey.html',
                            survey=survey_details['survey'],
                            collection_exercises=survey_details['collection_exercises'])
+
+
+@app.route('/surveys/<short_name>/<period>', methods=['GET'])
+def view_collection_exercise(short_name, period):
+    ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
+    return render_template('collection-exercise.html', ce=ce_details, period=period)

--- a/tests/test_data/collection_exercise/collection_exercise_details.json
+++ b/tests/test_data/collection_exercise/collection_exercise_details.json
@@ -1,0 +1,34 @@
+{
+  "collection_exercise": {
+    "actualExecutionDateTime": "2017-11-10T12:14:41.768+0000",
+    "actualPublishDateTime": "2017-11-10T12:16:28.509+0000",
+    "caseTypes": [
+      {
+        "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a7",
+        "sampleUnitType": "B"
+      },
+      {
+        "actionPlanId": "0009e978-0932-463b-a2a1-b45cb3ffcb2a",
+        "sampleUnitType": "BI"
+      }
+    ],
+    "executedBy": null,
+    "exerciseRef": "221_201712",
+    "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+    "name": "000000",
+    "periodEndDateTime": "2017-09-15T22:59:59.000+0000",
+    "periodStartDateTime": "2017-09-14T23:00:00.000+0000",
+    "scheduledEndDateTime": "2018-06-29T23:00:00.000+0000",
+    "scheduledExecutionDateTime": "2017-09-10T23:00:00.000+0000",
+    "scheduledReturnDateTime": "2017-10-06T00:00:00.000+0000",
+    "scheduledStartDateTime": "2017-09-11T23:00:00.000+0000",
+    "state": "PUBLISHED",
+    "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+  },
+  "survey": {
+    "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+    "longName": "Business Register and Employment Survey",
+    "shortName": "BRES",
+    "surveyRef": "221"
+  }
+}

--- a/tests/test_data/survey/survey.json
+++ b/tests/test_data/survey/survey.json
@@ -8,7 +8,7 @@
   ],
   "survey": {
     "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
-    "longName": "",
+    "longName": "Business Register and Employment Survey",
     "shortName": "BRES",
     "surveyRef": "221"
   }

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -14,6 +14,9 @@ with open('tests/test_data/survey/survey_list.json') as json_data:
 url_get_survey_by_short_name = f'{app.config["BACKSTAGE_API_URL"]}/survey/shortname/bres'
 with open('tests/test_data/survey/survey.json') as json_data:
     survey_info = json.load(json_data)
+url_get_collection_exercise = f'{app.config["BACKSTAGE_API_URL"]}/collection-exercise/test/000000'
+with open('tests/test_data/collection_exercise/collection_exercise_details.json') as json_data:
+    collection_exercise_details = json.load(json_data)
 
 
 class TestSurvey(unittest.TestCase):
@@ -62,6 +65,25 @@ class TestSurvey(unittest.TestCase):
         mock_request.get(url_get_survey_by_short_name, status_code=500)
 
         response = self.app.get("/surveys/bres")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("FAIL".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_collection_exercise_view(self, mock_request):
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+
+        response = self.app.get("/surveys/test/000000")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Business Register and Employment Survey".encode(), response.data)
+        self.assertIn("000000".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_collection_exercise_view_fail(self, mock_request):
+        mock_request.get(url_get_collection_exercise, status_code=500)
+
+        response = self.app.get("/surveys/test/000000")
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("FAIL".encode(), response.data)


### PR DESCRIPTION
Added a new page to show single collection exercise details.
![screen shot 2018-01-04 at 13 22 47](https://user-images.githubusercontent.com/22077099/34565345-64a519fa-f152-11e7-94d2-5b8222dac96c.png)

A single call is made to backstage which returns collection exercise and survey information.

This PR uses an endpoint in ras-backstage introduced in [this PR](https://github.com/ONSdigital/ras-backstage/pull/26)
The "Shown to respondent as" field wont be filled until story US002a is complete and in an environment.

[Trello](https://trello.com/c/Gsa6v2ou/37-us003-view-collection-exercise-details-l-5-days)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/160235584/US003+View+Collection+Exercise+Details+L)
  