### PR TITLE
Tbl133 use CI selection classifier correctly

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,7 +27,7 @@ pyjwt = "==1.5.3"
 redis = "==2.10.6"
 flask-session = "==0.3.1"
 cfenv = "==0.5.3"
-maya = "*"
+maya = "==0.3.4"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,20 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9f0bcfcc98a5256cb50784b8ab4ff1eb9e271a8d6ea18a71b20acc6f746ed1d5"
+            "sha256": "44198366cb3cd8942cdb870817824f41215eeeec2c36996d1be3e743884172da"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.6.3",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "16.7.0",
+            "platform_system": "Darwin",
+            "platform_version": "Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64",
+            "python_full_version": "3.6.3",
+            "python_version": "3.6",
+            "sys_platform": "darwin"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,8 +45,8 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
             ],
             "version": "==3.0.4"
         },
@@ -52,8 +65,8 @@
         },
         "dateparser": {
             "hashes": [
-                "sha256:940828183c937bcec530753211b70f673c0a9aab831e43273489b310538dff86",
-                "sha256:b452ef8b36cd78ae86a50721794bc674aa3994e19b570f7ba92810f4e0a2ae03"
+                "sha256:b452ef8b36cd78ae86a50721794bc674aa3994e19b570f7ba92810f4e0a2ae03",
+                "sha256:940828183c937bcec530753211b70f673c0a9aab831e43273489b310538dff86"
             ],
             "version": "==0.7.0"
         },
@@ -78,15 +91,15 @@
         },
         "flask-session": {
             "hashes": [
-                "sha256:a31c27e0c3287f00c825b3d9625aba585f4df4cccedb1e7dd5a69a215881a731",
-                "sha256:b9b32126bfc52c3169089f2ed9a40e34b589527bda48b633428e07d39d9c8792"
+                "sha256:b9b32126bfc52c3169089f2ed9a40e34b589527bda48b633428e07d39d9c8792",
+                "sha256:a31c27e0c3287f00c825b3d9625aba585f4df4cccedb1e7dd5a69a215881a731"
             ],
             "version": "==0.3.1"
         },
         "flask-wtf": {
             "hashes": [
-                "sha256:5d14d55cfd35f613d99ee7cba0fc3fbbe63ba02f544d349158c14ca15561cc36",
-                "sha256:d9a9e366b32dcbb98ef17228e76be15702cd2600675668bca23f63a7947fd5ac"
+                "sha256:d9a9e366b32dcbb98ef17228e76be15702cd2600675668bca23f63a7947fd5ac",
+                "sha256:5d14d55cfd35f613d99ee7cba0fc3fbbe63ba02f544d349158c14ca15561cc36"
             ],
             "version": "==0.14.2"
         },
@@ -111,16 +124,16 @@
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
             ],
             "version": "==2.6"
         },
         "iso8601": {
             "hashes": [
                 "sha256:210e0134677cc0d02f6028087fee1df1e1d76d372ee1db0bf30bf66c5c1c89a3",
-                "sha256:49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82",
-                "sha256:bbbae5fb4a7abfe71d4688fd64bff70b91bbd74ef6a99d964bab18f7fdf286dd"
+                "sha256:bbbae5fb4a7abfe71d4688fd64bff70b91bbd74ef6a99d964bab18f7fdf286dd",
+                "sha256:49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82"
             ],
             "version": "==0.1.12"
         },
@@ -164,21 +177,21 @@
         },
         "pendulum": {
             "hashes": [
-                "sha256:0c14388546db6605a860b8b7112cb69d0b11c9ce5e072210504544e0d4575799",
-                "sha256:39a255776528afe11ea0d57814f9bf3729c1e0b99063af2e5c6cfd750c3e1f7f",
-                "sha256:3c85e8cbc91f45e1cc916cc9180b34153cd6aaaaacfb51a48b3156318314fa82",
-                "sha256:8199206c479b13947dcac63c025575d035331bb3819d1783dc1d568a11962906",
-                "sha256:8798aeca58b3dd7ffdc5a4993c9eaafedc4048165429e8f499ddd62c73bf3964",
                 "sha256:881efe37328de0785c0731d462e1485a45712f2cd5cb55907d6c15458460ebeb",
+                "sha256:3c85e8cbc91f45e1cc916cc9180b34153cd6aaaaacfb51a48b3156318314fa82",
+                "sha256:0c14388546db6605a860b8b7112cb69d0b11c9ce5e072210504544e0d4575799",
+                "sha256:8798aeca58b3dd7ffdc5a4993c9eaafedc4048165429e8f499ddd62c73bf3964",
+                "sha256:8199206c479b13947dcac63c025575d035331bb3819d1783dc1d568a11962906",
                 "sha256:bcca072f82e84b419efec1320cd3ee5c230d263f3a601b146651ed4db77d89f0",
-                "sha256:ff0c5fa3af4a471a218408c448b804ac6bccb105127727474f4e83c0e4072e97"
+                "sha256:ff0c5fa3af4a471a218408c448b804ac6bccb105127727474f4e83c0e4072e97",
+                "sha256:39a255776528afe11ea0d57814f9bf3729c1e0b99063af2e5c6cfd750c3e1f7f"
             ],
             "version": "==1.4.2"
         },
         "pyjwt": {
             "hashes": [
-                "sha256:500be75b17a63f70072416843dc80c8821109030be824f4d14758f114978bae7",
-                "sha256:a4e5f1441e3ca7b382fd0c0b416777ced1f97c64ef0c33bfa39daf38505cfd2f"
+                "sha256:a4e5f1441e3ca7b382fd0c0b416777ced1f97c64ef0c33bfa39daf38505cfd2f",
+                "sha256:500be75b17a63f70072416843dc80c8821109030be824f4d14758f114978bae7"
             ],
             "version": "==1.5.3"
         },
@@ -197,22 +210,22 @@
         },
         "pytz": {
             "hashes": [
+                "sha256:ed6509d9af298b7995d69a440e2822288f2eca1681b8cce37673dbb10091e5fe",
+                "sha256:f93ddcdd6342f94cea379c73cddb5724e0d6d0a1c91c9bdef364dc0368ba4fda",
+                "sha256:61242a9abc626379574a166dc0e96a66cd7c3b27fc10868003fa210be4bff1c9",
+                "sha256:ba18e6a243b3625513d85239b3e49055a2f0318466e0b8a92b8fb8ca7ccdf55f",
                 "sha256:07edfc3d4d2705a20a6e99d97f0c4b61c800b8232dc1c04d87e8554f130148dd",
                 "sha256:3a47ff71597f821cd84a162e71593004286e5be07a340fd462f0d33a760782b5",
-                "sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0",
                 "sha256:5bd55c744e6feaa4d599a6cbd8228b4f8f9ba96de2c38d56f08e534b3c9edf0d",
-                "sha256:61242a9abc626379574a166dc0e96a66cd7c3b27fc10868003fa210be4bff1c9",
                 "sha256:887ab5e5b32e4d0c86efddd3d055c1f363cbaa583beb8da5e22d2fa2f64d51ef",
-                "sha256:ba18e6a243b3625513d85239b3e49055a2f0318466e0b8a92b8fb8ca7ccdf55f",
-                "sha256:ed6509d9af298b7995d69a440e2822288f2eca1681b8cce37673dbb10091e5fe",
-                "sha256:f93ddcdd6342f94cea379c73cddb5724e0d6d0a1c91c9bdef364dc0368ba4fda"
+                "sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0"
             ],
             "version": "==2018.3"
         },
         "pytzdata": {
             "hashes": [
-                "sha256:4e2cceb54335cd6c28caea46b15cd592e2aec5e8b05b0241cbccfb1b23c02ae7",
-                "sha256:7cd949123e2c2060fd12793de3a4a449e36b5dea5e169b810a3ac3f0b9877cfa"
+                "sha256:7cd949123e2c2060fd12793de3a4a449e36b5dea5e169b810a3ac3f0b9877cfa",
+                "sha256:4e2cceb54335cd6c28caea46b15cd592e2aec5e8b05b0241cbccfb1b23c02ae7"
             ],
             "version": "==2018.3"
         },
@@ -225,21 +238,21 @@
         },
         "regex": {
             "hashes": [
+                "sha256:333687d9a44738c486735955993f83bd22061a416c48f5a5f9e765e90cf1b0c9",
+                "sha256:361a1fd703a35580a4714ec28d85e29780081a4c399a99bbfb2aee695d72aedb",
+                "sha256:f69d1201a4750f763971ea8364ed95ee888fc128968b39d38883a72a4d005895",
+                "sha256:a50532f61b23d4ab9d216a6214f359dd05c911c1a1ad20986b6738a782926c1a",
                 "sha256:1b428a296531ea1642a7da48562746309c5c06471a97bd0c02dd6a82e9cecee8",
+                "sha256:5b9c0ddd5b4afa08c9074170a2ea9b34ea296e32aeea522faaaaeeeb2fe0af2e",
                 "sha256:27d72bb42dffb32516c28d218bb054ce128afd3e18464f30837166346758af67",
                 "sha256:32cf4743debee9ea12d3626ee21eae83052763740e04086304e7a74778bf58c9",
-                "sha256:32f6408dbca35040bc65f9f4ae1444d5546411fde989cb71443a182dd643305e",
-                "sha256:333687d9a44738c486735955993f83bd22061a416c48f5a5f9e765e90cf1b0c9",
                 "sha256:35eeccf17af3b017a54d754e160af597036435c58eceae60f1dd1364ae1250c7",
-                "sha256:361a1fd703a35580a4714ec28d85e29780081a4c399a99bbfb2aee695d72aedb",
-                "sha256:494bed6396a20d3aa6376bdf2d3fbb1005b8f4339558d8ac7b53256755f80303",
-                "sha256:5b9c0ddd5b4afa08c9074170a2ea9b34ea296e32aeea522faaaaeeeb2fe0af2e",
-                "sha256:a50532f61b23d4ab9d216a6214f359dd05c911c1a1ad20986b6738a782926c1a",
-                "sha256:a9243d7b359b72c681a2c32eaa7ace8d346b7e8ce09d172a683acf6853161d9c",
-                "sha256:b44624a38d07d3c954c84ad302c29f7930f4bf01443beef5589e9157b14e2a29",
                 "sha256:be42a601aaaeb7a317f818490a39d153952a97c40c6e9beeb2a1103616405348",
                 "sha256:eee4d94b1a626490fc8170ffd788883f8c641b576e11ba9b4a29c9f6623371e0",
-                "sha256:f69d1201a4750f763971ea8364ed95ee888fc128968b39d38883a72a4d005895"
+                "sha256:32f6408dbca35040bc65f9f4ae1444d5546411fde989cb71443a182dd643305e",
+                "sha256:a9243d7b359b72c681a2c32eaa7ace8d346b7e8ce09d172a683acf6853161d9c",
+                "sha256:494bed6396a20d3aa6376bdf2d3fbb1005b8f4339558d8ac7b53256755f80303",
+                "sha256:b44624a38d07d3c954c84ad302c29f7930f4bf01443beef5589e9157b14e2a29"
             ],
             "version": "==2018.2.21"
         },
@@ -252,37 +265,37 @@
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:01e30ecb1b1c0ebf9fce814dc20dace402571517277799291202b61b22096c24",
-                "sha256:02babffd019911841ba01b76e23dfec7c9e9b2725503fb2698c4982fa1a6e835",
-                "sha256:072f6364a89972e8dc0afdce3335a709d5464dfeaa4f736d092a54574338b874",
                 "sha256:14d161558e3bf89e87d77c218098be22fa9a0d6d0bea40250fce525b1d0cbee2",
-                "sha256:5504398fc755a2b14c9983b2101161a8591a4b30812590cc1c365e7fcc117dfa",
-                "sha256:68c8f2986bcb91b6db1aea8698941769840c7257e951a9377048f7eff35be773",
-                "sha256:6d05c5a5baf829c70916c226ef3200650846a7227de226bca8a59efaf88bb973",
-                "sha256:6d7929b24e329d662fa43b657fddfee5260e2d35d0a543065cd755d4e17a9b2f",
-                "sha256:8dc74821e4bb6b21fb1ab35964e159391d99ee44981d07d57bf96e2395f3ef75",
-                "sha256:9225c83952d28f302cfc23c3d9a6f8231bfd581476d7aff1e3c7de49eecb4ee9",
-                "sha256:b6c5d5f03ba78e3f27c7188a00c4e09b6a4507fe3154ba40a294e09cb30ee016",
+                "sha256:fcfc24a21594c071cc4588e84b7657a1f47ebcf6037c6c43fa15c4bbd3989ec2",
+                "sha256:02babffd019911841ba01b76e23dfec7c9e9b2725503fb2698c4982fa1a6e835",
                 "sha256:c0908896e34b617ead40552cab03c1769bdc43d1da02419160dc900c5dfddde2",
+                "sha256:01e30ecb1b1c0ebf9fce814dc20dace402571517277799291202b61b22096c24",
+                "sha256:b6c5d5f03ba78e3f27c7188a00c4e09b6a4507fe3154ba40a294e09cb30ee016",
+                "sha256:9225c83952d28f302cfc23c3d9a6f8231bfd581476d7aff1e3c7de49eecb4ee9",
                 "sha256:c41e04b526d0153c9246cfab87d7ddefdc9f165cb8886a8ec48ba7a2b73069f6",
-                "sha256:e2d2715bf92156bec5fb42e92e95dac1c4d9904f8a3d4e2d0c438758fe9092d7",
+                "sha256:6d05c5a5baf829c70916c226ef3200650846a7227de226bca8a59efaf88bb973",
                 "sha256:e3bbfe0d294e08fdbb0cb05485435a2ceb4e168e98b5dc611f051c1864986b4b",
+                "sha256:68c8f2986bcb91b6db1aea8698941769840c7257e951a9377048f7eff35be773",
+                "sha256:072f6364a89972e8dc0afdce3335a709d5464dfeaa4f736d092a54574338b874",
+                "sha256:5504398fc755a2b14c9983b2101161a8591a4b30812590cc1c365e7fcc117dfa",
+                "sha256:e2d2715bf92156bec5fb42e92e95dac1c4d9904f8a3d4e2d0c438758fe9092d7",
+                "sha256:6d7929b24e329d662fa43b657fddfee5260e2d35d0a543065cd755d4e17a9b2f",
                 "sha256:f2d02a4af5a13b09d0b823cdd0317b54f3e0115e50b5ac4d9840c3a1b566817f",
-                "sha256:fcfc24a21594c071cc4588e84b7657a1f47ebcf6037c6c43fa15c4bbd3989ec2"
+                "sha256:8dc74821e4bb6b21fb1ab35964e159391d99ee44981d07d57bf96e2395f3ef75"
             ],
             "version": "==0.15.35"
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
             ],
             "version": "==1.11.0"
         },
         "structlog": {
             "hashes": [
-                "sha256:6980001045abd235fa12582222627c19b89109e58b85eb77d5a5abc778df6e20",
-                "sha256:9947d12d904529e6133384e52091ce92d0541472a722460cfcb4bcc8d02340b0"
+                "sha256:9947d12d904529e6133384e52091ce92d0541472a722460cfcb4bcc8d02340b0",
+                "sha256:6980001045abd235fa12582222627c19b89109e58b85eb77d5a5abc778df6e20"
             ],
             "version": "==17.2.0"
         },
@@ -307,8 +320,8 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b",
+                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c"
             ],
             "version": "==0.14.1"
         },
@@ -322,8 +335,8 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
-                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
+                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450",
+                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9"
             ],
             "version": "==17.4.0"
         },
@@ -336,8 +349,8 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
             ],
             "version": "==3.0.4"
         },
@@ -348,75 +361,58 @@
             ],
             "version": "==2.0.9"
         },
-        "configparser": {
-            "hashes": [
-                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
-            ],
-            "markers": "python_version < '3.2'",
-            "version": "==3.5.0"
-        },
         "coverage": {
             "hashes": [
-                "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
-                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
-                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
-                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
-                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
-                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
-                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
-                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
-                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
-                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
-                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
-                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
-                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
-                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
-                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
-                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
-                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
-                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
-                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
                 "sha256:7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc",
-                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
-                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
-                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
-                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
-                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
-                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
-                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
-                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
-                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
-                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
-                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
-                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
-                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
-                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
+                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
                 "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
+                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
+                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
+                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
+                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
+                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
+                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
+                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
+                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
+                "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
+                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
+                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
+                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
+                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
+                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
+                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
+                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
+                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
+                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
+                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
+                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
+                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
+                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
                 "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
             "version": "==4.5.1"
         },
-        "enum34": {
-            "hashes": [
-                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
-                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
-                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
-                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.1.6"
-        },
         "flake8": {
             "hashes": [
-                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
-                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37"
+                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37",
+                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0"
             ],
             "version": "==3.5.0"
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
             ],
             "version": "==2.6"
         },
@@ -442,8 +438,8 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
-                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
+                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9",
+                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766"
             ],
             "version": "==2.3.1"
         },
@@ -456,15 +452,15 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:6db1c070aa412c30647b6aeb13c55670f900cf00fbafa003cdde560c3f4a8d76",
-                "sha256:72186b294cc88322a4427225fdb9240c95e3f01cc53c1ea4f4f79ffe39ff1955"
+                "sha256:72186b294cc88322a4427225fdb9240c95e3f01cc53c1ea4f4f79ffe39ff1955",
+                "sha256:6db1c070aa412c30647b6aeb13c55670f900cf00fbafa003cdde560c3f4a8d76"
             ],
             "version": "==3.3.0"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
-                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
+                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec",
+                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d"
             ],
             "version": "==2.5.1"
         },
@@ -477,15 +473,15 @@
         },
         "requests-mock": {
             "hashes": [
-                "sha256:2931887853c42e1d73879983d5bf03041109472991c5b4b8dba5d11ed23b9d0b",
-                "sha256:96a1e45b1c0bd18d14fcb2d55b3b09d6d46237e37bcae3155df4cb75bc42619e"
+                "sha256:96a1e45b1c0bd18d14fcb2d55b3b09d6d46237e37bcae3155df4cb75bc42619e",
+                "sha256:2931887853c42e1d73879983d5bf03041109472991c5b4b8dba5d11ed23b9d0b"
             ],
             "version": "==1.4.0"
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
             ],
             "version": "==1.11.0"
         },

--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import requests
@@ -9,16 +10,26 @@ from response_operations_ui import app
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def upload_collection_instrument(short_name, period, file):
-    logger.debug('Uploading collection instrument', short_name=short_name, period=period)
+def upload_collection_instrument(short_name, period, file, form_type=None):
+    logger.debug('Uploading collection instrument', short_name=short_name, period=period, form_type=form_type)
     url = f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-instrument/{short_name}/{period}'
-    response = requests.post(url, files={"file": (file.filename, file.stream, file.mimetype)})
+
+    params = dict()
+
+    if form_type:
+        classifiers = {
+            "form_type": form_type,
+        }
+        params['classifiers'] = json.dumps(classifiers)
+
+    response = requests.post(url, files={"file": (file.filename, file.stream, file.mimetype)}, params=params)
     if response.status_code != 201:
         logger.error('Failed to upload collection instrument', short_name=short_name, period=period,
-                     status=response.status_code)
+                     form_type=form_type, status=response.status_code)
         return False
 
-    logger.debug('Successfully uploaded collection instrument', short_name=short_name, period=period)
+    logger.debug('Successfully uploaded collection instrument', short_name=short_name, period=period,
+                 form_type=form_type)
     return True
 
 

--- a/response_operations_ui/static/js/read-csv.js
+++ b/response_operations_ui/static/js/read-csv.js
@@ -1,15 +1,5 @@
 
-function drawOutput(lines){
-	// Put the form types into their own separate array, so we can interrogate it faster
-	var formTypes = [];
-	for (var i = 0; i < lines.length; i++) {
-		formTypes.push(lines[i][lines.length - 1]);
-	}
-
-	var ciCount = formTypes.filter(function(val, i, arr) {
-        return arr.indexOf(val) === i;
-	}).length;
-
+function drawOutput(businessCount, ciCount){
 
 	//Clear previous data
 	document.getElementById("sample-preview").innerHTML = "";
@@ -20,7 +10,7 @@ function drawOutput(lines){
 	preview = preview + "    <h3 class='venus'>Sample contents</h3>";
 	preview = preview + "  </div>";
 	preview = preview + "  <div class='panel__body'>";
-	preview = preview + "    <div id='sample-preview-businesses'>Number of businesses: " + lines.length + "</div>";
+	preview = preview + "    <div id='sample-preview-businesses'>Number of businesses: " + businessCount + "</div>";
 	preview = preview + "    <div id='sample-preview-ci'>Collection instruments: " + ciCount + "</div>";
 	preview = preview + "  </div>";
 	preview = preview + "</div>";
@@ -37,33 +27,32 @@ function errorHandler(evt) {
 	}
 }
 
-function loadHandler(event) {
-    var csv = event.target.result;
-	processData(csv);
-}
-
-function getAsText(fileToRead) {
-	var reader = new FileReader();
-	// Handle errors load
-	reader.onload = loadHandler;
-	reader.onerror = errorHandler;
-	// Read file into memory as UTF-8
-	reader.readAsText(fileToRead);
-}
-
-function handleFiles(files) {
+function handleFiles(files, classifiers) {
 	// Check for the various File API support.
 	if (window.FileReader) {
 		// FileReader are supported.
-		getAsText(files[0]);
+		var reader = new FileReader();
+
+        // Handle errors load
+        reader.onload = function(evt) {
+            processFile(evt, classifiers);
+        };
+        reader.onerror = errorHandler;
+
+        // Read file into memory as UTF-8
+        reader.readAsText(files[0]);
+
 	} else {
 		alert('FileReader is not supported in this browser.');
 	}
 }
 
-function processData(csv) {
+function processFile(event, classifiers) {
+    var csv = event.target.result;
     var allTextLines = csv.split(/\r\n|\n/);
+    var classifierColumn = [];
     var lines = [];
+    var ciCount;
 
     while (allTextLines.length) {
         var line = allTextLines.shift().split(":")
@@ -72,7 +61,21 @@ function processData(csv) {
         }
     }
 
-    drawOutput(lines);
+    if (classifiers.indexOf('RU_REF') > -1) {
+        ciCount = lines.length  // each line should be a distinct RU_REF (sampleUnitRef)
+    } else if (classifiers.indexOf('FORM_TYPE') > -1){
+
+        // Put the form types into their own separate array, so we can interrogate it faster
+        for (var i = 0; i < lines.length; i++) {
+            classifierColumn.push(lines[i][lines.length - 1]);
+        }
+
+        ciCount = classifierColumn.filter(function(val, i, arr) {
+            return arr.indexOf(val) === i;
+        }).length;
+    }
+
+    drawOutput(lines.length, ciCount);
 }
 
 function cancelLoadSample(){

--- a/response_operations_ui/templates/collection-exercise.html
+++ b/response_operations_ui/templates/collection-exercise.html
@@ -208,7 +208,7 @@
                 Choose a sample file to check details before loading
               </p>
               <label class="upload-file u-vh" for="sampleFile">Choose file</label>
-              <input type="file" class="" name="sampleFile" id="sampleFile" onchange="handleFiles(this.files)"
+              <input type="file" class="" name="sampleFile" id="sampleFile" onchange="handleFiles(this.files, {{ ci_classifiers }})"
               accept=".csv">
 
               <div id="sample-preview" class="u-mb-s"></div>

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -164,7 +164,8 @@ def _validate_collection_instrument():
                 "message": "Please use XLSX file only"
             }
         else:
-            form_type = _get_form_type(file.filename)
+            # file name format is surveyId_period_formType
+            form_type = _get_form_type(file.filename) if file.filename.count('_') == 2 else None
             if not form_type.isdigit() and len(form_type) != 4:
                 logger.debug('Invalid file format uploaded', filename=file.filename)
                 error = {

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -121,13 +121,13 @@ def _select_collection_instrument(short_name, period):
             if not ci_added:
                 error = {
                     "section": "ciSelect",
-                    "header": "Error: Failed to add Collection Instrument(s)",
+                    "header": "Error: Failed to add collection instrument(s)",
                     "message": "Please try again"
                 }
     else:
         error = {
             "section": "ciSelect",
-            "header": "Error: No Collection Instruments selected",
+            "header": "Error: No collection instruments selected",
             "message": "Please select a collection instrument"
         }
 
@@ -145,7 +145,7 @@ def _upload_collection_instrument(short_name, period):
         if not ci_loaded:
             error = {
                 "section": "ciFile",
-                "header": "Error: Failed to upload Collection Instrument",
+                "header": "Error: Failed to upload collection instrument",
                 "message": "Please try again"
             }
 
@@ -160,25 +160,25 @@ def _validate_collection_instrument():
             logger.debug('Invalid file format uploaded', filename=file.filename)
             error = {
                 "section": "ciFile",
-                "header": "Error: wrong file type for Collection instrument",
+                "header": "Error: wrong file type for collection instrument",
                 "message": "Please use XLSX file only"
             }
         else:
             # file name format is surveyId_period_formType
-            form_type = _get_form_type(file.filename) if file.filename.count('_') == 2 else None
+            form_type = _get_form_type(file.filename) if file.filename.count('_') == 2 else ''
             if not form_type.isdigit() and len(form_type) != 4:
                 logger.debug('Invalid file format uploaded', filename=file.filename)
                 error = {
                     "section": "ciFile",
-                    "header": "Error: invalid file name format for Collection instrument",
+                    "header": "Error: invalid file name format for collection instrument",
                     "message": "Please provide file with correct form type in file name"
                 }
     else:
         logger.debug('No file uploaded')
         error = {
             "section": "ciFile",
-            "header": "Error: No Collection instrument supplied",
-            "message": "Please provide a Collection instrument"
+            "header": "Error: No collection instrument supplied",
+            "message": "Please provide a collection instrument"
         }
     return error
 

--- a/tests/test_data/collection_exercise/collection_exercise_details.json
+++ b/tests/test_data/collection_exercise/collection_exercise_details.json
@@ -79,5 +79,13 @@
     "state":"INIT",
     "totalSampleUnits":5,
     "expectedCollectionInstruments":2
+  },
+  "ci_classifiers": {
+    "id": "efa868fb-fb80-44c7-9f33-d6800a17c4da",
+    "name": "COLLECTION_INSTRUMENT",
+    "classifierTypes": [
+      "COLLECTION_EXERCISE",
+      "RU_REF"
+    ]
   }
 }

--- a/tests/test_data/collection_exercise/collection_exercise_details_failedvalidation.json
+++ b/tests/test_data/collection_exercise/collection_exercise_details_failedvalidation.json
@@ -86,5 +86,13 @@
       "tag": "exercise_end",
       "timestamp": "1993-05-15T23:00:00.000+0000"
     }
-  ]
+  ],
+  "ci_classifiers": {
+    "id": "efa868fb-fb80-44c7-9f33-d6800a17c4da",
+    "name": "COLLECTION_INSTRUMENT",
+    "classifierTypes": [
+      "COLLECTION_EXERCISE",
+      "RU_REF"
+    ]
+  }
 }

--- a/tests/test_data/collection_exercise/collection_exercise_details_no_ci.json
+++ b/tests/test_data/collection_exercise/collection_exercise_details_no_ci.json
@@ -66,5 +66,13 @@
       "tag": "exercise_end",
       "timestamp": "1993-05-15T23:00:00.000+0000"
     }
-  ]
+  ],
+  "ci_classifiers": {
+    "id": "efa868fb-fb80-44c7-9f33-d6800a17c4da",
+    "name": "COLLECTION_INSTRUMENT",
+    "classifierTypes": [
+      "COLLECTION_EXERCISE",
+      "RU_REF"
+    ]
+  }
 }

--- a/tests/test_data/collection_exercise/collection_exercise_details_no_sample.json
+++ b/tests/test_data/collection_exercise/collection_exercise_details_no_sample.json
@@ -69,5 +69,13 @@
       "tag": "exercise_end",
       "timestamp": "1993-05-15T23:00:00.000+0000"
     }
-  ]
+  ],
+  "ci_classifiers": {
+    "id": "efa868fb-fb80-44c7-9f33-d6800a17c4da",
+    "name": "COLLECTION_INSTRUMENT",
+    "classifierTypes": [
+      "COLLECTION_EXERCISE",
+      "RU_REF"
+    ]
+  }
 }

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -51,7 +51,7 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_upload_collection_instrument(self, mock_request):
         post_data = {
-            'ciFile': (BytesIO(b'data'), 'test.xlsx'),
+            'ciFile': (BytesIO(b'data'), '064_201803_0001.xlsx'),
             'load-ci': '',
         }
         mock_request.post(url_collection_instrument, status_code=201)
@@ -109,7 +109,7 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_view_collection_instrument_after_upload(self, mock_request):
         post_data = {
-            'ciFile': (BytesIO(b'data'), 'collection_instrument.xlsx'),
+            'ciFile': (BytesIO(b'data'), '064_201803_0001.xlsx'),
             'load-ci': '',
         }
         mock_request.post(url_collection_instrument, status_code=201)
@@ -123,7 +123,7 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_failed_upload_collection_instrument(self, mock_request):
         post_data = {
-            'ciFile': (BytesIO(b'data'), 'test.xlsx'),
+            'ciFile': (BytesIO(b'data'), '064_201803_0001.xlsx'),
             'load-ci': '',
         }
         mock_request.post(url_collection_instrument, status_code=500)
@@ -137,7 +137,7 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_no_upload_collection_instrument_when_bad_extension(self, mock_request):
         post_data = {
-            'ciFile': (BytesIO(b'data'), 'test.html'),
+            'ciFile': (BytesIO(b'data'), '064_201803_0001.html'),
             'load-ci': '',
         }
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
@@ -147,6 +147,20 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
         self.assertIn("Error: wrong file type for Collection instrument".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_no_upload_collection_instrument_when_bad_extension(self, mock_request):
+        post_data = {
+            'ciFile': (BytesIO(b'data'), '064_201803_xxxxx.xlsx'),
+            'load-ci': '',
+        }
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+
+        response = self.app.post("/surveys/test/000000", data=post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Collection instrument loaded".encode(), response.data)
+        self.assertIn("Error: invalid file name format for Collection instrument".encode(), response.data)
 
     @requests_mock.mock()
     def test_no_upload_collection_instrument_when_no_file(self, mock_request):

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -149,7 +149,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error: wrong file type for Collection instrument".encode(), response.data)
 
     @requests_mock.mock()
-    def test_no_upload_collection_instrument_when_bad_extension(self, mock_request):
+    def test_no_upload_collection_instrument_when_bad_form_type_format(self, mock_request):
         post_data = {
             'ciFile': (BytesIO(b'data'), '064_201803_xxxxx.xlsx'),
             'load-ci': '',

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -90,7 +90,7 @@ class TestCollectionExercise(unittest.TestCase):
         response = self.app.post("/surveys/test/000000", data=post_data)
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Error: Failed to add Collection Instrument(s)".encode(), response.data)
+        self.assertIn("Error: Failed to add collection instrument(s)".encode(), response.data)
 
     @requests_mock.mock()
     def test_failed_no_selected_collection_instrument(self, mock_request):
@@ -104,7 +104,7 @@ class TestCollectionExercise(unittest.TestCase):
         response = self.app.post("/surveys/test/000000", data=post_data)
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Error: No Collection Instruments selected".encode(), response.data)
+        self.assertIn("Error: No collection instruments selected".encode(), response.data)
 
     @requests_mock.mock()
     def test_view_collection_instrument_after_upload(self, mock_request):
@@ -132,7 +132,7 @@ class TestCollectionExercise(unittest.TestCase):
         response = self.app.post("/surveys/test/000000", data=post_data, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Error: Failed to upload Collection Instrument".encode(), response.data)
+        self.assertIn("Error: Failed to upload collection instrument".encode(), response.data)
 
     @requests_mock.mock()
     def test_no_upload_collection_instrument_when_bad_extension(self, mock_request):
@@ -146,7 +146,7 @@ class TestCollectionExercise(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
-        self.assertIn("Error: wrong file type for Collection instrument".encode(), response.data)
+        self.assertIn("Error: wrong file type for collection instrument".encode(), response.data)
 
     @requests_mock.mock()
     def test_no_upload_collection_instrument_when_bad_form_type_format(self, mock_request):
@@ -160,7 +160,21 @@ class TestCollectionExercise(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
-        self.assertIn("Error: invalid file name format for Collection instrument".encode(), response.data)
+        self.assertIn("Error: invalid file name format for collection instrument".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_no_upload_collection_instrument_bad_file_name_format(self, mock_request):
+        post_data = {
+            'ciFile': (BytesIO(b'data'), '064201803_xxxxx.xlsx'),
+            'load-ci': '',
+        }
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+
+        response = self.app.post("/surveys/test/000000", data=post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Collection instrument loaded".encode(), response.data)
+        self.assertIn("Error: invalid file name format for collection instrument".encode(), response.data)
 
     @requests_mock.mock()
     def test_no_upload_collection_instrument_when_no_file(self, mock_request):
@@ -173,7 +187,7 @@ class TestCollectionExercise(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
-        self.assertIn("Error: No Collection instrument supplied".encode(), response.data)
+        self.assertIn("Error: No collection instrument supplied".encode(), response.data)
 
     @requests_mock.mock()
     def test_view_collection_instrument(self, mock_request):


### PR DESCRIPTION
- Get form_type from file name and upload CI using this form type classifier
- Use classifier to calculate expected CI

To test functionality:
Use classifier to calculate expected CI
1) `Make up` ras-rm-docker-dev
2) For RSI/Bricks/blocks surveys load `business-survey-sample-data.csv` sample file from `rasrm-acceptance-tests/resources/sample_files` using this response-operations-ui branch
3) The preview panel should show 5 businesses and 1 Collection Instrument (this is because CI classifier for these surveys is FORM_TYPE)
4) Do the same for BRES and you should see 5 businesses and 5 Collection Instrument in the sample preview panel.
**You may need to run this sql script because the data for BRES may not be correct:
            `update ras_ci.seft_instrument`
`set file_name = 'test_collection_instrument.xlsx'`
`where file_name is null`

Get form_type from file name and upload CI using this form type classifier
1) `Make up` ras-rm-docker-dev
2) For RSI/Bricks/blocks surveys load `064_201803_0001.xlsx` collection instrument from `rasrm-acceptance-tests/resources/collection_instrument_files` using this response-operations-ui branch
3) Check response operations makes a post request to backstage with param 'classifiers' with correct 'form_type' value from the file (0001 in this case). 


A text change in this PR will mean a test in https://github.com/ONSdigital/rasrm-acceptance-tests will break. https://github.com/ONSdigital/rasrm-acceptance-tests/pull/77 is the fix for that and will need to be merged in after this PR is in