### PR TITLE
remove email from url

### DIFF
--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -148,7 +148,7 @@
                 <dd>
                 Verification email sent
                 <br>
-                  <a href="{{ url_for('reporting_unit_bp.resend_verification', ru_ref=ru_ref, email=respondent.pendingEmailAddress, party_id=party_id) }}">Re-send verification email</a>
+                  <a href="{{ url_for('reporting_unit_bp.resend_verification', ru_ref=ru_ref, party_id=party_id) }}">Re-send verification email</a>
                 </br>
                 </dd>
                 {% endif %}
@@ -181,7 +181,7 @@
                                     respondent_last_name=respondent.lastName, business_id=ru.id, trading_as=ru.trading_as, change_flag='DISABLED')}}"
                    id="change-enrolment-status">Disable</a>
                 {% elif respondent.enrolmentStatus == 'PENDING' %}
-                <a href="{{ url_for('reporting_unit_bp.view_resend_verification', ru_ref=ru_ref, email=respondent.emailAddress, party_id=respondent.id) }}">Re-send verification email</a>
+                <a href="{{ url_for('reporting_unit_bp.view_resend_verification', ru_ref=ru_ref, party_id=respondent.id) }}">Re-send verification email</a>
                 {% endif %}
               </div>
             </td>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
User emails should not be passed in url as they will be exposed in service logs

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Removed unnecessarily passing user email in url

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check you can still re send verification email for pending account.

There is a known bug for resending verification email for email changes, the changes in this PR did not create and will not fix this bug. 

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
