### PR TITLE
View active IAC code

### DIFF
--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -66,6 +66,12 @@
 
       <h4 class="neptune">Respondents</h4>
 
+      <div class="ru-survey-enrolment-code u-pb-s">
+        {% if survey.activeIacCode %}
+        Unused enrolment code: {{survey.activeIacCode}}
+        {% endif %}
+      </div>
+
       <table name="tbl-respondents-for-survey" class="table table__dense tbl-ru-survey-respondents" summary="Respondents for {{survey.shortName}} for {{ ru.sampleUnitRef }}">
         <thead class="table--head">
         <tr class="table--row">

--- a/tests/test_data/reporting_units/reporting_unit.json
+++ b/tests/test_data/reporting_units/reporting_unit.json
@@ -53,6 +53,7 @@
             "legalBasis": "",
             "surveyRef": "074",
             "shortName": "BLOCKS",
+            "activeIacCode": "22yrn9qzx7v2",
             "collection_exercises": [
                 {
                     "id": "c6467711-21eb-4e78-804c-1db8392f93fb",
@@ -122,6 +123,7 @@
             "legalBasis": "",
             "surveyRef": "074",
             "shortName": "BRICKS",
+            "activeIacCode": null,
             "collection_exercises": [
                 {
                     "id": "c6467711-21eb-4e78-804c-1db8392f93fb",


### PR DESCRIPTION
GIVEN
The user understands which surveys the RU Ref has been selected for 
WHEN
The surveys are displayed back to the user
THEN
For each survey, the user is displayed the most recent Enrolment Code issued for that RU for that Survey
Enrollment Code displayed is based on the issued code at notification which hasn't yet been used
Once code is used and respondent is fully active and enabled suppress the code
Enrollment Code displayed is last code unused using 'Generate Code'

Dependencies: https://github.com/ONSdigital/ras-backstage/pull/55