### PR TITLE
Remove unused survey_state template variable

### DIFF
--- a/response_operations_ui/views/surveys.py
+++ b/response_operations_ui/views/surveys.py
@@ -42,5 +42,4 @@ def view_survey(short_name):
     return render_template('survey.html',
                            survey=survey_details['survey'],
                            collection_exercises=survey_details['collection_exercises'],
-                           survey_state=collection_exercise['state'],
                            breadcrumbs=breadcrumbs)


### PR DESCRIPTION
If a survey has no collection exercises this will cause a 500 error as collection_exercise would never be assigned from the [for loop above](https://github.com/ONSdigital/response-operations-ui/blob/remove-survey-state/response_operations_ui/views/surveys.py#L39).