### PR TITLE
use raise for status

### DIFF
--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -25,9 +25,11 @@ def upload_collection_instrument(collection_exercise_id, file, form_type=None):
 
     files = {"file": (file.filename, file.stream, file.mimetype)}
     response = requests.post(url, files=files, params=params, auth=app.config['COLLECTION_INSTRUMENT_AUTH'])
-    if response.status_code != 201:
-        logger.error('Failed to upload collection instrument', collection_exercise_id=collection_exercise_id,
-                     form_type=form_type, status=response.status_code)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.exception('Failed to upload collection instrument', collection_exercise_id=collection_exercise_id,
+                         form_type=form_type, status=response.status_code)
         return False
 
     logger.debug('Successfully uploaded collection instrument', collection_exercise_id=collection_exercise_id,


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
CI build breaking because response operations is expecting a 201 explicitly on CI upload but collection instrument gives back a 200 response.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Using raise for status instead of explicit 201 check.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check you can upload a CI

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
