### PR TITLE
Count correct form type column

### DIFF
--- a/response_operations_ui/static/js/read-csv.js
+++ b/response_operations_ui/static/js/read-csv.js
@@ -64,10 +64,8 @@ function processFile(event, classifiers) {
     if (classifiers.indexOf('RU_REF') > -1) {
         ciCount = lines.length  // each line should be a distinct RU_REF (sampleUnitRef)
     } else if (classifiers.indexOf('FORM_TYPE') > -1){
-        console.log("CALCULATING FORMTYPE")
         // Put the form types into their own separate array, so we can interrogate it faster
         for (var i = 0; i < lines.length; i++) {
-            console.log(lines[i][lines[i].length - 2])
             classifierColumn.push(lines[i][lines[i].length - 2]);
         }
 

--- a/response_operations_ui/static/js/read-csv.js
+++ b/response_operations_ui/static/js/read-csv.js
@@ -64,10 +64,11 @@ function processFile(event, classifiers) {
     if (classifiers.indexOf('RU_REF') > -1) {
         ciCount = lines.length  // each line should be a distinct RU_REF (sampleUnitRef)
     } else if (classifiers.indexOf('FORM_TYPE') > -1){
-
+        console.log("CALCULATING FORMTYPE")
         // Put the form types into their own separate array, so we can interrogate it faster
         for (var i = 0; i < lines.length; i++) {
-            classifierColumn.push(lines[i][lines.length - 1]);
+            console.log(lines[i][lines[i].length - 2])
+            classifierColumn.push(lines[i][lines[i].length - 2]);
         }
 
         ciCount = classifierColumn.filter(function(val, i, arr) {


### PR DESCRIPTION
The preview panel when you select a sample file to load shows a count for expected CIs.
If you load a sample with multiple form types (Second last column) it does not show the correct count. This PR fixes this.