### PR TITLE
US026 Breadcrumb Navigation

### DIFF
--- a/response_operations_ui/static/scss/base.scss
+++ b/response_operations_ui/static/scss/base.scss
@@ -124,6 +124,12 @@ img {
     width: calc(100% / 1);
 }
 
+.mercury {
+    font-size: 0.77778rem;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
 .saturn {
     font-size: 1.55556rem;
 }

--- a/response_operations_ui/static/scss/components/breadcrumb.scss
+++ b/response_operations_ui/static/scss/components/breadcrumb.scss
@@ -1,0 +1,45 @@
+
+/* Breadcrumb trail styles */
+
+
+.breadcrumb{
+  /*display: none;*/
+}
+
+
+.breadcrumb{
+    list-style: none;
+    padding-left: 0;
+    margin-top: 1rem;
+}
+
+.breadcrumb--item, .breadcrumb--item__current{
+    list-style: none;
+    display: inline-block;
+    color: #666;
+    font-weight: 400;
+}
+
+.breadcrumb a:link{
+    text-decoration: none;
+}
+
+.breadcrumb a:visited{
+    text-decoration: none;
+}
+
+.breadcrumb a:hover{
+    text-decoration: underline;
+    color: #222;
+}
+
+.breadcrumb a:focus,
+.breadcrumb a:active{
+    text-decoration: underline;
+    color: #fff;
+}
+
+.breadcrumb--item::after{
+    content: " >  ";
+    margin: 0 0.3rem;
+}

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -2,72 +2,71 @@
 {% block page_title %}{{ce.shortName}} {{period}}{% endblock %}
 
 {% block main %}
-<div class="container page__container">
-  <div role="main" id="main" class="page__main">
-    <br/>
-    <h1 class="jupiter" name="page-ce-title">{{survey.shortName}} {{ce.exerciseRef}}</h1>
-    <ul>
-      {% if ci_loaded %}
-        <li id="collection-instrument-success" class="system-feedback__item success">Collection instrument loaded</li>
-      {% endif %}
-    </ul>
 
-    <div class="grid">
+<div role="main" id="main" class="page__main">
+  <br/>
+  <h1 class="jupiter" name="page-ce-title">{{survey.shortName}} {{ce.exerciseRef}}</h1>
+  <ul>
+    {% if ci_loaded %}
+      <li id="collection-instrument-success" class="system-feedback__item success">Collection instrument loaded</li>
+    {% endif %}
+  </ul>
 
-      <div class="grid__col col-6@l">
-        <section class="ce-section">
-          <h2 class="venus u-pt-m">Collection instruments</h2>
-          <div class="u-mb-m">
-            <form action="" class="form" method="post" enctype="multipart/form-data">
-              <p>
-                Choose a collection instrument (CI) to load
-              </p>
-              <label class="upload-file u-vh" for="ciFile">Choose CI file</label>
-              <input id="ciFile" type="file" class="" name="ciFile" accept=".xlsx">
-              <button id="btn-load-ci" class="btn btn--primary unready">Add CI</button>
-            </form>
-          </div>
-        </section>
-      </div>
+  <div class="grid">
 
-      <div class="grid__col col-1@l">
-      </div>
-
-      <div class="grid__col col-5@l">
-        <div class="ce-section ce-details">
-          <h2 class="venus u-pt-m">Reference information for this collection exercise</h2>
-
-          <table class="table table__dense" summary="Collection exercise details">
-            <tbody>
-              <tr class="table--row">
-                <td class="table--cell tbl-ce-label">
-                  Survey ID / Abbreviation / Title
-                </td>
-                <td class="table--cell tbl-ce-value" name="survey-info">
-                  {{survey.surveyRef}} - {{survey.longName}} ({{survey.shortName}})
-                </td>
-              </tr>
-
-              <tr class="table--row">
-                <td class="table--cell tbl-ce-">
-                  Period
-                </td>
-                <td class="table--cell tbl-ce-" name="period">
-                  {{ce.exerciseRef}}
-                </td>
-              </tr>
-
-              <tr class="table--row">
-                <td class="table--cell tbl-ce-">
-                  Shown to respondent as
-                </td>
-                <td class="table--cell tbl-ce-" name="user-description">
-                  {{ce.userDescription}}
-                </td>
-              </tr>
-            </tbody>
-          </table>
+    <div class="grid__col col-6@l">
+      <section class="ce-section">
+        <h2 class="venus u-pt-m">Collection instruments</h2>
+        <div class="u-mb-m">
+          <form action="" class="form" method="post" enctype="multipart/form-data">
+            <p>
+              Choose a collection instrument (CI) to load
+            </p>
+            <label class="upload-file u-vh" for="ciFile">Choose CI file</label>
+            <input id="ciFile" type="file" class="" name="ciFile" accept=".xlsx">
+            <button id="btn-load-ci" class="btn btn--primary unready">Add CI</button>
+          </form>
         </div>
+      </section>
+    </div>
+
+    <div class="grid__col col-1@l">
+    </div>
+
+    <div class="grid__col col-5@l">
+      <div class="ce-section ce-details">
+        <h2 class="venus u-pt-m">Reference information for this collection exercise</h2>
+
+        <table class="table table__dense" summary="Collection exercise details">
+          <tbody>
+            <tr class="table--row">
+              <td class="table--cell tbl-ce-label">
+                Survey ID / Abbreviation / Title
+              </td>
+              <td class="table--cell tbl-ce-value" name="survey-info">
+                {{survey.surveyRef}} - {{survey.longName}} ({{survey.shortName}})
+              </td>
+            </tr>
+
+            <tr class="table--row">
+              <td class="table--cell tbl-ce-">
+                Period
+              </td>
+              <td class="table--cell tbl-ce-" name="period">
+                {{ce.exerciseRef}}
+              </td>
+            </tr>
+
+            <tr class="table--row">
+              <td class="table--cell tbl-ce-">
+                Shown to respondent as
+              </td>
+              <td class="table--cell tbl-ce-" name="user-description">
+                {{ce.userDescription}}
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/response_operations_ui/templates/home.html
+++ b/response_operations_ui/templates/home.html
@@ -2,16 +2,14 @@
 {% block page_title %}Surveys | Survey Data Collection{% endblock %}
 
 {% block main %}
-<div class="container page__container">
-  <div class="grid">
-    <div class="grid__col col-12@m">
-      <div role="main" id="main" class="page__main">
-        <ul class="u-pt-l">
-          <li>
-            <a name="surveys-link" href="/surveys/">View list of business surveys</a>
-          </li>
-        </ul>
-      </div>
+<div class="grid">
+  <div class="grid__col col-12@m">
+    <div role="main" id="main" class="page__main">
+      <ul class="u-pt-l">
+        <li>
+          <a name="surveys-link" href="/surveys/">View list of business surveys</a>
+        </li>
+      </ul>
     </div>
   </div>
 </div>

--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -22,7 +22,12 @@
     <div class="page account">
       <div class="page__content">
         {% include 'partials/header.html' %}
-        {%- block main %}{% endblock main -%}
+        <div class="container page__container">
+          {% if breadcrumbs %}
+          {% include 'partials/breadcrumbs.html' %}
+          {% endif %}
+          {%- block main %}{% endblock main -%}
+        </div>
       </div>
     </div>
     {% include 'partials/footer.html' %}

--- a/response_operations_ui/templates/partials/breadcrumbs.html
+++ b/response_operations_ui/templates/partials/breadcrumbs.html
@@ -1,4 +1,4 @@
-<ol class="breadcrumb">
+<ol id="breadcrumbs" class="breadcrumb">
   <li id="breadcrumb-1" class="breadcrumb--item mercury">
     <a href="/">Home</a>
   </li>

--- a/response_operations_ui/templates/partials/breadcrumbs.html
+++ b/response_operations_ui/templates/partials/breadcrumbs.html
@@ -1,0 +1,13 @@
+<ol class="breadcrumb">
+  <li class="breadcrumb--item mercury">
+    <a href="/">Home</a>
+  </li>
+  {% for breadcrumb in breadcrumbs[:-1] %}
+  <li class="breadcrumb--item mercury">
+    <a href={{breadcrumb.link}}>{{breadcrumb.title}}</a>
+  </li>
+  {% endfor %}
+  <li class="breadcrumb--item__current mercury">
+    {{breadcrumbs[-1].title}}
+  </li>
+</ol>

--- a/response_operations_ui/templates/partials/breadcrumbs.html
+++ b/response_operations_ui/templates/partials/breadcrumbs.html
@@ -1,13 +1,13 @@
 <ol class="breadcrumb">
-  <li class="breadcrumb--item mercury">
+  <li id="breadcrumb-1" class="breadcrumb--item mercury">
     <a href="/">Home</a>
   </li>
   {% for breadcrumb in breadcrumbs[:-1] %}
-  <li class="breadcrumb--item mercury">
+  <li id="breadcrumb-{{loop.index+1}}" class="breadcrumb--item mercury">
     <a href={{breadcrumb.link}}>{{breadcrumb.title}}</a>
   </li>
   {% endfor %}
-  <li class="breadcrumb--item__current mercury">
+  <li id="breadcrumb-{{breadcrumbs | length + 1}}" class="breadcrumb--item__current mercury">
     {{breadcrumbs[-1].title}}
   </li>
 </ol>

--- a/response_operations_ui/templates/survey.html
+++ b/response_operations_ui/templates/survey.html
@@ -3,70 +3,68 @@
 
 {% block main %}
 </br>
-<div class="container page__container">
-  <div role="main" id="main" class="page__main">
-  <h1 class="jupiter" name="page-survey-title">{{survey.longName}}</h1>
+<div role="main" id="main" class="page__main">
+<h1 class="jupiter" name="page-survey-title">{{survey.longName}}</h1>
 
-    <div class="grid">
-      <div class="grid__col col-8@l">
-        <div class="">
-          <dl class="survey-info info-panel" id="survey-attributes">
-            <dt class="survey-info__title">
-              Survey ID:
-            </dt>
-            <dd class="survey-info__data" name="survey-id">
-              {{survey.surveyRef}}
-            </dd>
-            <dt class="survey-info__title">
-              Survey title:
-            </dt>
-            <dd class="survey-info__data" name="survey-title">
-              {{survey.longName}}
-            </dd>
-            <dt class="survey-info__title">
-              Abbreviation:
-            </dt>
-            <dd class="survey-info__data" name="survey-abbreviation">
-              {{survey.shortName}}
-            </dd>
-            <dt class="survey-info__title">
-              Legal basis:
-            </dt>
-            <dd class="survey-info__data" name="survey-legal-basis">
-              {{survey.legalBasis}}
-            </dd>
-          </dl>
-        </div>
-        <div class="ce-list">
-          <h2 class="saturn u-pt-m">Collection exercises for {{survey.shortName}}</h2>
-          <table class="table__dense" summary="Collection exercises for the MWSS survey" id="tbl-collection-exercise">
-            <thead class="table--head">
-              <tr class="table--row">
-                <th scope="col" class="table--header--cell tbl-ce-period">
-                  Period
-                </th>
-                <th scope="col" class="table--header--cell tbl-ce-respondent-info">
-                  Shown to respondent as
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for exercise in collection_exercises %}
-              <tr class="table--row">
-                <td class="table--cell tbl-ce-period" name="tbl-ce-period">
-                  <a href="/surveys/{{ survey.shortName.replace(' ', '') }}/{{ exercise.exerciseRef }}"
-                     name="ce-link-{{exercise.exerciseRef}}">
-                    {{exercise.exerciseRef}}
-                  </a>
-                </td>
-                <td class="table--cell tbl-ce-respondent-info" name="tbl-ce-shown-as">
-                  {{exercise.userDescription}}
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
+  <div class="grid">
+    <div class="grid__col col-8@l">
+      <div class="">
+        <dl class="survey-info info-panel" id="survey-attributes">
+          <dt class="survey-info__title">
+            Survey ID:
+          </dt>
+          <dd class="survey-info__data" name="survey-id">
+            {{survey.surveyRef}}
+          </dd>
+          <dt class="survey-info__title">
+            Survey title:
+          </dt>
+          <dd class="survey-info__data" name="survey-title">
+            {{survey.longName}}
+          </dd>
+          <dt class="survey-info__title">
+            Abbreviation:
+          </dt>
+          <dd class="survey-info__data" name="survey-abbreviation">
+            {{survey.shortName}}
+          </dd>
+          <dt class="survey-info__title">
+            Legal basis:
+          </dt>
+          <dd class="survey-info__data" name="survey-legal-basis">
+            {{survey.legalBasis}}
+          </dd>
+        </dl>
+      </div>
+      <div class="ce-list">
+        <h2 class="saturn u-pt-m">Collection exercises for {{survey.shortName}}</h2>
+        <table class="table__dense" summary="Collection exercises for the MWSS survey" id="tbl-collection-exercise">
+          <thead class="table--head">
+            <tr class="table--row">
+              <th scope="col" class="table--header--cell tbl-ce-period">
+                Period
+              </th>
+              <th scope="col" class="table--header--cell tbl-ce-respondent-info">
+                Shown to respondent as
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for exercise in collection_exercises %}
+            <tr class="table--row">
+              <td class="table--cell tbl-ce-period" name="tbl-ce-period">
+                <a href="/surveys/{{ survey.shortName.replace(' ', '') }}/{{ exercise.exerciseRef }}"
+                   name="ce-link-{{exercise.exerciseRef}}">
+                  {{exercise.exerciseRef}}
+                </a>
+              </td>
+              <td class="table--cell tbl-ce-respondent-info" name="tbl-ce-shown-as">
+                {{exercise.userDescription}}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/response_operations_ui/templates/surveys.html
+++ b/response_operations_ui/templates/surveys.html
@@ -3,52 +3,50 @@
 
 {% block main %}
 </br>
-<div class="container page__container">
-  <div role="main" id="main" class="page__main">
-    <h1 class="jupiter" name="page-surveys-title">Surveys</h1>
-    <div class="grid">
-      <div class="grid__col col-12@l">
-        <div class="survey-list">
+<div role="main" id="main" class="page__main">
+  <h1 class="jupiter" name="page-surveys-title">Surveys</h1>
+  <div class="grid">
+    <div class="grid__col col-12@l">
+      <div class="survey-list">
 
-          <table id="tbl-surveys" class="table__dense" summary="Surveys in the system">
-            <thead class="table--head">
-              <tr class="table--row">
-                <th scope="col" class="table--header--cell tbl-surveys-id">
-                  ID
-                </th>
-                <th scope="col" class="table--header--cell tbl-surveys-title">
-                  Title
-                </th>
-                <th scope="col" class="table--header--cell tbl-surveys-abbreviation">
-                  Abbreviation
-                </th>
-                <th scope="col" class="table--header--cell tbl-surveys-legal-basis">
-                  Legal basis
-                </th>
-              </tr>
-            </thead>
+        <table id="tbl-surveys" class="table__dense" summary="Surveys in the system">
+          <thead class="table--head">
+            <tr class="table--row">
+              <th scope="col" class="table--header--cell tbl-surveys-id">
+                ID
+              </th>
+              <th scope="col" class="table--header--cell tbl-surveys-title">
+                Title
+              </th>
+              <th scope="col" class="table--header--cell tbl-surveys-abbreviation">
+                Abbreviation
+              </th>
+              <th scope="col" class="table--header--cell tbl-surveys-legal-basis">
+                Legal basis
+              </th>
+            </tr>
+          </thead>
 
-            <tbody>
-              {% for survey in survey_list %}
-              <tr class="table--row table--row__selectable">
-                <td name="tbl-surveys-id" class="table--cell tbl-surveys-id">
-                  {{ survey.surveyRef }}
-                </td>
-                <td name="tbl-surveys-title" class="table--cell tbl-surveys-title">
-                  <a href="/surveys/{{ survey.shortName.replace(' ', '') }}" name="survey-link-{{survey.shortName}}">{{ survey.longName }}</a>
-                </td>
-                <td name="tbl-surveys-abbreviation" class="table--cell tbl-surveys-abbreviation">
-                  {{ survey.shortName }}
-                </td>
-                <td name="tbl-surveys-legal-basis" class="table--cell tbl-surveys-legal-basis">
-                  {{ survey.legalBasis }}
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
+          <tbody>
+            {% for survey in survey_list %}
+            <tr class="table--row table--row__selectable">
+              <td name="tbl-surveys-id" class="table--cell tbl-surveys-id">
+                {{ survey.surveyRef }}
+              </td>
+              <td name="tbl-surveys-title" class="table--cell tbl-surveys-title">
+                <a href="/surveys/{{ survey.shortName.replace(' ', '') }}" name="survey-link-{{survey.shortName}}">{{ survey.longName }}</a>
+              </td>
+              <td name="tbl-surveys-abbreviation" class="table--cell tbl-surveys-abbreviation">
+                {{ survey.shortName }}
+              </td>
+              <td name="tbl-surveys-legal-basis" class="table--cell tbl-surveys-legal-basis">
+                {{ survey.legalBasis }}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
 
-        </div>
       </div>
     </div>
   </div>

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -13,9 +13,23 @@ logger = wrap_logger(logging.getLogger(__name__))
 @app.route('/surveys/<short_name>/<period>', methods=['GET'])
 def view_collection_exercise(short_name, period):
     ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
+    breadcrumbs = [
+        {
+            "title": "Surveys",
+            "link": "/surveys"
+        },
+        {
+            "title": f"{ce_details['survey']['surveyRef']} {ce_details['survey']['shortName']}",
+            "link": f"/surveys/{ce_details['survey']['shortName'].replace(' ', '')}"
+        },
+        {
+            "title": f"{ce_details['collection_exercise']['exerciseRef']}"
+        }
+    ]
     return render_template('collection-exercise.html', survey=ce_details['survey'],
                            ce=ce_details['collection_exercise'],
-                           collection_instruments=ce_details['collection_instruments'])
+                           collection_instruments=ce_details['collection_instruments'],
+                           breadcrumbs=breadcrumbs)
 
 
 @app.route('/surveys/<short_name>/<period>', methods=['POST'])

--- a/response_operations_ui/views/surveys.py
+++ b/response_operations_ui/views/surveys.py
@@ -19,22 +19,47 @@ def view_home():
 @app.route('/surveys', methods=['GET'])
 def view_surveys():
     survey_list = survey_controllers.get_surveys_list()
-    return render_template('surveys.html', survey_list=survey_list)
+    breadcrumbs = [{"title": "Surveys"}]
+    return render_template('surveys.html', survey_list=survey_list, breadcrumbs=breadcrumbs)
 
 
 @app.route('/surveys/<short_name>', methods=['GET'])
 def view_survey(short_name):
     survey_details = survey_controllers.get_survey(short_name)
+    breadcrumbs = [
+       {
+           "title": "Surveys",
+           "link": "/surveys"
+       },
+       {
+           "title": f"{survey_details['survey']['surveyRef']} {survey_details['survey']['shortName']}",
+       }
+    ]
     return render_template('survey.html',
                            survey=survey_details['survey'],
-                           collection_exercises=survey_details['collection_exercises'])
+                           collection_exercises=survey_details['collection_exercises'],
+                           breadcrumbs=breadcrumbs)
 
 
 @app.route('/surveys/<short_name>/<period>', methods=['GET'])
 def view_collection_exercise(short_name, period):
     ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
+    breadcrumbs = [
+       {
+           "title": "Surveys",
+           "link": "/surveys"
+       },
+       {
+           "title": f"{ce_details['survey']['surveyRef']} {ce_details['survey']['shortName']}",
+           "link": f"/surveys/{ce_details['survey']['shortName'].replace(' ', '')}"
+       },
+       {
+           "title": f"{ce_details['collection_exercise']['exerciseRef']}"
+       }
+    ]
     return render_template('collection-exercise.html',
-                           survey=ce_details['survey'], ce=ce_details['collection_exercise'])
+                           survey=ce_details['survey'], ce=ce_details['collection_exercise'],
+                           breadcrumbs=breadcrumbs)
 
 
 @app.route('/surveys/<short_name>/<period>', methods=['POST'])

--- a/response_operations_ui/views/surveys.py
+++ b/response_operations_ui/views/surveys.py
@@ -27,13 +27,13 @@ def view_surveys():
 def view_survey(short_name):
     survey_details = survey_controllers.get_survey(short_name)
     breadcrumbs = [
-       {
-           "title": "Surveys",
-           "link": "/surveys"
-       },
-       {
-           "title": f"{survey_details['survey']['surveyRef']} {survey_details['survey']['shortName']}",
-       }
+        {
+            "title": "Surveys",
+            "link": "/surveys"
+        },
+        {
+            "title": f"{survey_details['survey']['surveyRef']} {survey_details['survey']['shortName']}",
+        }
     ]
     return render_template('survey.html',
                            survey=survey_details['survey'],
@@ -45,17 +45,17 @@ def view_survey(short_name):
 def view_collection_exercise(short_name, period):
     ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
     breadcrumbs = [
-       {
-           "title": "Surveys",
-           "link": "/surveys"
-       },
-       {
-           "title": f"{ce_details['survey']['surveyRef']} {ce_details['survey']['shortName']}",
-           "link": f"/surveys/{ce_details['survey']['shortName'].replace(' ', '')}"
-       },
-       {
-           "title": f"{ce_details['collection_exercise']['exerciseRef']}"
-       }
+        {
+            "title": "Surveys",
+            "link": "/surveys"
+        },
+        {
+            "title": f"{ce_details['survey']['surveyRef']} {ce_details['survey']['shortName']}",
+            "link": f"/surveys/{ce_details['survey']['shortName'].replace(' ', '')}"
+        },
+        {
+            "title": f"{ce_details['collection_exercise']['exerciseRef']}"
+        }
     ]
     return render_template('collection-exercise.html',
                            survey=ce_details['survey'], ce=ce_details['collection_exercise'],


### PR DESCRIPTION
Added a breadcrumb trail component which is added into the top of any page which has a `breadcrumbs` variable passed to it.
The format of this variable is
```
breadcrumbs = [
    {
        "title": "Surveys",
        "link": "/surveys"
    },
    {
        "title": "064 QIFDI",
        "link": "/surveys/QIFDI"
    },
    {
        "title": "201803"
    }
]
```
which would produce 
![screen shot 2018-01-17 at 16 01 53](https://user-images.githubusercontent.com/22077099/35052556-c67f1fde-fb9f-11e7-823a-a3112cdb64ab.png)

[Trello](https://trello.com/c/NyqftvPv/44-us026-breadcrumb-navigation-15pts-m-3-days)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/174686327/US026+Breadcrumb+Navigation+M)