### PR TITLE
Rename working directory to app for consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6
 
-WORKDIR /response_operations_ui
-COPY . /response_operations_ui
+WORKDIR /app
+COPY . /app
 EXPOSE 8085
 RUN pip3 install pipenv && pipenv install --deploy --system
 


### PR DESCRIPTION
# Motivation and Context
The working directory difference is inconsistent with the other dockerized apps in ras/rm.

# What has changed
Rename container working directory to `/app` to align with other apps.

# How to test?
Build and run container from branched Dockerfile.

# Links
Issue spotted in [hot-reloading PR](https://github.com/ONSdigital/ras-rm-docker-dev/pull/58#pullrequestreview-128273605) (compose file will also need updating).
