### PR TITLE
Add header that's missing from the design

### DIFF
--- a/response_operations_ui/templates/partials/header.html
+++ b/response_operations_ui/templates/partials/header.html
@@ -19,4 +19,28 @@
       {% endif %}
   </div>
 
+  <div class="bar bar__sitenavigation" role="banner">
+    <div class="bar__inner container">
+      <div class="sitenavigation">
+        <ul class="sitenavigation__list">
+          <li class="sitenavigation__listitem {% if request.path == '/' %} sitenavigation__listitem--active{% endif %}">
+            <a href="/">Home</a>
+          </li>
+          <li class="sitenavigation__listitem{% if request.path.startswith('/surveys') %} sitenavigation__listitem--active{% endif %}">
+            <a href="/surveys/">Surveys</a>
+          </li>
+          <li class="sitenavigation__listitem{% if request.path.startswith('/reporting-units') %} sitenavigation__listitem--active{% endif %}">
+            <a href="/reporting-units/">Reporting units</a>
+          </li>
+          <li class="sitenavigation__listitem{% if request.path.startswith('/respondents') %} sitenavigation__listitem--active{% endif %}">
+            <a href="/respondents/">Respondents</a>
+          </li>
+          <li class="sitenavigation__listitem{% if request.path.startswith('/messages') %} sitenavigation__listitem--active{% endif %}">
+            <a href="/messages/">Messages</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
 </header>


### PR DESCRIPTION
The designs include a 3rd header bar with broad categories in them (surveys, messages, etc) but it's not on the site yet.  This includes that bar and the logic required to show which one is active.