### PR TITLE
[TBL] Link and unlink CI's and CE's directly

### DIFF
--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -40,9 +40,13 @@ def upload_collection_instrument(collection_exercise_id, file, form_type=None):
 def link_collection_instrument(ce_id, ci_id):
     logger.debug('Linking collection instrument to collection exercise',
                  collection_exercise_id=ce_id, collection_instrument_id=ci_id)
-    url = f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-instrument/link/{ci_id}/{ce_id}'
-    response = requests.post(url)
-    if response.status_code != 200:
+    url = f'{app.config["COLLECTION_INSTRUMENT_URL"]}' \
+          f'/collection-instrument-api/1.0.2/link-exercise/{ci_id}/{ce_id}'
+
+    response = requests.post(url, auth=app.config['COLLECTION_INSTRUMENT_AUTH'])
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
         logger.error('Failed to link collection instrument to collection exercise',
                      collection_exercise_id=ce_id, collection_instrument_id=ci_id, status=response.status_code)
         return False
@@ -55,9 +59,13 @@ def link_collection_instrument(ce_id, ci_id):
 def unlink_collection_instrument(ce_id, ci_id):
     logger.debug('Unlinking collection instrument and collection exercise',
                  collection_exercise_id=ce_id, collection_instrument_id=ci_id)
-    url = f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-instrument/unlink/{ci_id}/{ce_id}'
-    response = requests.put(url)
-    if response.status_code != 200:
+    url = f'{app.config["COLLECTION_INSTRUMENT_URL"]}' \
+          f'/collection-instrument-api/1.0.2/unlink-exercise/{ci_id}/{ce_id}'
+
+    response = requests.put(url, auth=app.config['COLLECTION_INSTRUMENT_AUTH'])
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
         logger.error('Failed to unlink collection instrument and collection exercise',
                      collection_exercise_id=ce_id, collection_instrument_id=ci_id, status=response.status_code)
         return False

--- a/tests/test_data/collection_exercise/exercise_data.json
+++ b/tests/test_data/collection_exercise/exercise_data.json
@@ -1,5 +1,5 @@
 [{
-  "id": "6e65acc4-4192-474b-bd3d-08071c4768e2",
+  "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
   "surveyId": "0b1f8376-28e9-4884-bea5-acf9d709464e",
   "name": "Monthly Business Sur",
   "scheduledExecutionDateTime": "2018-06-19T00:00:00.000Z",

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -7,9 +7,14 @@ import requests_mock
 from config import TestingConfig
 from response_operations_ui import app
 
-collection_exercise_id = "14fb3e68-4dca-46db-bf49-04b84e07e77c"
-survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
 
+collection_exercise_id = '14fb3e68-4dca-46db-bf49-04b84e07e77c'
+collection_instrument_id = 'a32800c5-5dc1-459d-9932-0da6c21d2ed2'
+sample_summary_id = '1a11543f-eb19-41f5-825f-e41aca15e724'
+survey_id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+survey_ref = '141'
+short_name = 'ashortname'
+period = '000000'
 
 collex_root = "tests/test_data/collection_exercise/collection_exercise_details"
 no_sample = collex_root + "_no_sample.json"
@@ -35,60 +40,67 @@ with open("tests/test_data/survey/survey_by_id.json") as fp:
 with open("tests/test_data/collection_exercise/exercise_data.json") as json_data:
     exercise_data = json.load(json_data)
 
-
 """Define URLS"""
 
 url_get_collection_exercise = (
-    f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-exercise/test/000000'
+    f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-exercise/{short_name}/{period}'
 )
 
 url_collection_instrument = (
     f'{app.config["COLLECTION_INSTRUMENT_URL"]}'
-    f"/collection-instrument-api/1.0.2/upload/6e65acc4-4192-474b-bd3d-08071c4768e2"
+    f'/collection-instrument-api/1.0.2/upload/{collection_exercise_id}'
 )
 
 url_collection_instrument_link = (
-    f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-instrument/link/111111/000000'
+    f'{app.config["COLLECTION_INSTRUMENT_URL"]}'
+    f'/collection-instrument-api/1.0.2/link-exercise'
+    f'/{collection_instrument_id}/{collection_exercise_id}'
 )
 
 url_collection_instrument_unlink = (
-    f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-instrument/'
-    f"unlink/14fb3e68-4dca-46db-bf49-04b84e07e77c/000000"
+    f'{app.config["COLLECTION_INSTRUMENT_URL"]}'
+    f'/collection-instrument-api/1.0.2/unlink-exercise'
+    f'/{collection_instrument_id}/{collection_exercise_id}'
 )
 
-url_survey_shortname = f'{app.config["SURVEY_URL"]}/surveys/shortname/test'
+url_survey_shortname = f'{app.config["SURVEY_URL"]}/surveys/shortname/{short_name}'
 
 url_sample_service_upload = f'{app.config["SAMPLE_URL"]}/samples/B/fileupload'
 
 url_collection_exercise_survey_id = (
-    f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/survey/'
-    "af6ddd8f-7bd0-4c51-b879-ff4b367461c5"
+    f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/survey'
+    f'/{survey_id}'
 )
 
 url_collection_exercise_link = (
-    f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/link/'
-    "6e65acc4-4192-474b-bd3d-08071c4768e2"
+    f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/link'
+    f'/{collection_exercise_id}'
 )
 
-url_upload_sample = f'{app.config["BACKSTAGE_API_URL"]}/v1/sample/test/000000'
+url_upload_sample = f'{app.config["BACKSTAGE_API_URL"]}/v1/sample/{short_name}/{period}'
 
-url_execute = f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-exercise/test/000000/execute'
+url_execute = (
+    f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-exercise'
+    f'/{short_name}/{period}/execute'
+)
 
 url_update_ce = (
-    f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-exercise/update-collection-exercise-details/'
-    f"{collection_exercise_id}"
+    f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-exercise/update-collection-exercise-details'
+    f'/{collection_exercise_id}'
 )
 
-url_get_survey_by_short_name = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/shortname/test'
+url_get_survey_by_short_name = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/shortname/{short_name}'
 
 url_create_collection_exercise = f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises'
 
 url_ce_remove_sample = (
     f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/unlink/{collection_exercise_id}'
-    f"/sample/1a11543f-eb19-41f5-825f-e41aca15e724"
+    f'/sample/{sample_summary_id}'
 )
 
-url_ce_by_survey = f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/survey/' f"{survey_id}"
+url_ce_by_survey = (
+    f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/survey/{survey_id}'
+)
 
 
 class TestCollectionExercise(unittest.TestCase):
@@ -101,18 +113,18 @@ class TestCollectionExercise(unittest.TestCase):
         self.headers = {"Authorization": "test_jwt", "Content-Type": "application/json"}
         self.collection_exercises = [
             {
-                "id": "c6467711-21eb-4e78-804c-1db8392f93fb",
+                "id": collection_exercise_id,
                 "exerciseRef": "201601",
                 "scheduledExecutionDateTime": "2017-05-15T00:00:00Z",
             }
         ]
-        self.survey_data = {"id": "af6ddd8f-7bd0-4c51-b879-ff4b367461c5"}
+        self.survey_data = {"id": survey_id}
 
     @requests_mock.mock()
     def test_collection_exercise_view(self, mock_request):
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.get("/surveys/test/000000")
+        response = self.app.get(f'/surveys/{short_name}/{period}')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Business Register and Employment Survey".encode(), response.data)
@@ -122,7 +134,7 @@ class TestCollectionExercise(unittest.TestCase):
     def test_collection_exercise_view_fail(self, mock_request):
         mock_request.get(url_get_collection_exercise, status_code=500)
 
-        response = self.app.get("/surveys/test/000000", follow_redirects=True)
+        response = self.app.get(f'/surveys/{short_name}/{period}', follow_redirects=True)
 
         self.assertEqual(response.status_code, 500)
         self.assertIn("Error 500 - Server error".encode(), response.data)
@@ -135,29 +147,33 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_collection_exercise_survey_id, status_code=200, json=exercise_data)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data, follow_redirects=True)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Collection instrument loaded".encode(), response.data)
 
     @requests_mock.mock()
     def test_select_collection_instrument(self, mock_request):
-        post_data = {"checkbox-answer": ["111111"], "ce_id": "000000", "select-ci": ""}
+        post_data = {
+            "checkbox-answer": [collection_instrument_id],
+            "ce_id": collection_exercise_id,
+            "select-ci": ""
+        }
         mock_request.post(url_collection_instrument_link, status_code=200)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f"/surveys/{short_name}/{period}", data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Collection instruments added".encode(), response.data)
 
     @requests_mock.mock()
     def test_failed_select_collection_instrument(self, mock_request):
-        post_data = {"checkbox-answer": ["111111"], "ce_id": "000000", "select-ci": ""}
+        post_data = {"checkbox-answer": [collection_instrument_id], "ce_id": collection_exercise_id, "select-ci": ""}
         mock_request.post(url_collection_instrument_link, status_code=500)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f"/surveys/{short_name}/{period}", data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Error: Failed to add collection instrument(s)".encode(), response.data)
@@ -167,7 +183,7 @@ class TestCollectionExercise(unittest.TestCase):
         post_data = {"checkbox-answer": [], "ce_id": "000000", "select-ci": ""}
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Error: No collection instruments selected".encode(), response.data)
@@ -180,7 +196,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_collection_exercise_survey_id, status_code=200, json=exercise_data)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data, follow_redirects=True)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("collection_instrument.xlsx".encode(), response.data)
@@ -193,7 +209,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_collection_exercise_survey_id, status_code=200, json=exercise_data)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data, follow_redirects=True)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Error: Failed to upload collection instrument".encode(), response.data)
@@ -203,7 +219,7 @@ class TestCollectionExercise(unittest.TestCase):
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_0001.html"), "load-ci": ""}
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
@@ -214,7 +230,7 @@ class TestCollectionExercise(unittest.TestCase):
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_xxxxx.xlsx"), "load-ci": ""}
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
@@ -227,7 +243,7 @@ class TestCollectionExercise(unittest.TestCase):
         post_data = {"ciFile": (BytesIO(b"data"), "064201803_xxxxx.xlsx"), "load-ci": ""}
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
@@ -240,7 +256,7 @@ class TestCollectionExercise(unittest.TestCase):
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_123E.xlsx"), "load-ci": ""}
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
@@ -253,7 +269,7 @@ class TestCollectionExercise(unittest.TestCase):
         post_data = {"load-ci": ""}
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Collection instrument loaded".encode(), response.data)
@@ -263,7 +279,7 @@ class TestCollectionExercise(unittest.TestCase):
     def test_view_collection_instrument(self, mock_request):
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.get("/surveys/test/000000")
+        response = self.app.get(f'/surveys/{short_name}/{period}')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("collection_instrument.xlsx".encode(), response.data)
@@ -275,7 +291,7 @@ class TestCollectionExercise(unittest.TestCase):
         ) as collection_exercise:
             mock_request.get(url_get_collection_exercise, json=json.load(collection_exercise))
 
-        response = self.app.get("/surveys/test/000000")
+        response = self.app.get(f'/surveys/{short_name}/{period}')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Add a collection instrument. Must be XLSX".encode(), response.data)
@@ -284,7 +300,7 @@ class TestCollectionExercise(unittest.TestCase):
     def test_add_another_collection_instrument_when_already_uploaded(self, mock_request):
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.get("/surveys/test/000000")
+        response = self.app.get(f'/surveys/{short_name}/{period}')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Add another collection instrument. Must be XLSX".encode(), response.data)
@@ -294,7 +310,7 @@ class TestCollectionExercise(unittest.TestCase):
         post_data = {"sampleFile": (BytesIO(b"data"), "test.csv"), "load-sample": ""}
 
         sample_data = {
-            "id": "d29489a0-1044-4c33-9d0d-02aeb57ce82d"
+            "id": sample_summary_id
         }
 
         collection_exercise_link = {"id": ""}
@@ -309,7 +325,7 @@ class TestCollectionExercise(unittest.TestCase):
             url_collection_exercise_link, status_code=200, json=collection_exercise_link
         )
 
-        response = self.app.post("/surveys/test/000000", data=post_data, follow_redirects=True)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Sample loaded successfully".encode(), response.data)
@@ -322,7 +338,7 @@ class TestCollectionExercise(unittest.TestCase):
         post_data = {"sampleFile": (BytesIO(b"data"), "test.csv"), "load-sample": ""}
 
         sample_data = {
-            "id": "d29489a0-1044-4c33-9d0d-02aeb57ce82d"
+            "id": sample_summary_id
         }
 
         collection_exercise_link = {"id": ""}
@@ -337,7 +353,7 @@ class TestCollectionExercise(unittest.TestCase):
             url_collection_exercise_link, status_code=500, json=collection_exercise_link
         )
 
-        response = self.app.post("/surveys/test/000000", data=post_data, follow_redirects=True)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data, follow_redirects=True)
 
         self.assertEqual(response.status_code, 500)
         self.assertIn("Error 500 - Server error".encode(), response.data)
@@ -347,11 +363,10 @@ class TestCollectionExercise(unittest.TestCase):
         post_data = {"sampleFile": (BytesIO(b"data"), "test.csv"), "load-sample": ""}
 
         sample_data = {
-            "id": "d29489a0-1044-4c33-9d0d-02aeb57ce82d"
+            "id": sample_summary_id
         }
 
         collection_exercise_link = {"id": ""}
-        url_survey_shortname = f'{app.config["SURVEY_URL"]}/surveys/shortname/test'
 
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
         mock_request.get(url_survey_shortname, status_code=200, json=self.survey_data)
@@ -361,7 +376,7 @@ class TestCollectionExercise(unittest.TestCase):
             url_collection_exercise_link, status_code=200, json=collection_exercise_link
         )
 
-        response = self.app.post("/surveys/test/000000", data=post_data, follow_redirects=True)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data, follow_redirects=True)
 
         self.assertEqual(response.status_code, 500)
         self.assertIn("Error 500 - Server error".encode(), response.data)
@@ -373,7 +388,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.post(url_upload_sample, status_code=500)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=data, follow_redirects=True)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=data, follow_redirects=True)
 
         self.assertEqual(response.status_code, 500)
         self.assertIn("Error 500 - Server error".encode(), response.data)
@@ -389,7 +404,7 @@ class TestCollectionExercise(unittest.TestCase):
             url_collection_exercise_survey_id, status_code=200, json=exercise_data
         )
 
-        response = self.app.post("/surveys/test/000000", data=data, follow_redirects=True)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=data, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Sample loaded successfully".encode(), response.data)
@@ -407,7 +422,7 @@ class TestCollectionExercise(unittest.TestCase):
             url_collection_exercise_survey_id, status_code=200, json=exercise_data
         )
         response = self.app.post(
-            "/surveys/test/000000", data=data, follow_redirects=True
+            f'/surveys/{short_name}/{period}', data=data, follow_redirects=True
         )
 
         self.assertEqual(response.status_code, 200)
@@ -420,7 +435,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.post(url_execute, status_code=200)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Sample loaded successfully".encode(), response.data)
@@ -433,7 +448,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.post(url_execute, status_code=500)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Sample loaded successfully".encode(), response.data)
@@ -445,7 +460,7 @@ class TestCollectionExercise(unittest.TestCase):
         collection_exercise_details["collection_exercise"]["state"] = "EXECUTION_STARTED"
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.get("/surveys/test/000000")
+        response = self.app.get(f'/surveys/{short_name}/{period}')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Processing collection exercise".encode(), response.data)
@@ -456,7 +471,7 @@ class TestCollectionExercise(unittest.TestCase):
             url_get_collection_exercise, json=collection_exercise_details_failedvalidation
         )
 
-        response = self.app.get("/surveys/test/000000")
+        response = self.app.get(f'/surveys/{short_name}/{period}')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Ready for review".encode(), response.data)
@@ -466,7 +481,7 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_update_collection_exercise_details_success(self, mock_request):
         changed_ce_details = {
-            "collection_exercise_id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+            "collection_exercise_id": collection_exercise_id,
             "user_description": "16th June 2019",
             "period": "201906",
             "hidden_survey_id": survey_id,
@@ -476,7 +491,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_ce_by_survey, json=self.collection_exercises)
         mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
         response = self.app.post(
-            f"/surveys/test/000000/edit-collection-exercise-details",
+            f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
             data=changed_ce_details,
             follow_redirects=True,
         )
@@ -488,7 +503,7 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_update_collection_exercise_details_fail(self, mock_request):
         changed_ce_details = {
-            "collection_exercise_id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+            "collection_exercise_id": collection_exercise_id,
             "user_description": "16th June 2019",
             "period": "201906",
             "hidden_survey_id": survey_id,
@@ -497,7 +512,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.put(url_update_ce, status_code=500)
 
         response = self.app.post(
-            f"/surveys/test/000000/edit-collection-exercise-details",
+            f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
             data=changed_ce_details,
             follow_redirects=True,
         )
@@ -509,24 +524,24 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
         mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
         response = self.app.get(
-            f"/surveys/test/000000/edit-collection-exercise-details", follow_redirects=True
+            f"/surveys/{short_name}/{period}/edit-collection-exercise-details", follow_redirects=True
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("14fb3e68-4dca-46db-bf49-04b84e07e77c".encode(), response.data)
+        self.assertIn(collection_exercise_id.encode(), response.data)
 
     @requests_mock.mock()
     def test_unlink_collection_instrument(self, mock_request):
         post_data = {
-            "ci_id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
-            "ce_id": "000000",
+            "ci_id": collection_instrument_id,
+            "ce_id": collection_exercise_id,
             "unselect-ci": "",
         }
 
         mock_request.put(url_collection_instrument_unlink, status_code=200)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f"/surveys/{short_name}/{period}", data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Collection instrument removed".encode(), response.data)
@@ -534,15 +549,15 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_failed_unlink_collection_instrument(self, mock_request):
         post_data = {
-            "ci_id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
-            "ce_id": "000000",
+            "ci_id": collection_instrument_id,
+            "ce_id": collection_exercise_id,
             "unselect-ci": "",
         }
 
         mock_request.put(url_collection_instrument_unlink, status_code=500)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
 
-        response = self.app.post("/surveys/test/000000", data=post_data)
+        response = self.app.post(f"/surveys/{short_name}/{period}", data=post_data)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Error: Failed to remove collection instrument".encode(), response.data)
@@ -560,7 +575,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.post(url_create_collection_exercise, status_code=200)
 
         response = self.app.post(
-            f"/surveys/141-test/create-collection-exercise",
+            f"/surveys/{survey_ref}-{short_name}/create-collection-exercise",
             data=new_collection_exercise_details,
             follow_redirects=True,
         )
@@ -580,7 +595,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.post(url_create_collection_exercise, status_code=500)
 
         response = self.app.post(
-            f"/surveys/141-test/create-collection-exercise",
+            f"/surveys/{survey_ref}-{short_name}/create-collection-exercise",
             data=new_collection_exercise_details,
             follow_redirects=True,
         )
@@ -591,7 +606,7 @@ class TestCollectionExercise(unittest.TestCase):
     def test_get_create_ce_form(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
         response = self.app.get(
-            f"/surveys/141-test/create-collection-exercise", follow_redirects=True
+            f"/surveys/{survey_ref}-{short_name}/create-collection-exercise", follow_redirects=True
         )
 
         self.assertEqual(response.status_code, 200)
@@ -610,7 +625,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.post(url_create_collection_exercise, status_code=200)
 
         response = self.app.post(
-            f"/surveys/141-test/create-collection-exercise",
+            f"/surveys/{survey_ref}-{short_name}/create-collection-exercise",
             data=new_collection_exercise_details,
             follow_redirects=True,
         )
@@ -633,7 +648,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.post(url_create_collection_exercise, status_code=200)
 
         response = self.app.post(
-            f"/surveys/141-test/create-collection-exercise",
+            f"/surveys/{survey_ref}-{short_name}/create-collection-exercise",
             data=new_collection_exercise_details,
             follow_redirects=True,
         )
@@ -643,7 +658,7 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_failed_edit_ce_validation_period_exists(self, mock_request):
         changed_ce_details = {
-            "collection_exercise_id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+            "collection_exercise_id": collection_exercise_id,
             "user_description": "16th June 2019",
             "period": "201601",
             "hidden_survey_id": survey_id,
@@ -653,7 +668,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_ce_by_survey, json=self.collection_exercises)
         mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
         response = self.app.post(
-            f"/surveys/test/000000/edit-collection-exercise-details",
+            f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
             data=changed_ce_details,
             follow_redirects=True,
         )
@@ -667,7 +682,7 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_failed_edit_ce_validation_letters_in_period_fails_validation(self, mock_request):
         changed_ce_details = {
-            "collection_exercise_id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+            "collection_exercise_id": collection_exercise_id,
             "user_description": "16th June 2019",
             "period": "hello",
             "hidden_survey_id": survey_id,
@@ -677,7 +692,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_ce_by_survey, json=self.collection_exercises)
         mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
         response = self.app.post(
-            f"/surveys/test/000000/edit-collection-exercise-details",
+            f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
             data=changed_ce_details,
             follow_redirects=True,
         )
@@ -690,7 +705,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
         mock_request.delete(url_ce_remove_sample, status_code=200)
         response = self.app.post(
-            f"/surveys/test/000000/confirm-remove-sample", follow_redirects=True
+            f"/surveys/{short_name}/{period}/confirm-remove-sample", follow_redirects=True
         )
 
         self.assertEquals(response.status_code, 200)
@@ -701,7 +716,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
         mock_request.delete(url_ce_remove_sample, status_code=500)
         response = self.app.post(
-            f"/surveys/test/000000/confirm-remove-sample", follow_redirects=True
+            f"/surveys/{short_name}/{period}/confirm-remove-sample", follow_redirects=True
         )
 
         self.assertEquals(response.status_code, 200)
@@ -710,8 +725,8 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_get_confirm_remove_sample(self, mock_request):
         response = self.app.get(
-            f"/surveys/test/000000/confirm-remove-sample", follow_redirects=True
+            f"/surveys/{short_name}/{period}/confirm-remove-sample", follow_redirects=True
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Remove sample from test 000000".encode(), response.data)
+        self.assertIn(f"Remove sample from {short_name} {period}".encode(), response.data)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes the call to backstage for linking and unlinking collection instruments.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Changes the links/unlink method in collection_exercise_controllers.py to hit the collection instrument service directly.

This also tidies up the test module to use predictable variables to use across the test methods.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the unit tests, make sure they pass.
Tail the logs for backstage, collection instrument service. Go to a collection exercise's detail page and select / deselect a collection instrument. Make sure backstage doesn't get the call, but collection instrument service does.