### PR TITLE
Us044 display ru details

### DIFF
--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -39,5 +39,6 @@ def user_loader(user_id):
     # down the line once uaa is sorted out.
     return User(user_id)
 
+
 import response_operations_ui.views  # NOQA # pylint: disable=wrong-import-position
 import response_operations_ui.error_handlers  # NOQA # pylint: disable=wrong-import-position

--- a/response_operations_ui/controllers/reporting_units_controllers.py
+++ b/response_operations_ui/controllers/reporting_units_controllers.py
@@ -1,0 +1,21 @@
+import logging
+
+import requests
+from structlog import wrap_logger
+
+from response_operations_ui import app
+from response_operations_ui.exceptions.exceptions import ApiError
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def get_reporting_unit(ru_ref):
+    logger.debug('Retrieving reporting unit', ru_ref=ru_ref)
+    url = f'{app.config["BACKSTAGE_API_URL"]}/v1/reporting-unit/{ru_ref}'
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise ApiError(response)
+
+    logger.debug('Successfully retrieved reporting unit', ru_ref=ru_ref)
+    return response.json()

--- a/response_operations_ui/controllers/reporting_units_controllers.py
+++ b/response_operations_ui/controllers/reporting_units_controllers.py
@@ -17,6 +17,7 @@ def get_reporting_unit(ru_ref):
         raise ApiError(response)
 
     logger.debug('Successfully retrieved reporting unit', ru_ref=ru_ref)
+    return response.json()
 
 
 def search_reporting_units(query):

--- a/response_operations_ui/static/scss/base.scss
+++ b/response_operations_ui/static/scss/base.scss
@@ -220,3 +220,18 @@ a {
 .panel--simple.panel--error {
     border-color: #d0021b;
 }
+
+.item-headlines-term {
+    float: left;
+    clear: left;
+    width: 6rem;
+    margin: 0;
+    padding: 0;
+    color: #444;
+    font-weight: 600;
+}
+
+.item-headlines-definition {
+    margin: 0 0 0 6rem;
+    padding: 0 0 0.5rem 0;
+}

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -8,7 +8,7 @@
   <dt class="item-headlines-term">
     Reference:
   </dt>
-  <dd class="item-headlines-definition">
+  <dd id="RU_REF" class="item-headlines-definition">
     {{ ru.sampleUnitRef }}
   </dd>
 </dl>

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -1,0 +1,15 @@
+{% extends "layouts/base.html" %}
+{% block page_title %}{{ru.name}} | Reporting units | Survey Data Collection{% endblock %}
+
+{% block main %}
+<h1 class="jupiter">{{ ru.name }}</h1>
+
+<dl class="item-headlines">
+  <dt class="item-headlines-term">
+    Reference:
+  </dt>
+  <dd class="item-headlines-definition">
+    {{ ru.attributes.ruref }}
+  </dd>
+</dl>
+{% endblock %}

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -2,7 +2,7 @@
 {% block page_title %}{{ru.name}} | Reporting units | Survey Data Collection{% endblock %}
 
 {% block main %}
-<h1 class="jupiter">{{ ru.name }}</h1>
+<h1 id="RU_NAME" class="jupiter">{{ ru.name }}</h1>
 
 <dl class="item-headlines">
   <dt class="item-headlines-term">

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -9,7 +9,7 @@
     Reference:
   </dt>
   <dd class="item-headlines-definition">
-    {{ ru.attributes.ruref }}
+    {{ ru.sampleUnitRef }}
   </dd>
 </dl>
 {% endblock %}

--- a/response_operations_ui/views/__init__.py
+++ b/response_operations_ui/views/__init__.py
@@ -4,6 +4,7 @@ from response_operations_ui.views.errors import error_bp
 from response_operations_ui.views.home import home_bp
 from response_operations_ui.views.info import info_bp
 from response_operations_ui.views.logout import logout_bp
+from response_operations_ui.views.reporting_units import reporting_unit_bp
 from response_operations_ui.views.sign_in import sign_in_bp
 from response_operations_ui.views.surveys import surveys_bp
 
@@ -12,5 +13,6 @@ app.register_blueprint(error_bp, url_prefix='/errors')
 app.register_blueprint(home_bp, url_prefix='/')
 app.register_blueprint(info_bp, url_prefix='/info')
 app.register_blueprint(logout_bp, url_prefix='/logout')
+app.register_blueprint(reporting_unit_bp, url_prefix='/reporting-units')
 app.register_blueprint(sign_in_bp, url_prefix='/sign-in')
 app.register_blueprint(surveys_bp, url_prefix='/surveys')

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -1,0 +1,28 @@
+import logging
+
+from flask import Blueprint, render_template
+from flask_login import login_required
+from structlog import wrap_logger
+
+from response_operations_ui.controllers import reporting_units_controllers
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+reporting_unit_bp = Blueprint('reporting_unit_bp', __name__, static_folder='static', template_folder='templates')
+
+
+@reporting_unit_bp.route('/<ru_ref>', methods=['GET'])
+@login_required
+def view_reporting_unit(ru_ref):
+    reporting_unit = reporting_units_controllers.get_reporting_unit(ru_ref)
+    breadcrumbs = [
+        {
+            "title": "Reporting units",
+            "link": "/reporting-units"
+        },
+        {
+            "title": f"{ru_ref}"
+        }
+    ]
+    return render_template('reporting-unit.html', ru=reporting_unit, breadcrumbs=breadcrumbs)

--- a/tests/test_data/reporting_units/reporting_unit.json
+++ b/tests/test_data/reporting_units/reporting_unit.json
@@ -1,0 +1,47 @@
+{
+    "associations": [
+        {
+        "enrolments": [
+            {
+                "enrolmentStatus": "ENABLED",
+                "name": "Business Register and Employment Survey",
+                "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+            }
+        ],
+        "partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"
+        }
+    ],
+    "attributes": {
+        "ruref": "50012345678",
+        "checkletter": "A",
+        "frosic92": "11111",
+        "rusic92": "11111",
+        "frosic2007": "11111",
+        "rusic2007": "11111",
+        "froempment": 50,
+        "frotover": 50,
+        "entref": "1234567890",
+        "legalstatus": "B",
+        "entrepmkr": "C",
+        "region": "DE",
+        "birthdate": "01/09/1993",
+        "entname1": "ENTNAME1",
+        "entname2": "ENTNAME2",
+        "entname3": "ENTNAME3",
+        "runame1": "Bolts",
+        "runame2": "and",
+        "runame3": "Ratchets Ltd",
+        "tradstyle1": "TRADSTYLE1",
+        "tradstyle2": "TRADSTYLE2",
+        "tradstyle3": "TRADSTYLE3",
+        "seltype": "F",
+        "inclexcl": "G",
+        "cell_no": 1,
+        "formtype": "0001",
+        "currency": "H"
+    },
+    "id": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+    "sampleUnitRef": "50012345678",
+    "sampleUnitType": "B",
+    "name": "Bolts and Ratchets Ltd"
+}

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -28,3 +28,13 @@ class TestReportingUnits(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Bolts and Ratchets Ltd".encode(), response.data)
+        self.assertIn("50012345678".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_get_reporting_unit_fail(self, mock_request):
+        mock_request.get(url_get_reporting_unit, status_code=500)
+
+        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("Error 500 - Server error".encode(), response.data)

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -1,0 +1,30 @@
+import json
+import unittest
+
+import requests_mock
+
+from config import TestingConfig
+from response_operations_ui import app
+
+
+url_get_reporting_unit = f'{app.config["BACKSTAGE_API_URL"]}/v1/reporting-unit/50012345678'
+with open('tests/test_data/reporting_units/reporting_unit.json') as json_data:
+    reporting_unit = json.load(json_data)
+
+
+class TestReportingUnits(unittest.TestCase):
+
+    def setUp(self):
+        app_config = TestingConfig()
+        app.config.from_object(app_config)
+        app.login_manager.init_app(app)
+        self.app = app.test_client()
+
+    @requests_mock.mock()
+    def test_get_reporting_unit(self, mock_request):
+        mock_request.get(url_get_reporting_unit, json=reporting_unit)
+
+        response = self.app.get("/reporting-units/50012345678")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Bolts and Ratchets Ltd".encode(), response.data)


### PR DESCRIPTION
Added new page at /reporting-units/<ru_ref>
Currently it only displays the most recent reporting unit name and the RU_REF

[Trello](https://trello.com/c/zHV82xsH/77-us044-int-view-ru-details-med)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/248643696/US044+View+RU+Details)