### PR TITLE
View list of collection instruments uploaded

### DIFF
--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -26,5 +26,5 @@ logger_initial_config(service_name='response-operations-ui', log_level=app.confi
 
 
 from response_operations_ui import error_handlers  # NOQA # pylint: disable=wrong-import-position
-from response_operations_ui.views import surveys  # NOQA # pylint: disable=wrong-import-position
+from response_operations_ui.views import collection_exercise, surveys  # NOQA # pylint: disable=wrong-import-position
 from response_operations_ui.views import info  # NOQA # pylint: disable=wrong-import-position

--- a/response_operations_ui/controllers/collection_exercise_controllers.py
+++ b/response_operations_ui/controllers/collection_exercise_controllers.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import requests
@@ -6,7 +5,6 @@ from structlog import wrap_logger
 
 from response_operations_ui import app
 from response_operations_ui.exceptions.exceptions import ApiError
-
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -20,4 +18,4 @@ def get_collection_exercise(short_name, period):
 
     logger.debug('Successfully retrieved collection exercise details',
                  short_name=short_name, period=period)
-    return json.loads(response.text)
+    return response.json()

--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import requests

--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -16,12 +16,3 @@ def upload_collection_instrument(short_name, period, file):
     response = requests.post(url, files={"file": (file.filename, file.stream, file.mimetype)})
     if response.status_code != 201:
         raise ApiError(response)
-
-
-def get_collection_instruments(short_name, period):
-    logger.debug('Getting collection instruments', short_name=short_name, period=period)
-    url = f'{app.config["BACKSTAGE_API_URL"]}/collection-instrument/{short_name}/{period}'
-    response = requests.get(url)
-    if response.status_code != 200:
-        raise ApiError(response)
-    return json.loads(response.text)

--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import requests
@@ -15,3 +16,12 @@ def upload_collection_instrument(short_name, period, file):
     response = requests.post(url, files={"file": (file.filename, file.stream, file.mimetype)})
     if response.status_code != 201:
         raise ApiError(response)
+
+
+def get_collection_instruments(short_name, period):
+    logger.debug('Getting collection instruments', short_name=short_name, period=period)
+    url = f'{app.config["BACKSTAGE_API_URL"]}/collection-instrument/{short_name}/{period}'
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise ApiError(response)
+    return json.loads(response.text)

--- a/response_operations_ui/controllers/survey_controllers.py
+++ b/response_operations_ui/controllers/survey_controllers.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import requests
@@ -6,7 +5,6 @@ from structlog import wrap_logger
 
 from response_operations_ui import app
 from response_operations_ui.exceptions.exceptions import ApiError
-
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -19,7 +17,7 @@ def get_surveys_list():
         raise ApiError(response)
 
     logger.debug('Successfully retrieved surveys list')
-    return json.loads(response.text)
+    return response.json()
 
 
 def get_survey(short_name):
@@ -31,4 +29,4 @@ def get_survey(short_name):
         raise ApiError(response)
 
     logger.debug('Successfully retrieved survey', short_name=short_name)
-    return json.loads(response.text)
+    return response.json()

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -20,7 +20,7 @@
 
           {% if collection_instruments %}
           <div>
-            <table class="table table__dense" summary="Sample details for this collection exercise">
+            <table id="collection-instruments-table" class="table table__dense" summary="Sample details for this collection exercise">
               <thead class="table--head u-vh">
                 <tr class="table--row">
                   <th scope="col" class="table--header--cell tbl-ce-value">

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -33,7 +33,7 @@
               {% for collection_instrument in collection_instruments %}
                 <tr class="table--row">
                   <td class="table--cell tbl-ce-value">
-                    {{collection_instrument}}
+                    {{collection_instrument.file_name}}
                   </td>
                 </tr>
               {% endfor %}

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -17,10 +17,36 @@
       <div class="grid__col col-6@l">
         <section class="ce-section">
           <h2 class="venus u-pt-m">Collection instruments</h2>
+
+          {% if collection_instruments %}
+          <div>
+            <table class="table table__dense" summary="Sample details for this collection exercise">
+              <thead class="table--head u-vh">
+                <tr class="table--row">
+                  <th scope="col" class="table--header--cell tbl-ce-value">
+                    Collection instrument
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+
+              {% for collection_instrument in collection_instruments %}
+                <tr class="table--row">
+                  <td class="table--cell tbl-ce-value">
+                    {{collection_instrument}}
+                  </td>
+                </tr>
+              {% endfor %}
+
+              </tbody>
+            </table>
+          </div>
+          {% endif %}
+
           <div class="u-mb-m">
             <form action="" class="form" method="post" enctype="multipart/form-data">
               <p>
-                Choose a collection instrument (CI) to load
+                {{ 'Add another collection instrument (CI)' if collection_instruments else 'Choose a collection instrument (CI) to load'}}
               </p>
               <label class="upload-file u-vh" for="ciFile">Choose CI file</label>
               <input id="ciFile" type="file" class="" name="ciFile" accept=".xlsx">

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -13,9 +13,9 @@ logger = wrap_logger(logging.getLogger(__name__))
 @app.route('/surveys/<short_name>/<period>', methods=['GET'])
 def view_collection_exercise(short_name, period):
     ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
-    cis = collection_instrument_controllers.get_collection_instruments(short_name, period)
     return render_template('collection-exercise.html', survey=ce_details['survey'],
-                           ce=ce_details['collection_exercise'], collection_instruments=cis)
+                           ce=ce_details['collection_exercise'],
+                           collection_instruments=ce_details['collection_instruments'])
 
 
 @app.route('/surveys/<short_name>/<period>', methods=['POST'])
@@ -28,9 +28,9 @@ def upload_collection_instrument(short_name, period):
         ci_loaded = True
 
     ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
-    cis = collection_instrument_controllers.get_collection_instruments(short_name, period)
     return render_template('collection-exercise.html', survey=ce_details['survey'],
-                           ce=ce_details['collection_exercise'], ci_loaded=ci_loaded, collection_instruments=cis)
+                           ce=ce_details['collection_exercise'], ci_loaded=ci_loaded,
+                           collection_instruments=ce_details['collection_instruments'])
 
 
 def _validate_collection_instrument():

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -1,0 +1,47 @@
+import logging
+
+from flask import render_template, request
+from structlog import wrap_logger
+
+from response_operations_ui import app
+from response_operations_ui.controllers import collection_exercise_controllers
+from response_operations_ui.controllers import collection_instrument_controllers
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+@app.route('/surveys/<short_name>/<period>', methods=['GET'])
+def view_collection_exercise(short_name, period):
+    ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
+    cis = collection_instrument_controllers.get_collection_instruments(short_name, period)
+    return render_template('collection-exercise.html', survey=ce_details['survey'],
+                           ce=ce_details['collection_exercise'], collection_instruments=cis)
+
+
+@app.route('/surveys/<short_name>/<period>', methods=['POST'])
+def upload_collection_instrument(short_name, period):
+    error = _validate_collection_instrument()
+    ci_loaded = False
+
+    if not error:
+        collection_instrument_controllers.upload_collection_instrument(short_name, period, request.files['ciFile'])
+        ci_loaded = True
+
+    ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
+    cis = collection_instrument_controllers.get_collection_instruments(short_name, period)
+    return render_template('collection-exercise.html', survey=ce_details['survey'],
+                           ce=ce_details['collection_exercise'], ci_loaded=ci_loaded, collection_instruments=cis)
+
+
+def _validate_collection_instrument():
+    error = None
+    if 'ciFile' in request.files:
+        file = request.files['ciFile']
+        if not str.endswith(file.filename, '.xlsx'):
+            logger.debug('Invalid file format uploaded', filename=file.filename)
+            error = 'Invalid file format'
+    else:
+        logger.debug('No file uploaded')
+        error = 'File not uploaded'
+
+    return error

--- a/response_operations_ui/views/surveys.py
+++ b/response_operations_ui/views/surveys.py
@@ -1,11 +1,10 @@
 import logging
 
-from flask import render_template, request
+from flask import render_template
 from structlog import wrap_logger
 
 from response_operations_ui import app
-from response_operations_ui.controllers import collection_exercise_controllers, survey_controllers
-from response_operations_ui.controllers import collection_instrument_controllers
+from response_operations_ui.controllers import survey_controllers
 
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -28,39 +27,3 @@ def view_survey(short_name):
     return render_template('survey.html',
                            survey=survey_details['survey'],
                            collection_exercises=survey_details['collection_exercises'])
-
-
-@app.route('/surveys/<short_name>/<period>', methods=['GET'])
-def view_collection_exercise(short_name, period):
-    ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
-    return render_template('collection-exercise.html',
-                           survey=ce_details['survey'], ce=ce_details['collection_exercise'])
-
-
-@app.route('/surveys/<short_name>/<period>', methods=['POST'])
-def upload_collection_instrument(short_name, period):
-    error = _validate_collection_instrument()
-    ci_loaded = False
-
-    if not error:
-        collection_instrument_controllers.upload_collection_instrument(short_name, period, request.files['ciFile'])
-        ci_loaded = True
-
-    ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
-    return render_template('collection-exercise.html',
-                           survey=ce_details['survey'], ce=ce_details['collection_exercise'], error=error,
-                           ci_loaded=ci_loaded)
-
-
-def _validate_collection_instrument():
-    error = None
-    if 'ciFile' in request.files:
-        file = request.files['ciFile']
-        if not str.endswith(file.filename, '.xlsx'):
-            logger.debug('Invalid file format uploaded', filename=file.filename)
-            error = 'Invalid file format'
-    else:
-        logger.debug('No file uploaded')
-        error = 'File not uploaded'
-
-    return error

--- a/tests/test_data/collection_exercise/collection_exercise_details_no_ci.json
+++ b/tests/test_data/collection_exercise/collection_exercise_details_no_ci.json
@@ -32,17 +32,5 @@
     "surveyRef": "221"
   },
   "collection_instruments": [
-    {
-      "classifiers": {
-        "COLLECTION_EXERCISE": [
-          "e33daf0e-6a27-40cd-98dc-c6231f50e84a"
-        ],
-        "RU_REF": [],
-        "SURVEY_ID": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
-      },
-      "file_name": "collection_instrument.xlsx",
-      "id": "f732afbe-c710-4c95-a8d3-6644833195a7",
-      "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
-    }
   ]
 }

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -1,0 +1,129 @@
+import json
+import unittest
+from io import BytesIO
+
+import requests_mock
+
+from response_operations_ui import app
+
+url_get_collection_exercise = f'{app.config["BACKSTAGE_API_URL"]}/collection-exercise/test/000000'
+with open('tests/test_data/collection_exercise/collection_exercise_details.json') as json_data:
+    collection_exercise_details = json.load(json_data)
+url_collection_instrument = f'{app.config["BACKSTAGE_API_URL"]}/collection-instrument/test/000000'
+
+
+class TestCollectionExercise(unittest.TestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+
+    @requests_mock.mock()
+    def test_collection_exercise_view(self, mock_request):
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_collection_instrument, json=[])
+
+        response = self.app.get("/surveys/test/000000")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Business Register and Employment Survey".encode(), response.data)
+        self.assertIn("221_201712".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_collection_exercise_view_fail(self, mock_request):
+        mock_request.get(url_get_collection_exercise, status_code=500)
+
+        response = self.app.get("/surveys/test/000000")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("FAIL".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_upload_collection_instrument(self, mock_request):
+        file = dict(
+            ciFile=(BytesIO(b'data'), 'test.xlsx'),
+        )
+        mock_request.post(url_collection_instrument, status_code=201)
+        mock_request.get(url_collection_instrument, json=[])
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+
+        response = self.app.post("/surveys/test/000000", data=file)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Collection instrument loaded".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_failed_upload_collection_instrument(self, mock_request):
+        file = dict(
+            ciFile=(BytesIO(b'data'), 'test.xlsx'),
+        )
+        mock_request.post(url_collection_instrument, status_code=500)
+        mock_request.get(url_collection_instrument, json=[])
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+
+        response = self.app.post("/surveys/test/000000", data=file)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("FAIL".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_no_upload_collection_instrument_when_bad_extension(self, mock_request):
+        file = dict(
+            ciFile=(BytesIO(b'data'), 'test.html'),
+        )
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_collection_instrument, json=[])
+
+        response = self.app.post("/surveys/test/000000", data=file)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Collection instrument loaded".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_no_upload_collection_instrument_when_no_file(self, mock_request):
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_collection_instrument, json=[])
+
+        response = self.app.post("/surveys/test/000000")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Collection instrument loaded".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_view_collection_instrument(self, mock_request):
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_collection_instrument, json=['collection_instrument.xlsx'])
+
+        response = self.app.get("/surveys/test/000000")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("collection_instrument.xlsx".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_choose_collection_instrument_when_first(self, mock_request):
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_collection_instrument, json=[])
+
+        response = self.app.get("/surveys/test/000000")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Choose a collection instrument (CI) to load".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_add_another_collection_instrument_when_already_uploaded(self, mock_request):
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_collection_instrument, json=['collection_instrument.xlsx'])
+
+        response = self.app.get("/surveys/test/000000")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Add another collection instrument (CI)".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_failed_get_collection_instruments(self, mock_request):
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_collection_instrument, status_code=500)
+
+        response = self.app.get("/surveys/test/000000")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("FAIL".encode(), response.data)

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -1,13 +1,11 @@
 import json
 import unittest
-from io import BytesIO
 from unittest.mock import MagicMock
 
-from requests import RequestException
 import requests_mock
+from requests import RequestException
 
 from response_operations_ui import app
-
 
 url_get_survey_list = f'{app.config["BACKSTAGE_API_URL"]}/survey/surveys'
 with open('tests/test_data/survey/survey_list.json') as json_data:
@@ -15,10 +13,6 @@ with open('tests/test_data/survey/survey_list.json') as json_data:
 url_get_survey_by_short_name = f'{app.config["BACKSTAGE_API_URL"]}/survey/shortname/bres'
 with open('tests/test_data/survey/survey.json') as json_data:
     survey_info = json.load(json_data)
-url_get_collection_exercise = f'{app.config["BACKSTAGE_API_URL"]}/collection-exercise/test/000000'
-with open('tests/test_data/collection_exercise/collection_exercise_details.json') as json_data:
-    collection_exercise_details = json.load(json_data)
-url_upload_collection_instrument = f'{app.config["BACKSTAGE_API_URL"]}/collection-instrument/test/000000'
 
 
 class TestSurvey(unittest.TestCase):
@@ -79,69 +73,3 @@ class TestSurvey(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("FAIL".encode(), response.data)
-
-    @requests_mock.mock()
-    def test_collection_exercise_view(self, mock_request):
-        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
-
-        response = self.app.get("/surveys/test/000000")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("Business Register and Employment Survey".encode(), response.data)
-        self.assertIn("221_201712".encode(), response.data)
-
-    @requests_mock.mock()
-    def test_collection_exercise_view_fail(self, mock_request):
-        mock_request.get(url_get_collection_exercise, status_code=500)
-
-        response = self.app.get("/surveys/test/000000")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("FAIL".encode(), response.data)
-
-    @requests_mock.mock()
-    def test_upload_collection_instrument(self, mock_request):
-        file = dict(
-            ciFile=(BytesIO(b'data'), 'test.xlsx'),
-        )
-        mock_request.post(url_upload_collection_instrument, status_code=201)
-        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
-
-        response = self.app.post("/surveys/test/000000", data=file)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("Collection instrument loaded".encode(), response.data)
-
-    @requests_mock.mock()
-    def test_failed_upload_collection_instrument(self, mock_request):
-        file = dict(
-            ciFile=(BytesIO(b'data'), 'test.xlsx'),
-        )
-        mock_request.post(url_upload_collection_instrument, status_code=500)
-        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
-
-        response = self.app.post("/surveys/test/000000", data=file)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("FAIL".encode(), response.data)
-
-    @requests_mock.mock()
-    def test_no_upload_collection_instrument_when_bad_extension(self, mock_request):
-        file = dict(
-            ciFile=(BytesIO(b'data'), 'test.html'),
-        )
-        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
-
-        response = self.app.post("/surveys/test/000000", data=file)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertNotIn("Collection instrument loaded".encode(), response.data)
-
-    @requests_mock.mock()
-    def test_no_upload_collection_instrument_when_no_file(self, mock_request):
-        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
-
-        response = self.app.post("/surveys/test/000000")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertNotIn("Collection instrument loaded".encode(), response.data)


### PR DESCRIPTION
* User story *
As a Collection Exercise Coordinator
I need: to view the collection instruments that the system holds for the
given collection exercise
So that: I am happy that the collection instrument(s) loaded are correct

* Acceptance criteria *
Given the collection instruments have been loaded
When the user navigates to the collection exercise details page
Then they are able to see the filename (surveyid_formtype_period) of all
collection instruments that have been loaded