### PR TITLE
Fix bug in secure message inbox

### DIFF
--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -130,6 +130,14 @@ def _refine(message):
         'business_name': message.get('@ru_id').get('name'),
         'subject': message.get('subject'),
         'from': message.get('msg_from'),
-        'to': message.get('@msg_to')[0].get('firstName') + ' ' + message.get('@msg_to')[0].get('lastName'),
+        'to': _get_name_from_message(message),
         'sent_date': message.get('sent_date').split(".")[0]
     }
+
+
+def _get_name_from_message(message):
+    try:
+        name = message.get('@msg_to')[0].get('firstName') + ' ' + message.get('@msg_to')[0].get('lastName')
+    except IndexError:
+        name = message.get('msg_to')[0]
+    return name


### PR DESCRIPTION
There is a bug in the messages inbox where messages sent from the 'create message' option in frontstage didn't contain the name fields it expected, causing a 500 error on loading the page.

This fixes it by taking the 'msg_to' field if the message does not have names.