### PR TITLE
Upgrade jquery from 1.7.1 to 3.3.1

### DIFF
--- a/response_operations_ui/static/js/test.js
+++ b/response_operations_ui/static/js/test.js
@@ -1,5 +1,0 @@
-$(document).ready(function(){
-    $("#test-button").click(function(){
-        $("#test-div").hide();
-    });
-});

--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -13,7 +13,7 @@
     {% assets "scss_all" %}
     <link rel=stylesheet type=text/css href="{{ ASSET_URL }}">
     {% endassets %}
-    <script type="text/javascript" src="http://code.jquery.com/jquery-1.7.1.min.js"></script>
+    <script type="text/javascript" src="http://code.jquery.com/jquery-3.3.1.min.js"></script>
     {% assets "js_all" %}
     <script type="text/javascript" src="{{ ASSET_URL }}"></script>
     {% endassets %}

--- a/response_operations_ui/templates/layouts/spoke.html
+++ b/response_operations_ui/templates/layouts/spoke.html
@@ -13,7 +13,7 @@
     {% assets "scss_all" %}
     <link rel=stylesheet type=text/css href="{{ ASSET_URL }}">
     {% endassets %}
-    <script type="text/javascript" src="http://code.jquery.com/jquery-1.7.1.min.js"></script>
+    <script type="text/javascript" src="http://code.jquery.com/jquery-3.3.1.min.js"></script>
     {% assets "js_all" %}
     <script type="text/javascript" src="{{ ASSET_URL }}"></script>
     {% endassets %}


### PR DESCRIPTION
There seems to be only 2 files that actually uses jquery (static/js/validate-ci.js and static/js/read-csv.js), and all the functions it uses are in jquery 3.3.1 as well as 1.7.1 so there shouldn't be any downside.
I'd encourage people to test a bit of the site they know to make sure nothing is wrong, but I'm fairly confident that it should be fine as the site uses such a small amount of it.