### PR TITLE
Remove email from url

### DIFF
--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -158,7 +158,7 @@
               {{ respondent.enrolmentStatus }}
                 {% if respondent.enrolmentStatus|upper == "PENDING" %}
                 <br>
-                  <a href="{{ url_for('reporting_unit_bp.resend_verification', ru_ref=ru_ref, email=respondent.emailAddress, party_id=party_id) }}">Re-send verification email</a>
+                  <a href="{{ url_for('reporting_unit_bp.view_resend_verification', ru_ref=ru_ref, party_id=party_id) }}">Re-send verification email</a>
                 </br>
                 {% endif %}
             </td>

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -113,16 +113,17 @@ def search_reporting_units():
     return render_template('reporting-units.html', business_list=business_list, form=form, breadcrumbs=breadcrumbs)
 
 
-@reporting_unit_bp.route('/resend_verification/<ru_ref>/<email>/<party_id>', methods=['GET'])
+@reporting_unit_bp.route('/resend_verification/<ru_ref>/<party_id>', methods=['GET'])
 @login_required
-def resend_verification(ru_ref, email, party_id):
+def view_resend_verification(ru_ref, party_id):
     logger.debug("Re-send verification email requested", ru_ref=ru_ref, party_id=party_id)
-    return render_template('re-send-verification-email.html', ru_ref=ru_ref, email=email)
+    respondent = contact_details_controller.get_contact_details(party_id)
+    return render_template('re-send-verification-email.html', ru_ref=ru_ref, email=respondent['emailAddress'])
 
 
-@reporting_unit_bp.route('/resend_verification/<ru_ref>/<email>/<party_id>', methods=['POST'])
+@reporting_unit_bp.route('/resend_verification/<ru_ref>/<party_id>', methods=['POST'])
 @login_required
-def resent_verification(ru_ref, email, party_id):
+def resend_verification(ru_ref, party_id):
     reporting_units_controllers.resend_verification_email(party_id)
     logger.info("Re-sent verification email.", party_id=party_id)
     return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ru_ref,

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -154,10 +154,11 @@ class TestReportingUnits(unittest.TestCase):
         self.assertEqual(response.status_code, 500)
         self.assertIn("Error 500 - Server error".encode(), response.data)
 
-    def test_resend_verification_email(self):
+    @requests_mock.mock()
+    def test_resend_verification_email(self, mock_request):
+        mock_request.get(url_get_contact_details, json=respondent)
         response = self.app.get(
-            f"reporting-units/resend_verification/50012345678/"
-            f"brooke.bond%40email.com/{respondent_party_id}")
+            f"reporting-units/resend_verification/50012345678/{respondent_party_id}")
         self.assertEqual(response.status_code, 200)
 
     @requests_mock.mock()
@@ -174,16 +175,14 @@ class TestReportingUnits(unittest.TestCase):
                          json=self.case_group_status)
 
         response = self.app.post(
-            f"reporting-units/resend_verification/50012345678/"
-            f"brooke.bond%40email.com/{respondent_party_id}", follow_redirects=True)
+            f"reporting-units/resend_verification/50012345678/{respondent_party_id}", follow_redirects=True)
         self.assertEqual(response.status_code, 200)
 
     @requests_mock.mock()
     def test_fail_resent_verification_email(self, mock_request):
         mock_request.post(url_resend_verification_email, status_code=500)
         response = self.app.post(
-            f"reporting-units/resend_verification/50012345678/"
-            f"brooke.bond%40email.com/{respondent_party_id}", follow_redirects=True)
+            f"reporting-units/resend_verification/50012345678/{respondent_party_id}", follow_redirects=True)
         self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()


### PR DESCRIPTION
User email should not be exposed in logs, as far as I know.
This PR removes the email being passed in the url (which would be exposed in the logs).