### PR TITLE
Sm101 collection case id fix

### DIFF
--- a/response_operations_ui/forms.py
+++ b/response_operations_ui/forms.py
@@ -30,6 +30,7 @@ class SecureMessageForm(FlaskForm):
     hidden_survey_id = HiddenField('hidden_survey_id')
     hidden_ru_ref = HiddenField('hidden_ru_ref')
     hidden_business = HiddenField('hidden_business')
+    hidden_case_id = HiddenField('case_id')
     hidden_to = HiddenField('hidden_to')
     hidden_to_uuid = HiddenField('hidden_to_uuid')
     hidden_to_ru_id = HiddenField('hidden_to_ru_id')

--- a/response_operations_ui/templates/home.html
+++ b/response_operations_ui/templates/home.html
@@ -17,6 +17,7 @@
           <input type="hidden" name="business" value="Bolts & Rachets Ltd">
           <input type="hidden" name="survey" value="BRES 2017">
           <input type="hidden" name="survey_id" value="cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87">
+          <input type="hidden" name="case_id" value="c614e64e-d981-4eba-b016-d9822f09a4fb">
           <input type="hidden" name="msg_to_name" value="Jacky Turner">
           <input type="hidden" name="msg_to" value="f62dfda8-73b0-4e0e-97cf-1b06327a6712">
         </form></li>

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -128,7 +128,7 @@
               <input type="hidden" name="business" value={{ ru.name }}>
               <input type="hidden" name="survey" value={{ survey.shortName }}>
               <input type="hidden" name="survey_id" value={{ survey.id }}>
-              <input type="hidden" name="case_id" value={{ respondent.case_id }}
+              <input type="hidden" name="case_id" value={{ respondent.case_id }}>
               <input type="hidden" name="msg_to_name" value="{{ respondent.firstName }} {{ respondent.lastName }}">
               <input type="hidden" name="msg_to" value={{ respondent.id }}>
             </form>

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -128,6 +128,7 @@
               <input type="hidden" name="business" value={{ ru.name }}>
               <input type="hidden" name="survey" value={{ survey.shortName }}>
               <input type="hidden" name="survey_id" value={{ survey.id }}>
+              <input type="hidden" name="case_id" value={{ respondent.case_id }}
               <input type="hidden" name="msg_to_name" value="{{ respondent.firstName }} {{ respondent.lastName }}">
               <input type="hidden" name="msg_to" value={{ respondent.id }}>
             </form>

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -71,8 +71,7 @@ def _get_message_json(form):
         'subject': form.subject.data,
         'body': form.body.data,
         'thread_id': "",
-        'collection_case': "",
-        # TODO Make this UUID for v2 api
+        'collection_case': form.hidden_case_id.data,
         'survey': form.hidden_survey_id.data,
         'ru_id': form.hidden_to_ru_id.data})
 
@@ -88,6 +87,7 @@ def _populate_hidden_form_fields_from_post(current_view_form, calling_form):
         current_view_form.hidden_survey_id.data = calling_form['survey_id']
         current_view_form.hidden_ru_ref.data = calling_form['ru_ref']
         current_view_form.hidden_business.data = calling_form['business']
+        current_view_form.hidden_case_id.data = calling_form['case_id']
         current_view_form.hidden_to_uuid.data = calling_form['msg_to']
         current_view_form.hidden_to.data = calling_form['msg_to_name']
         current_view_form.hidden_to_ru_id.data = calling_form['ru_id']

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -105,6 +105,7 @@ class TestMessage(unittest.TestCase):
                   'survey_id': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                   'ru_ref': '49900000280',
                   'business': 'Bolts & Rachets Ltd',
+                  'case_id': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                   'msg_to_name': 'Jacky Turner',
                   'msg_to': 'f62dfda8-73b0-4e0e-97cf-1b06327a6712',
                   'ru_id': 'c614e64e-d981-4eba-b016-d9822f09a4fb'}


### PR DESCRIPTION
Adds the case ID to the data expected on the reporting units page which is then passed to the create message page through the create message button. This field is required by secure-message to log case events for message exchanges.

Story page:
https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/223281382/SM101+Internal+User+to+Send+Message