### PR TITLE
removed unused line in the file picker css to stop 404's

### DIFF
--- a/response_operations_ui/static/scss/components/file-picker.scss
+++ b/response_operations_ui/static/scss/components/file-picker.scss
@@ -3,7 +3,6 @@
 
 .upload-file::before {
   content: " ";
-  background: transparent url("/s/img/icons/upload--icon_blue.svg") no-repeat center center;
   background-size: 1.6rem;
   min-width: 27px;
   min-width: 1.5rem;


### PR DESCRIPTION
the file picker css refers to a background image which doesn't exist, we don't actually need this bit of the css so it's been removed so we don't get 404 in the logs for every request