### PR TITLE
Add RU name to pop up style views.

### DIFF
--- a/response_operations_ui/templates/change-response-status.html
+++ b/response_operations_ui/templates/change-response-status.html
@@ -26,6 +26,12 @@
                                     {{ ru_ref }}
                                 </dd>
                                 <dt class="">
+                                    Name:
+                                </dt>
+                                <dd class="">
+                                    {{ ru_name }}
+                                </dd>
+                                <dt class="">
                                     Trading as:
                                 </dt>
                                 <dd class="">

--- a/response_operations_ui/templates/confirm-enrolment-change.html
+++ b/response_operations_ui/templates/confirm-enrolment-change.html
@@ -21,6 +21,13 @@
         </dd>
 
         <dt class="">
+          Name:
+        </dt>
+        <dd class="" id="ru_name">
+          {{ ru_name }}
+        </dd>
+
+        <dt class="">
           Trading as:
         </dt>
         <dd class="">

--- a/response_operations_ui/templates/new-enrolment-code.html
+++ b/response_operations_ui/templates/new-enrolment-code.html
@@ -17,6 +17,12 @@
           {{ru_ref}}
         </dd>
         <dt class="">
+          Name:
+        </dt>
+        <dd class="">
+          {{ru_name}}
+        </dd>
+        <dt class="">
           Trading as:
         </dt>
         <dd class="">

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -178,7 +178,7 @@
                 {% if respondent.enrolmentStatus == 'ENABLED' %}
                 <a href="{{ url_for('reporting_unit_bp.confirm_change_enrolment_status', ru_ref=ru.sampleUnitRef, ru_name=ru.name, survey_id=survey.id,
                                     survey_name=survey.shortName, respondent_id=respondent.id, respondent_first_name=respondent.firstName,
-                                    respondent_last_name=respondent.lastName, business_id=ru.id, trading_as=trading_as, change_flag='DISABLED')}}"
+                                    respondent_last_name=respondent.lastName, business_id=ru.id, trading_as=ru.trading_as, change_flag='DISABLED')}}"
                    id="change-enrolment-status">Disable</a>
                 {% elif respondent.enrolmentStatus == 'PENDING' %}
                 <a href="{{ url_for('reporting_unit_bp.view_resend_verification', ru_ref=ru_ref, email=respondent.emailAddress, party_id=respondent.id) }}">Re-send verification email</a>

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -96,8 +96,9 @@
           </div>
           {% endif %}
           <a href="{{ url_for('reporting_unit_bp.generate_new_enrolment_code',
-                              collection_exercise_id=survey.collection_exercises[-1]['id'], ru_ref=ru.sampleUnitRef,
-                              trading_as=ru.trading_as, survey_ref=survey.surveyRef, survey_name=survey.shortName) }}"
+                              collection_exercise_id=survey.collection_exercises[-1]['id'], ru_name=ru.name,
+                              ru_ref=ru.sampleUnitRef, trading_as=ru.trading_as, survey_ref=survey.surveyRef,
+                              survey_name=survey.shortName) }}"
              id="generate-new-code">
             Generate new enrolment code
           </a>
@@ -175,9 +176,10 @@
               
               <div>
                 {% if respondent.enrolmentStatus == 'ENABLED' %}
-                <a href="{{ url_for('reporting_unit_bp.confirm_change_enrolment_status', ru_ref=ru.sampleUnitRef, survey_id=survey.id, survey_name=survey.shortName,
-                                    respondent_id=respondent.id, respondent_first_name=respondent.firstName, respondent_last_name=respondent.lastName, business_id=ru.id,
-                                    trading_as=trading_as, change_flag='DISABLED')}}" id="change-enrolment-status">Disable</a>
+                <a href="{{ url_for('reporting_unit_bp.confirm_change_enrolment_status', ru_ref=ru.sampleUnitRef, ru_name=ru.name, survey_id=survey.id,
+                                    survey_name=survey.shortName, respondent_id=respondent.id, respondent_first_name=respondent.firstName,
+                                    respondent_last_name=respondent.lastName, business_id=ru.id, trading_as=trading_as, change_flag='DISABLED')}}"
+                   id="change-enrolment-status">Disable</a>
                 {% elif respondent.enrolmentStatus == 'PENDING' %}
                 <a href="{{ url_for('reporting_unit_bp.view_resend_verification', ru_ref=ru_ref, email=respondent.emailAddress, party_id=respondent.id) }}">Re-send verification email</a>
                 {% endif %}

--- a/response_operations_ui/views/case.py
+++ b/response_operations_ui/views/case.py
@@ -18,7 +18,7 @@ def get_response_statuses(ru_ref):
     statuses['available_statuses'] = {event: map_ce_response_status(status)
                                       for event, status in statuses['available_statuses'].items()}
     return render_template('change-response-status.html', ru_ref=statuses['ru_ref'], trading_as=statuses['trading_as'],
-                           survey_short_name=short_name, survey_id=statuses['survey_id'], ru_name=statuses['name'],
+                           survey_short_name=short_name, survey_id=statuses['survey_id'], ru_name=statuses['ru_name'],
                            ce_period=collection_exercise_period,
                            case_group_status=map_ce_response_status(statuses['current_status']),
                            statuses=statuses['available_statuses'])
@@ -39,7 +39,7 @@ def update_response_status(ru_ref):
     statuses['available_statuses'] = {event: map_ce_response_status(status)
                                       for event, status in statuses['available_statuses'].items()}
     return render_template('change-response-status.html', ru_ref=statuses['ru_ref'], trading_as=statuses['trading_as'],
-                           survey_short_name=short_name, survey_id=statuses['survey_id'], ru_name=statuses['name'],
+                           survey_short_name=short_name, survey_id=statuses['survey_id'], ru_name=statuses['ru_name'],
                            ce_period=collection_exercise_period,
                            case_group_status=map_ce_response_status(statuses['current_status']),
                            statuses=statuses['available_statuses'],

--- a/response_operations_ui/views/case.py
+++ b/response_operations_ui/views/case.py
@@ -18,7 +18,7 @@ def get_response_statuses(ru_ref):
     statuses['available_statuses'] = {event: map_ce_response_status(status)
                                       for event, status in statuses['available_statuses'].items()}
     return render_template('change-response-status.html', ru_ref=statuses['ru_ref'], trading_as=statuses['trading_as'],
-                           survey_short_name=short_name, survey_id=statuses['survey_id'],
+                           survey_short_name=short_name, survey_id=statuses['survey_id'], ru_name=statuses['name'],
                            ce_period=collection_exercise_period,
                            case_group_status=map_ce_response_status(statuses['current_status']),
                            statuses=statuses['available_statuses'])

--- a/response_operations_ui/views/case.py
+++ b/response_operations_ui/views/case.py
@@ -39,7 +39,7 @@ def update_response_status(ru_ref):
     statuses['available_statuses'] = {event: map_ce_response_status(status)
                                       for event, status in statuses['available_statuses'].items()}
     return render_template('change-response-status.html', ru_ref=statuses['ru_ref'], trading_as=statuses['trading_as'],
-                           survey_short_name=short_name, survey_id=statuses['survey_id'],
+                           survey_short_name=short_name, survey_id=statuses['survey_id'], ru_name=statuses['name'],
                            ce_period=collection_exercise_period,
                            case_group_status=map_ce_response_status(statuses['current_status']),
                            statuses=statuses['available_statuses'],

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -186,6 +186,7 @@ def resend_verification(ru_ref, party_id):
 def generate_new_enrolment_code(ru_ref, collection_exercise_id):
     case = reporting_units_controllers.generate_new_enrolment_code(collection_exercise_id, ru_ref)
     return render_template('new-enrolment-code.html', case=case, ru_ref=ru_ref,
+                           ru_name=request.args.get('ru_name'),
                            trading_as=request.args.get('trading_as'),
                            survey_name=request.args.get('survey_name'),
                            survey_ref=request.args.get('survey_ref'))
@@ -195,6 +196,7 @@ def generate_new_enrolment_code(ru_ref, collection_exercise_id):
 @login_required
 def confirm_change_enrolment_status(ru_ref):
     return render_template('confirm-enrolment-change.html', business_id=request.args['business_id'], ru_ref=ru_ref,
+                           ru_name=request.args.get('ru_name'),
                            trading_as=request.args['trading_as'], survey_id=request.args['survey_id'],
                            survey_name=request.args['survey_name'], respondent_id=request.args['respondent_id'],
                            first_name=request.args['respondent_first_name'],

--- a/tests/views/test_case.py
+++ b/tests/views/test_case.py
@@ -15,6 +15,7 @@ class TestCase(unittest.TestCase):
         self.app = app.test_client()
         self.case_group_status = {
             "ru_ref": "19000001",
+            "ru_name": "RU Name",
             "trading_as": "Company Name",
             "survey_id": "123",
             "short_name": "MYSURVEY",
@@ -38,6 +39,7 @@ class TestCase(unittest.TestCase):
         data = response.data
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'19000001', data)
+        self.assertIn(b'RU Name', data)
         self.assertIn(b'Company Name', data)
         self.assertIn(b'123 &nbsp; MYSURVEY', data)
         self.assertIn(b'Not started', data)

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -73,6 +73,7 @@ class TestReportingUnits(unittest.TestCase):
         self.app = app.test_client()
         self.case_group_status = {
             "ru_ref": "19000001",
+            "ru_name": "RU Name",
             "trading_as": "Company Name",
             "survey_id": "123",
             "short_name": "MYSURVEY",
@@ -554,10 +555,15 @@ class TestReportingUnits(unittest.TestCase):
     def test_reporting_unit_generate_new_code(self, mock_request):
         mock_request.post(url_generate_new_code, json=case)
 
-        response = self.app.get("/reporting-units/ru_ref/ce_id/new_enrolment_code", follow_redirects=True)
+        response = self.app.get("/reporting-units/ru_ref/ce_id/new_enrolment_code"
+                                "?survey_name=test_survey_name&trading_as=trading_name&ru_name=test_ru_name",
+                                follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("jkbvyklkwj88".encode(), response.data)
+        self.assertIn("test_ru_name".encode(), response.data)
+        self.assertIn("trading_name".encode(), response.data)
+        self.assertIn("test_survey_name".encode(), response.data)
 
     @requests_mock.mock()
     def test_reporting_unit_generate_new_code_fail(self, mock_request):
@@ -572,9 +578,10 @@ class TestReportingUnits(unittest.TestCase):
         response = self.app.get("/reporting-units/ru_ref/change-enrolment-status"
                                 "?survey_id=test_id&survey_name=test_survey_name&respondent_id=test_id"
                                 "&respondent_first_name=first_name&respondent_last_name=last_name&business_id=test_id"
-                                "&trading_as=test_name&change_flag=DISABLED")
+                                "&trading_as=test_name&change_flag=DISABLED&ru_name=test_ru_name")
 
         self.assertEqual(response.status_code, 200)
+        self.assertIn("test_ru_name".encode(), response.data)
         self.assertIn("test_name".encode(), response.data)
         self.assertIn("test_survey_name".encode(), response.data)
         self.assertIn("first_name".encode(), response.data)


### PR DESCRIPTION
Requires this branch of ras-backstage:
https://github.com/ONSdigital/ras-backstage/pull/108

The RU name should now be displayed on the 'Change enrollment status', 'Generate new enrollment code' and 'Change response status' pop up style views.

Trello card:
https://trello.com/c/1aqQQgXZ/226-change-request-add-business-names-to-pop-up-views-in-response-operations-ui