### PR TITLE
Reload templates without restarting

### DIFF
--- a/config.py
+++ b/config.py
@@ -104,6 +104,9 @@ class DevelopmentConfig(Config):
     SURVEY_PASSWORD = os.getenv('SURVEY_PASSWORD', 'secret')
     SURVEY_AUTH = (SURVEY_USERNAME, SURVEY_PASSWORD)
 
+    TEMPLATES_AUTO_RELOAD = True
+    EXPLAIN_TEMPLATE_LOADING = True
+
     UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL', 'http://localhost:9080')
     UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID', 'response_operations')
     UAA_CLIENT_SECRET = os.getenv('UAA_CLIENT_SECRET', 'password')

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -52,6 +52,9 @@ if app.config['SESSION_TYPE'] == 'redis':
     # wrap in the flask server side session manager and back it by redis
     app.config['SESSION_REDIS'] = redis
 
+if app.config['DEBUG'] == True:
+    app.jinja_env.auto_reload = True
+
 Session(app)
 
 


### PR DESCRIPTION
# Motivation and Context
Autoreloads templates when running debug mode. Developers will see changes to html templates without having to restart a running server.

# What has changed
Added new config to config.py to set auto reloading to true and to enable more verbose output of template loading information.

# How to test?
- Run the server either under ras-rm-docker-dev or locally.
- Make sure the app is running in debug mode.
- Navigate to the sign in page.
- Alter the source code for one of the relevant templates.
- Reload the page, check the change is visible.
