### PR TITLE
Add Width Limit to Messages View Table Columns

### DIFF
--- a/response_operations_ui/static/css/override.css
+++ b/response_operations_ui/static/css/override.css
@@ -500,6 +500,7 @@ background: #eee;
 
 .message-list__ru-name{
   width: 16rem;
+  max-width: 22rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -514,6 +515,7 @@ background: #eee;
 
 .message-list__from{
   width: 10rem;
+  max-width: 16rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Two of the columns in the messages view had unlimited widths, long business names never got cut off and caused the rest of the table to spill over the screen. 

**How to review:**
Load the messages view with a message with a very long business name (can be done by editing the HTML in browser), without this update it is unlimited and pushed other fields off the screen. This should now be limited to a reasonable width.