### PR TITLE
[TBL] Call the survey service direct to retrieve list of surveys

### DIFF
--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -14,7 +14,7 @@ from response_operations_ui.views.messages import _get_unread_status
 
 shortname_url = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/shortname'
 url_sign_in_data = f'{app.config["UAA_SERVICE_URL"]}/oauth/token'
-url_get_surveys_list = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/surveys'
+url_get_surveys_list = f'{app.config["SURVEY_URL"]}/surveys'
 url_get_thread = f'{app.config["SECURE_MESSAGE_URL"]}/v2/threads/fb0e79bd-e132-4f4f-a7fd-5e8c6b41b9af'
 url_get_threads_list = f'{app.config["SECURE_MESSAGE_URL"]}/threads'
 url_send_message = f'{app.config["SECURE_MESSAGE_URL"]}/v2/messages'

--- a/tests/views/test_sign_in.py
+++ b/tests/views/test_sign_in.py
@@ -6,7 +6,7 @@ import requests_mock
 from response_operations_ui import app
 
 url_sign_in_data = f'{app.config["UAA_SERVICE_URL"]}/oauth/token'
-url_surveys = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/surveys'
+url_surveys = f'{app.config["SURVEY_URL"]}/surveys'
 
 
 class TestSignIn(unittest.TestCase):

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -388,3 +388,9 @@ class TestSurvey(unittest.TestCase):
                                            '23a83a62-87dd-4c6c-97e2-4b207f7e57f5',
                                            '9f9d28c6-d010-47cc-832c-6ab9b741ee96',
                                            '48b6c58a-bf5b-4bb3-8d7d-5e205ff3a0fd'])
+
+    def test_format_shortname(self):
+        from response_operations_ui.controllers.survey_controllers import format_short_name
+
+        self.assertEqual(format_short_name('QBS'), 'QBS')
+        self.assertEqual(format_short_name('Sand&Gravel'), 'Sand & Gravel')

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -11,7 +11,7 @@ from response_operations_ui import app
 from response_operations_ui.controllers.survey_controllers import get_survey_short_name_by_id
 from response_operations_ui.views.surveys import _sort_collection_exercise
 
-url_get_survey_list = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/surveys'
+url_get_survey_list = f'{app.config["SURVEY_URL"]}/surveys'
 url_get_legal_basis_list = f'{app.config["SURVEY_URL"]}/legal-bases'
 url_create_survey = f'{app.config["SURVEY_URL"]}/surveys'
 
@@ -58,6 +58,14 @@ class TestSurvey(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("BRES".encode(), response.data)
         self.assertIn("BRUS".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_survey_list_no_surveys(self, mock_request):
+        mock_request.get(url_get_survey_list, status_code=204)
+
+        response = self.app.get("/surveys")
+
+        self.assertEqual(response.status_code, 200)
 
     @requests_mock.mock()
     def test_survey_list_fail(self, mock_request):


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes the call to backstage for listing surveys.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Changes the get_surveys_list function in survey_controllers.py to hit the survey service directly.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the unit tests, make sure they pass.
Tail the logs for backstage, survey service. Go to /surveys. Make sure backstage doesn't get the call, but survey service does.