### PR TITLE
US027 validate collection instrument

### DIFF
--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -4,7 +4,7 @@ import requests
 from structlog import wrap_logger
 
 from response_operations_ui import app
-from response_operations_ui.exceptions.exceptions import ApiError
+
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -14,4 +14,8 @@ def upload_collection_instrument(short_name, period, file):
     url = f'{app.config["BACKSTAGE_API_URL"]}/collection-instrument/{short_name}/{period}'
     response = requests.post(url, files={"file": (file.filename, file.stream, file.mimetype)})
     if response.status_code != 201:
-        raise ApiError(response)
+        logger.error('Failed to upload collection instrument', short_name=short_name, period=period)
+        return False
+
+    logger.debug('Successfully uploaded collection instrument', short_name=short_name, period=period)
+    return True

--- a/response_operations_ui/static/js/validate-ci.js
+++ b/response_operations_ui/static/js/validate-ci.js
@@ -1,0 +1,44 @@
+function checkCI(file){
+
+	var type = file.type;
+
+	if( type == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ){
+
+		$("#ciFileErrorPanel").removeClass("panel");
+		$("#ciFileErrorPanel").removeClass("panel--simple");
+		$("#ciFileErrorPanel").removeClass("panel--error");
+
+		$("#ciFileErrorPanelBody").removeClass("panel__body");
+		$("#ciFileErrorPanelBody p").addClass("hidden");
+
+		$("#btn-add-ci").removeClass("unready");
+
+	}else{
+
+		//alert("that's not an xlsx :(");
+
+		$("#ciFileErrorPanel").addClass("panel");
+		$("#ciFileErrorPanel").addClass("panel--simple");
+		$("#ciFileErrorPanel").addClass("panel--error");
+
+		$("#ciFileErrorPanelBody").addClass("panel__body");
+		$("#ciFileErrorPanelBody p").removeClass("hidden");
+
+		$("#btn-add-ci").addClass("unready");
+
+	}
+
+
+}
+
+function checkSelectedCI(files){
+
+	// Check for the various File API support.
+	if (window.FileReader) {
+		// FileReader are supported.
+		checkCI(files[0]);
+	} else {
+		alert('FileReader is not supported in this browser.');
+	}
+
+}

--- a/response_operations_ui/static/js/validate-ci.js
+++ b/response_operations_ui/static/js/validate-ci.js
@@ -2,7 +2,7 @@ function checkCI(file){
 
 	var type = file.type;
 
-	if( type == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ){
+	if( type === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ){
 
 		$("#ciFileErrorPanel").removeClass("panel");
 		$("#ciFileErrorPanel").removeClass("panel--simple");
@@ -13,9 +13,7 @@ function checkCI(file){
 
 		$("#btn-add-ci").removeClass("unready");
 
-	}else{
-
-		//alert("that's not an xlsx :(");
+	} else{
 
 		$("#ciFileErrorPanel").addClass("panel");
 		$("#ciFileErrorPanel").addClass("panel--simple");
@@ -37,8 +35,6 @@ function checkSelectedCI(files){
 	if (window.FileReader) {
 		// FileReader are supported.
 		checkCI(files[0]);
-	} else {
-		alert('FileReader is not supported in this browser.');
 	}
 
 }

--- a/response_operations_ui/static/scss/base.scss
+++ b/response_operations_ui/static/scss/base.scss
@@ -199,3 +199,24 @@ em {
 a {
     color: #4263c2;
 }
+
+.hidden {
+    display: none;
+}
+
+.panel {
+    border-radius: 0;
+}
+
+.panel--simple {
+    border: none;
+    border-left: 8px solid transparent;
+    margin-left: -8px;
+    color: #222;
+    padding: 16px;
+    padding: 1rem;
+}
+
+.panel--simple.panel--error {
+    border-color: #d0021b;
+}

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -17,6 +17,9 @@
 
   <div class="grid">
     <div class="grid__col col-6@l">
+
+      {% include 'partials/error-box.html' %}
+
       <section class="ce-section ce-events">
         <h2 class="venus u-pt-m">Dates</h2>
         <table class="table table__dense" summary="Dates for this collection exercise">
@@ -164,7 +167,6 @@
                 </td>
               </tr>
             {% endfor %}
-
             </tbody>
           </table>
         </div>
@@ -173,10 +175,17 @@
         <div class="u-mb-m">
           <form id="form-load-ci" action="" class="form" method="post" enctype="multipart/form-data">
             <p>
-              {{ 'Add another collection instrument (CI)' if collection_instruments else 'Choose a collection instrument (CI) to load'}}
+              {{'Add another' if collection_instruments else 'Add a'}} collection instrument. Must be XLSX
             </p>
-            <label class="upload-file u-vh" for="ciFile">Choose CI file</label>
-            <input id="ciFile" type="file" class="" name="ciFile" accept=".xlsx">
+            <div id="ciFileErrorPanel" class="{{'panel panel--simple panel--error' if error.section == 'ciFile' else ''}}">
+              <div id="ciFileErrorPanelBody" class="{{'panel__body' if error.section == 'ciFile' else ''}}">
+                <p class="hidden">
+                  Incorrect file type. Please choose a file type XLSX
+                </p>
+                <label class="upload-file u-vh" for="ciFile">Choose CI file</label>
+                <input type="file" class="u-mb-s" name="ciFile" id="ciFile" required accept=".xlsx" onchange="checkSelectedCI(this.files)" />
+              </div>
+            </div>
             <button id="btn-load-ci" name="load-ci" class="btn btn--primary unready">Add CI</button>
           </form>
         </div>

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -179,7 +179,7 @@
             </p>
             <div id="ciFileErrorPanel" class="{{'panel panel--simple panel--error' if error.section == 'ciFile' else ''}}">
               <div id="ciFileErrorPanelBody" class="{{'panel__body' if error.section == 'ciFile' else ''}}">
-                <p class="hidden">
+                <p id="ciFileErrorText" class="hidden">
                   Incorrect file type. Please choose a file type XLSX
                 </p>
                 <label class="upload-file u-vh" for="ciFile">Choose CI file</label>

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -175,7 +175,7 @@
         <div class="u-mb-m">
           <form id="form-load-ci" action="" class="form" method="post" enctype="multipart/form-data">
             <p>
-              {{'Add another' if collection_instruments else 'Add a'}} collection instrument. Must be XLSX
+              Add {{'another' if collection_instruments else 'a'}} collection instrument. Must be XLSX
             </p>
             <div id="ciFileErrorPanel" class="{{'panel panel--simple panel--error' if error.section == 'ciFile' else ''}}">
               <div id="ciFileErrorPanelBody" class="{{'panel__body' if error.section == 'ciFile' else ''}}">

--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -12,6 +12,7 @@
     {% assets "scss_all" %}
     <link rel=stylesheet type=text/css href="{{ ASSET_URL }}">
     {% endassets %}
+    <script type="text/javascript" src="http://code.jquery.com/jquery-1.7.1.min.js"></script>
     {% assets "js_all" %}
     <script type="text/javascript" src="{{ ASSET_URL }}"></script>
     {% endassets %}

--- a/response_operations_ui/templates/partials/error-box.html
+++ b/response_operations_ui/templates/partials/error-box.html
@@ -1,7 +1,7 @@
 {% if error %}
 <div class="panel panel--error u-mb-s" data-qa="error">
   <div class="panel__header">
-    <h1 class="panel__title venus">{{ error.header }}</h1>
+    <h1 id="error-header" class="panel__title venus">{{ error.header }}</h1>
   </div>
   <div class="panel__body" data-qa="error-body">
     <a href="#{{error.section}}">{{ error.message }}</a>

--- a/response_operations_ui/templates/partials/error-box.html
+++ b/response_operations_ui/templates/partials/error-box.html
@@ -1,0 +1,10 @@
+{% if error %}
+<div class="panel panel--error u-mb-s" data-qa="error">
+  <div class="panel__header">
+    <h1 class="panel__title venus">{{ error.header }}</h1>
+  </div>
+  <div class="panel__body" data-qa="error-body">
+    <a href="#{{error.section}}">{{ error.message }}</a>
+  </div>
+</div>
+{% endif %}

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -13,7 +13,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 @app.route('/surveys/<short_name>/<period>', methods=['GET'])
-def view_collection_exercise(short_name, period, error={}, ci_loaded=False, sample_loaded=False):
+def view_collection_exercise(short_name, period, error=None, ci_loaded=False, sample_loaded=False):
     ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
     ce_details['sample_summary'] = _format_sample_summary(ce_details['sample_summary'])
     formatted_events = convert_events_to_new_format(ce_details['events'])

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -76,7 +76,7 @@ class TestCollectionExercise(unittest.TestCase):
         response = self.app.post("/surveys/test/000000", data=file)
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("FAIL".encode(), response.data)
+        self.assertIn("Error: Failed to upload Collection Instrument".encode(), response.data)
 
     @requests_mock.mock()
     def test_no_upload_collection_instrument_when_bad_extension(self, mock_request):
@@ -89,6 +89,7 @@ class TestCollectionExercise(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
+        self.assertIn("Error: wrong file type for Collection instrument".encode(), response.data)
 
     @requests_mock.mock()
     def test_no_upload_collection_instrument_when_no_file(self, mock_request):
@@ -98,6 +99,7 @@ class TestCollectionExercise(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
+        self.assertIn("Error: No Collection instrument supplied".encode(), response.data)
 
     @requests_mock.mock()
     def test_view_collection_instrument(self, mock_request):
@@ -116,7 +118,7 @@ class TestCollectionExercise(unittest.TestCase):
         response = self.app.get("/surveys/test/000000")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Choose a collection instrument (CI) to load".encode(), response.data)
+        self.assertIn("Add a collection instrument. Must be XLSX".encode(), response.data)
 
     @requests_mock.mock()
     def test_add_another_collection_instrument_when_already_uploaded(self, mock_request):
@@ -125,7 +127,7 @@ class TestCollectionExercise(unittest.TestCase):
         response = self.app.get("/surveys/test/000000")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Add another collection instrument (CI)".encode(), response.data)
+        self.assertIn("Add another collection instrument. Must be XLSX".encode(), response.data)
 
     @requests_mock.mock()
     def test_upload_sample(self, mock_request):


### PR DESCRIPTION
Added client side validation of the collection instrument file type.
Added error message boxes for invalid collection instrument types and for a failed upload of a collection instrument.

[Trello](https://trello.com/c/jyN3I43Y/58-us027-validate-collection-instrument-file-format-size-medium)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/230490136/US027+Validate+Collection+Instrument+s+Medium)