### PR TITLE
Only build branch on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,7 @@ script:
 
 after_success:
   - pipenv run codecov
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
This change will cause a build only for the PR and master branch. It
stops the branch and PR being built as it's only necessary for the PR to
be built as they are effectively same things.