### PR TITLE
fix file name validation

### DIFF
--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -166,7 +166,7 @@ def _validate_collection_instrument():
         else:
             # file name format is surveyId_period_formType
             form_type = _get_form_type(file.filename) if file.filename.count('_') == 2 else ''
-            if not form_type.isdigit() and len(form_type) != 4:
+            if not form_type.isdigit() or len(form_type) != 4:
                 logger.debug('Invalid file format uploaded', filename=file.filename)
                 error = {
                     "section": "ciFile",

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -177,6 +177,20 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error: invalid file name format for collection instrument".encode(), response.data)
 
     @requests_mock.mock()
+    def test_no_upload_collection_instrument_form_type_not_integer(self, mock_request):
+        post_data = {
+            'ciFile': (BytesIO(b'data'), '064_201803_123E.xlsx'),
+            'load-ci': '',
+        }
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+
+        response = self.app.post("/surveys/test/000000", data=post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Collection instrument loaded".encode(), response.data)
+        self.assertIn("Error: invalid file name format for collection instrument".encode(), response.data)
+
+    @requests_mock.mock()
     def test_no_upload_collection_instrument_when_no_file(self, mock_request):
         post_data = {
             'load-ci': '',


### PR DESCRIPTION
Validation should fail if form type is not a digit or the length is not 4.