### PR TITLE
add trading as in ru search result

### DIFF
--- a/response_operations_ui/templates/reporting-units.html
+++ b/response_operations_ui/templates/reporting-units.html
@@ -40,6 +40,9 @@
                         <th scope="col" class="table--header--cell">
                             Name
                         </th>
+                        <th scope="col" class="table--header--cell">
+                            Trading as
+                        </th>
                     </tr>
                     </thead>
 
@@ -47,10 +50,13 @@
                     {% for business in business_list %}
                     <tr class="table--row table--row__selectable">
                         <td class="table--cell ">
-                            <a href="/reporting-units/{{ business.ruref }}" name="survey-link-{{ business.ruref }}">{{ business.ruref }}</a>
+                            <a href="/reporting-units/{{ business.ruref }}" name="details-link-{{ business.ruref }}">{{ business.ruref }}</a>
                         </td>
                         <td class="table--cell">
                             {{ business.name }}
+                        </td>
+                        <td class="table--cell">
+                            {{ business.trading_as }}
                         </td>
                     </tr>
                     {% endfor %}


### PR DESCRIPTION
The reporting unit trading as name should be shown as well the business name. This pr adds a trading as column to the reporting units search results page.

You will need the ras party changes for the trading as names to show: https://github.com/ONSdigital/ras-party/pull/131
