### PR TITLE
Stop caching messages page

### DIFF
--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -59,5 +59,6 @@ Session(app)
 def user_loader(user_id):
     return User(user_id)
 
+
 import response_operations_ui.views  # NOQA # pylint: disable=wrong-import-position
 import response_operations_ui.error_handlers  # NOQA # pylint: disable=wrong-import-position

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -1,8 +1,7 @@
 import json
 import logging
 
-from flask import Blueprint, flash, g, Markup, render_template, request, redirect, session, url_for, make_response
-
+from flask import Blueprint, flash, g, make_response, Markup, render_template, request, redirect, session, url_for
 from flask_login import login_required, current_user
 from structlog import wrap_logger
 
@@ -10,9 +9,9 @@ from response_operations_ui.common.dates import get_formatted_date
 from response_operations_ui.common.mappers import format_short_name
 from response_operations_ui.common.surveys import Surveys, FDISurveys
 from response_operations_ui.controllers import message_controllers, survey_controllers
+from response_operations_ui.controllers.survey_controllers import get_survey_short_name_by_id, get_survey_ref_by_id
 from response_operations_ui.exceptions.exceptions import ApiError, InternalError, NoMessagesError
 from response_operations_ui.forms import SecureMessageForm
-from response_operations_ui.controllers.survey_controllers import get_survey_short_name_by_id, get_survey_ref_by_id
 
 logger = wrap_logger(logging.getLogger(__name__))
 messages_bp = Blueprint('messages_bp', __name__,

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from flask import Blueprint, flash, g, Markup, render_template, request, redirect, session, url_for
+from flask import Blueprint, flash, g, Markup, render_template, request, redirect, session, url_for, make_response
 
 from flask_login import login_required, current_user
 from structlog import wrap_logger
@@ -153,11 +153,13 @@ def view_selected_survey(selected_survey):
 
         refined_messages = [_refine(message) for message in message_controllers.get_thread_list(params)]
 
-        return render_template("messages.html",
-                               breadcrumbs=breadcrumbs,
-                               messages=refined_messages,
-                               selected_survey=formatted_survey,
-                               change_survey=True)
+        response = make_response(render_template("messages.html",
+                                 breadcrumbs=breadcrumbs,
+                                 messages=refined_messages,
+                                 selected_survey=formatted_survey,
+                                 change_survey=True))
+        response.headers.set("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")
+        return response
 
     except TypeError:
         logger.exception("Failed to retrieve survey id")

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -337,7 +337,7 @@ def _get_unread_status(message):
 
 
 @messages_bp.after_request
-def disabling_caching_headers(response):
+def disable_caching(response):
     for k, v in CACHE_HEADERS.items():
         response.headers[k] = v
     return response


### PR DESCRIPTION
This PR stops the messages page from being cached by the browser. 

Testing:
Make sure all tests pass and unread messages become read when navigating back to the messages page using the back button.