### PR TITLE
Bug fix: Missing string quotes in html

### DIFF
--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -155,13 +155,13 @@
             <td class="table--cell">
               <form action="{{ url_for('messages_bp.create_message')}}" method="post" id="create-message-view">
                 <button type="submit" name="create-message" id="create-message-button-{{ loop.index }}" value="create-message-view" class="btn-link">Create message</button>
-                <input type="hidden" name="ru_ref" value={{ ru.sampleUnitRef }} >
-                <input type="hidden" name="ru_id" value={{ ru.id }}>
-                <input type="hidden" name="business" value={{ ru.name }}>
-                <input type="hidden" name="survey" value={{ survey.shortName }}>
-                <input type="hidden" name="survey_id" value={{ survey.id }}>
+                <input type="hidden" name="ru_ref" value="{{ ru.sampleUnitRef }}">
+                <input type="hidden" name="ru_id" value="{{ ru.id }}">
+                <input type="hidden" name="business" value="{{ ru.name }}">
+                <input type="hidden" name="survey" value="{{ survey.shortName }}">
+                <input type="hidden" name="survey_id" value="{{ survey.id }}">
                 <input type="hidden" name="msg_to_name" value="{{ respondent.firstName }} {{ respondent.lastName }}">
-                <input type="hidden" name="msg_to" value={{ respondent.id }}>
+                <input type="hidden" name="msg_to" value="{{ respondent.id }}">
               </form>
             </td>
           </tr>


### PR DESCRIPTION
The calling form for creating a message in the reporting unit page wasn't wrapping it's values in string quotes. If a string had a space in, only the first word up to the space was actually getting passed through the form.