### PR TITLE
Revert "Add security headers (#127)"

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,8 +24,6 @@ Flask-Session = "==0.3.1"
 cfenv = "==0.5.3"
 cryptography = "*"
 flask-paginate = "*"
-flask-talisman = "*"
-
 
 [dev-packages]
 codecov = "==2.0.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a551f267787e47bee685b1da4675ee56fb8e138c154038adfd516e8085473d24"
+            "sha256": "d47a64801baa17c240c380503e1d20d5423efbed49c2b98ab81351fd07d5bb43"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -151,14 +151,6 @@
             ],
             "index": "pypi",
             "version": "==0.3.1"
-        },
-        "flask-talisman": {
-            "hashes": [
-                "sha256:5d77780b2220012a6748e0b603cbbf7889a2833c4e77157794e13dddb183e347",
-                "sha256:e4e3ccba66895e1f46d5b62a9cc0f273731da601bc92d2b9af908011298c0e2b"
-            ],
-            "index": "pypi",
-            "version": "==0.5.0"
         },
         "flask-wtf": {
             "hashes": [
@@ -312,10 +304,10 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
+                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
             ],
-            "version": "==18.1.0"
+            "version": "==17.4.0"
         },
         "certifi": {
             "hashes": [
@@ -419,6 +411,8 @@
         },
         "pycodestyle": {
             "hashes": [
+                "sha256:1ec08a51c901dfe44921576ed6e4c1f5b7ecbad403f871397feedb5eb8e4fa14",
+                "sha256:5ff2fbcbab997895ba9ead77e1b38b3ebc2e5c3b8a6194ef918666e4c790a00e",
                 "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
                 "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
             ],

--- a/config.py
+++ b/config.py
@@ -1,9 +1,8 @@
 import os
-from distutils.util import strtobool
 
 
 class Config(object):
-    DEBUG = strtobool(os.getenv('DEBUG', 'False'))
+    DEBUG = os.getenv('DEBUG', False)
     TESTING = False
     PORT = os.getenv('PORT', 8085)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
@@ -28,11 +27,10 @@ class Config(object):
 
     UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL')
     RAS_SECURE_MESSAGING_JWT_SECRET = os.getenv('RAS_SECURE_MESSAGING_JWT_SECRET')
-    SECURE_COOKIES = strtobool(os.getenv('SECURE_COOKIES', 'True'))
 
 
 class DevelopmentConfig(Config):
-    DEBUG = strtobool(os.getenv('DEBUG', 'True'))
+    DEBUG = os.getenv('DEBUG', True)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'DEBUG')
     BACKSTAGE_API_URL = os.getenv('BACKSTAGE_API_URL', 'http://localhost:8001/backstage-api')
     SECURE_MESSAGE_URL = os.getenv('SECURE_MESSAGE_URL', 'http://localhost:5050')
@@ -47,7 +45,6 @@ class DevelopmentConfig(Config):
     COLLECTION_EXERCISE_USERNAME = os.getenv('COLLECTION_EXERCISE_USERNAME', 'admin')
     COLLECTION_EXERCISE_PASSWORD = os.getenv('COLLECTION_EXERCISE_PASSWORD', 'secret')
     COLLECTION_EXERCISE_AUTH = (COLLECTION_EXERCISE_USERNAME, COLLECTION_EXERCISE_PASSWORD)
-    SECURE_COOKIES = strtobool(os.getenv('SECURE_COOKIES', 'False'))
 
     UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL', 'http://localhost:9080')
     RAS_SECURE_MESSAGING_JWT_SECRET = os.getenv('RAS_SECURE_MESSAGING_JWT_SECRET', 'testsecret')
@@ -60,4 +57,3 @@ class TestingConfig(DevelopmentConfig):
     WTF_CSRF_ENABLED = False
     SESSION_TYPE = "filesystem"
     SESSION_PERMANENT = False
-    SECURE_COOKIES = True

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -6,20 +6,10 @@ from flask_assets import Bundle, Environment
 from flask_login import LoginManager
 from flask_session import Session
 import redis
-from flask_talisman import Talisman
 
 from response_operations_ui.cloud.cloudfoundry import ONSCloudFoundry
 from response_operations_ui.logger_config import logger_initial_config
 from response_operations_ui.user import User
-
-CSP_POLICY = {
-    'default-src': ["'self'", 'https://cdn.ons.gov.uk', ],
-    'style-src': ["'self'", 'https://cdn.ons.gov.uk', 'https://maxcdn.bootstrapcdn.com', ],
-    'font-src': ["'self'", 'data:', 'https://cdn.ons.gov.uk', 'https://fonts.gstatic.com', ],
-    'script-src': ["'self'", 'https://www.google-analytics.com', 'https://cdn.ons.gov.uk', 'http://code.jquery.com', ],
-    'connect-src': ["'self'", 'https://www.google-analytics.com', 'https://cdn.ons.gov.uk', ],
-    'img-src': ["'self'", 'data:', 'https://www.google-analytics.com', 'https://cdn.ons.gov.uk', ]
-}
 
 app = Flask(__name__)
 
@@ -61,17 +51,6 @@ if app.config['SESSION_TYPE'] == 'redis':
 
     # wrap in the flask server side session manager and back it by redis
     app.config['SESSION_REDIS'] = redis
-
-Talisman(app,
-         content_security_policy=CSP_POLICY,
-         content_security_policy_nonce_in=['script-src'],
-         session_cookie_secure=app.config['SECURE_COOKIES'],
-         force_https=False,  # this is handled at the firewall
-         strict_transport_security=True,
-         strict_transport_security_max_age=31536000,
-         strict_transport_security_include_subdomains=True,
-         referrer_policy='same-origin',
-         frame_options='DENY')
 
 Session(app)
 

--- a/tests/views/test_info.py
+++ b/tests/views/test_info.py
@@ -15,14 +15,12 @@ class TestInfo(unittest.TestCase):
 
     def setUp(self):
         self.app = app.test_client()
-        with open('git_info', 'w') as outfile:
-            json.dump({"test": "test"}, outfile)
+        self.delete_git_info()
 
     def tearDown(self):
         self.delete_git_info()
 
     def test_info_no_git_info(self):
-        self.delete_git_info()
         response = self.app.get("/info")
 
         self.assertEqual(response.status_code, 200)
@@ -30,49 +28,20 @@ class TestInfo(unittest.TestCase):
         self.assertNotIn('"test": "test"'.encode(), response.data)
 
     def test_info_with_git_info(self):
+        with open('git_info', 'w') as outfile:
+            json.dump({"test": "test"}, outfile)
+
         response = self.app.get("/info")
 
         self.assertEqual(response.status_code, 200)
         self.assertIn('"name": "response-operations-ui"'.encode(), response.data)
 
     def test_info_with_non_json_git_info(self):
-        self.delete_git_info()
         with open('git_info', 'w') as outfile:
             outfile.write('"test": "test"')
+
         response = self.app.get("/info")
 
         self.assertEqual(response.status_code, 200)
         self.assertIn('"name": "response-operations-ui"'.encode(), response.data)
         self.assertNotIn('"test": "test"'.encode(), response.data)
-
-    def test_strict_transport_security_header_is_set(self):
-        response = self.app.get("/info", base_url='https://localhost')
-
-        self.assertEqual(response.headers['Strict-Transport-Security'], 'max-age=31536000; includeSubDomains')
-
-    def test_content_security_policy_header_is_set(self):
-        response = self.app.get("/info")
-
-        self.assertIn('font-src \'self\' data: https://cdn.ons.gov.uk', response.headers['Content-Security-Policy'])
-        self.assertIn('default-src \'self\' https://cdn.ons.gov.uk', response.headers['Content-Security-Policy'])
-        self.assertIn('connect-src \'self\' https://www.google-analytics.com https://cdn.ons.gov.uk',
-                      response.headers['Content-Security-Policy'])
-        self.assertIn('img-src \'self\' data: https://www.google-analytics.com https://cdn.ons.gov.uk',
-                      response.headers['Content-Security-Policy'])
-        self.assertIn('script-src \'self\' https://www.google-analytics.com https://cdn.ons.gov.uk',
-                      response.headers['Content-Security-Policy'])
-
-    def test_x_xss_protection_header_is_set(self):
-        response = self.app.get("/info")
-
-        self.assertEqual(response.headers['X-XSS-Protection'], '1; mode=block')
-
-    def test_x_content_type_options_header_is_set(self):
-        response = self.app.get("/info")
-
-        self.assertEqual(response.headers['X-Content-Type-Options'], 'nosniff')
-
-    def test_referrer_policy_header_is_set(self):
-        response = self.app.get("/info")
-
-        self.assertEqual(response.headers['Referrer-Policy'], 'same-origin')

--- a/tests/views/test_sign_in.py
+++ b/tests/views/test_sign_in.py
@@ -101,12 +101,3 @@ class TestSignIn(unittest.TestCase):
         self.assertIn("Surveys".encode(), response.data)
         self.assertIn("Legal basis".encode(), response.data)
         self.assertIn("Statistics of Trade Act 1947".encode(), response.data)
-
-    @requests_mock.mock()
-    def test_sign_in_with_secure_cookies(self, mock_request):
-        mock_request.post(url_sign_in_data, json={"token": "1234abc"}, status_code=201)
-
-        response = self.app.post("/sign-in", follow_redirects=True, base_url='https://localhost',
-                                 data={"username": "user", "password": "pass"})
-
-        self.assertIn('Secure;', response.headers['Set-Cookie'])


### PR DESCRIPTION
This reverts commit ea346ae1cb2b051aa11c2840e102096e466cd92a.

CSP is preventing executing inline javascript. We will need to add logic to generate and inject a nonce into the html like https://github.com/ONSdigital/eq-survey-runner/blob/b5168bb07890cefd64658f0ef0f426b810f7d3e2/app/talisman.py