### PR TITLE
Handle date format changes services with iso8601 package

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,7 +20,7 @@ cssmin = "==0.2.0"
 jsmin = "==2.2.2"
 gunicorn = "==19.7.1"
 requests = "==2.18.4"
-"iso8601" = "*"
+"iso8601" = "==0.1.12"
 
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ cssmin = "==0.2.0"
 jsmin = "==2.2.2"
 gunicorn = "==19.7.1"
 requests = "==2.18.4"
+"iso8601" = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "46fc1cbf387b3d65e94daa83434ebdaf90ef1f989b77e5b6d1baf398825f9908"
+            "sha256": "fd36454f3e52097455a65efaeac91eca45b554422fa2471cd4380374342fadca"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ee726a3c9bbac5e0075142e07675bfc87cc27b7c0913628258bbd52c4a8fbbe4"
+            "sha256": "46fc1cbf387b3d65e94daa83434ebdaf90ef1f989b77e5b6d1baf398825f9908"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -9,9 +9,9 @@
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "16.4.0",
+            "platform_release": "17.3.0",
             "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.4.0: Thu Dec 22 22:53:21 PST 2016; root:xnu-3789.41.3~3/RELEASE_X86_64",
+            "platform_version": "Darwin Kernel Version 17.3.0: Thu Nov  9 18:09:22 PST 2017; root:xnu-4570.31.3~1/RELEASE_X86_64",
             "python_full_version": "3.6.3",
             "python_version": "3.6",
             "sys_platform": "darwin"
@@ -31,10 +31,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:244be0d93b71e93fc0a0a479862051414d0e00e16435707e5bf5000f92e04694",
-                "sha256:5ec74291ca1136b40f0379e1128ff80e866597e4e2c1e755739a913bbc3613c0"
+                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
+                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
             ],
-            "version": "==2017.11.5"
+            "version": "==2018.1.18"
         },
         "chardet": {
             "hashes": [
@@ -82,6 +82,14 @@
                 "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
             ],
             "version": "==2.6"
+        },
+        "iso8601": {
+            "hashes": [
+                "sha256:210e0134677cc0d02f6028087fee1df1e1d76d372ee1db0bf30bf66c5c1c89a3",
+                "sha256:bbbae5fb4a7abfe71d4688fd64bff70b91bbd74ef6a99d964bab18f7fdf286dd",
+                "sha256:49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82"
+            ],
+            "version": "==0.1.12"
         },
         "itsdangerous": {
             "hashes": [
@@ -150,26 +158,26 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:f3000aa146ce8a9da8ca3e978e0e931c2a58eb56c323a5efb6b4307f7832b549",
-                "sha256:6246e5fc98a505824113fb6aca993d45ea284a2bcffdc2c65d0c538e53e4abd3"
+                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b",
+                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c"
             ],
-            "version": "==0.13"
+            "version": "==0.14.1"
         }
     },
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:e7d51b70f19a4da5fe6b3c9938983e0af3b91e230edc504bd73c443d98037063",
-                "sha256:c78f53e32d7cf36d8597c8a2c7e3c0ad210f97b9509e152e4c37fa80869f823c"
+                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450",
+                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9"
             ],
-            "version": "==17.3.0"
+            "version": "==17.4.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:244be0d93b71e93fc0a0a479862051414d0e00e16435707e5bf5000f92e04694",
-                "sha256:5ec74291ca1136b40f0379e1128ff80e866597e4e2c1e755739a913bbc3613c0"
+                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
+                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
             ],
-            "version": "==2017.11.5"
+            "version": "==2018.1.18"
         },
         "chardet": {
             "hashes": [

--- a/response_operations_ui/common/mappers.py
+++ b/response_operations_ui/common/mappers.py
@@ -1,11 +1,11 @@
 import calendar
-from datetime import datetime
+import iso8601
 
 
 def convert_events_to_new_format(events):
     formatted_events = {}
     for event in events:
-        date_time = datetime.strptime(event['timestamp'], '%Y-%m-%dT%H:%M:%S.%f%z')
+        date_time = iso8601.parse_date(event['timestamp'])
         day = calendar.day_name[date_time.weekday()]
         month = calendar.month_name[date_time.month][:3]
         date = f"{date_time.strftime('%d')} {month} {date_time.strftime('%Y')}"

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -1,4 +1,4 @@
-import datetime
+import iso8601
 import logging
 
 from flask import render_template, request
@@ -140,7 +140,7 @@ def _validate_sample():
 def _format_sample_summary(sample):
 
     if sample and sample.get('ingestDateTime'):
-        submission_datetime = datetime.datetime.strptime(sample['ingestDateTime'], "%Y-%m-%dT%H:%M:%S.%f%z")
+        submission_datetime = iso8601.parse_date(sample['ingestDateTime'])
         submission_time = submission_datetime.strftime("%I:%M%p on %B %d, %Y")
         sample["ingestDateTime"] = submission_time
 


### PR DESCRIPTION
The Java services are now consolidating the datetime format that is returned in their JSON to be more flexible but a side-effect of this is that in the main Java returns "Zulu time" using ISO8601. 

This PR adds a package for specifically parsing strings in this format (`%Y-%m-%dT%H:%M:%S.%f%z`)  and returning datetime objects. (NB: Let's not use this as an excuse to mangle things on backstage).