### PR TITLE
[TBL] Get survey details direct from survey service

### DIFF
--- a/response_operations_ui/controllers/sample_controllers.py
+++ b/response_operations_ui/controllers/sample_controllers.py
@@ -11,6 +11,24 @@ from response_operations_ui.exceptions.exceptions import ApiError
 logger = wrap_logger(logging.getLogger(__name__))
 
 
+def get_sample_summary(sample_summary_id):
+    logger.debug('Retrieving sample summary', sample_summary_id=sample_summary_id)
+    url = f'{app.config["SAMPLE_URL"]}/samples/samplesummary/{sample_summary_id}'
+
+    response = requests.get(url, auth=app.config['SAMPLE_AUTH'])
+
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        logger.error('Error retrieving sample summary',
+                     sample_summary_id=sample_summary_id,
+                     status_code=response.status_code)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully retrieved sample summary', sample_summary_id=sample_summary_id)
+    return response.json()
+
+
 def upload_sample(short_name, period, file):
     logger.debug('Uploading sample', short_name=short_name, period=period, filename=file.filename)
 

--- a/response_operations_ui/controllers/sample_controllers.py
+++ b/response_operations_ui/controllers/sample_controllers.py
@@ -23,7 +23,7 @@ def get_sample_summary(sample_summary_id):
         logger.error('Error retrieving sample summary',
                      sample_summary_id=sample_summary_id,
                      status_code=response.status_code)
-        raise ApiError(url, response.status_code)
+        raise ApiError(response)
 
     logger.debug('Successfully retrieved sample summary', sample_summary_id=sample_summary_id)
     return response.json()

--- a/response_operations_ui/controllers/survey_controllers.py
+++ b/response_operations_ui/controllers/survey_controllers.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import requests
 from requests.exceptions import HTTPError, RequestException
@@ -6,6 +7,10 @@ from structlog import wrap_logger
 
 from response_operations_ui import app
 from response_operations_ui.common.surveys import FDISurveys
+from response_operations_ui.controllers.collection_exercise_controllers import (
+    get_collection_exercise_events, get_collection_exercises_by_survey,
+    get_linked_sample_summary_id)
+from response_operations_ui.controllers.sample_controllers import get_sample_summary
 from response_operations_ui.exceptions.exceptions import ApiError
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -54,16 +59,43 @@ def get_surveys_list():
     return response.json()
 
 
-def get_survey(short_name):
-    logger.debug('Retrieving survey', short_name=short_name)
-    url = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/shortname/{short_name}'
+def get_survey_by_short_name(short_name):
+    logger.debug('Retrieving survey by short name', short_name=short_name)
+    url = f'{app.config["SURVEY_URL"]}/surveys/shortname/{short_name}'
 
-    response = requests.get(url)
-    if response.status_code != 200:
+    response = requests.get(url, auth=app.config['SURVEY_AUTH'])
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        logger.error('Failed to get survey by short name', short_name=short_name)
         raise ApiError(response)
 
-    logger.debug('Successfully retrieved survey', short_name=short_name)
+    logger.debug('Successfully retrieved survey by short name', short_name=short_name)
     return response.json()
+
+
+def format_short_name(short_name):
+    return re.sub('(&)', r' \1 ', short_name)
+
+
+def get_survey(short_name):
+    survey = get_survey_by_shortname(short_name)
+    logger.debug('Getting survey details', short_name=short_name, survey_id=survey['id'])
+
+    # Format survey shortName
+    survey['shortName'] = format_short_name(survey['shortName'])
+    # Build collection exercises list
+    ce_list = get_collection_exercises_by_survey(survey['id'])
+    for ce in ce_list:
+        # add collection exercise events
+        ce['events'] = get_collection_exercise_events(ce['id'])
+        # add sample summaries
+        sample_summary_id = get_linked_sample_summary_id(ce['id'])
+        if sample_summary_id:
+            ce['sample_summary'] = get_sample_summary(sample_summary_id)
+
+    logger.debug('Successfully retrieved survey details', short_name=short_name, survey_id=survey['id'])
+    return {"survey": survey, "collection_exercises": ce_list}
 
 
 def convert_specific_fdi_survey_to_fdi(survey_short_name):
@@ -95,15 +127,8 @@ def get_survey_short_name_by_id(survey_id):
 
 def get_survey_id_by_short_name(short_name):
     logger.debug('Retrieving survey id by short name', short_name=short_name)
-    url = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/shortname/{short_name}'
 
-    response = requests.get(url)
-    if response.status_code != 200:
-        raise ApiError(response)
-
-    survey_data = response.json()
-
-    return survey_data['survey']['id']
+    return get_survey_by_shortname(short_name)['id']
 
 
 def get_survey_ref_by_id(survey_id):

--- a/response_operations_ui/controllers/survey_controllers.py
+++ b/response_operations_ui/controllers/survey_controllers.py
@@ -1,11 +1,11 @@
 import logging
-import re
 
 import requests
 from requests.exceptions import HTTPError, RequestException
 from structlog import wrap_logger
 
 from response_operations_ui import app
+from response_operations_ui.common.mappers import format_short_name
 from response_operations_ui.common.surveys import FDISurveys
 from response_operations_ui.controllers.collection_exercise_controllers import (
     get_collection_exercise_events, get_collection_exercises_by_survey,
@@ -72,10 +72,6 @@ def get_surveys_list():
     return sorted(survey_list, key=lambda k: k['surveyRef'])
 
 
-def format_short_name(short_name):
-    return re.sub('(&)', r' \1 ', short_name)
-
-
 def get_survey_by_short_name(short_name):
     logger.debug('Retrieving survey by short name', short_name=short_name)
     url = f'{app.config["SURVEY_URL"]}/surveys/shortname/{short_name}'
@@ -89,10 +85,6 @@ def get_survey_by_short_name(short_name):
 
     logger.debug('Successfully retrieved survey by short name', short_name=short_name)
     return response.json()
-
-
-def format_short_name(short_name):
-    return re.sub('(&)', r' \1 ', short_name)
 
 
 def get_survey(short_name):

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -340,7 +340,7 @@ def edit_collection_exercise_details(short_name, period):
                     short_name=short_name, period=period)
         ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
         ce_state = ce_details['collection_exercise']['state']
-        survey_details = survey_controllers.get_survey(short_name)
+        survey_id = survey_controllers.get_survey_id_by_short_name(short_name)
         locked = ce_state in ('LIVE', 'READY_FOR_LIVE', 'EXECUTION_STARTED', 'VALIDATED', 'EXECUTED')
 
         return render_template('edit-collection-exercise-details.html', survey_ref=ce_details['survey']['surveyRef'],
@@ -348,7 +348,7 @@ def edit_collection_exercise_details(short_name, period):
                                ce_state=ce_details['collection_exercise']['state'], errors=form.errors,
                                user_description=ce_details['collection_exercise']['userDescription'],
                                collection_exercise_id=ce_details['collection_exercise']['id'],
-                               survey_id=survey_details['survey']['id'])
+                               survey_id=survey_id)
 
     else:
         logger.info("Updating collection exercise details", short_name=short_name, period=period)

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -7,9 +7,11 @@ import requests_mock
 from config import TestingConfig
 from response_operations_ui import app
 
+collection_exercise_event_id = 'b4a36392-a21f-485b-9dc4-d151a8fcd565'
 collection_exercise_id = "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+sample_summary_id = 'b9487b59-2ac7-4fbf-b734-5a4c260ff235'
+short_name = "test"
 survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
-
 
 collex_root = "tests/test_data/collection_exercise/collection_exercise_details"
 no_sample = collex_root + "_no_sample.json"
@@ -41,54 +43,56 @@ with open("tests/test_data/collection_exercise/exercise_data.json") as json_data
 url_get_collection_exercise = (
     f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-exercise/test/000000'
 )
-
 url_collection_instrument = (
     f'{app.config["COLLECTION_INSTRUMENT_URL"]}'
-    f"/collection-instrument-api/1.0.2/upload/6e65acc4-4192-474b-bd3d-08071c4768e2"
+    f"/collection-instrument-api/1.0.2/upload/{collection_exercise_id}"
 )
-
 url_collection_instrument_link = (
     f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-instrument/link/111111/000000'
 )
-
 url_collection_instrument_unlink = (
     f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-instrument/'
-    f"unlink/14fb3e68-4dca-46db-bf49-04b84e07e77c/000000"
+    f"unlink/{collection_exercise_id}/000000"
 )
-
 url_survey_shortname = f'{app.config["SURVEY_URL"]}/surveys/shortname/test'
-
 url_sample_service_upload = f'{app.config["SAMPLE_URL"]}/samples/B/fileupload'
-
 url_collection_exercise_survey_id = (
     f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/survey/'
     "af6ddd8f-7bd0-4c51-b879-ff4b367461c5"
 )
-
 url_collection_exercise_link = (
-    f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/link/'
-    "6e65acc4-4192-474b-bd3d-08071c4768e2"
+    f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/link'
+    f'/{collection_exercise_id}'
 )
-
 url_upload_sample = f'{app.config["BACKSTAGE_API_URL"]}/v1/sample/test/000000'
-
 url_execute = f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-exercise/test/000000/execute'
-
 url_update_ce = (
     f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-exercise/update-collection-exercise-details/'
     f"{collection_exercise_id}"
 )
-
-url_get_survey_by_short_name = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/shortname/test'
-
+url_get_survey_by_short_name = f'{app.config["SURVEY_URL"]}/surveys/shortname/{short_name}'
 url_create_collection_exercise = f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises'
-
 url_ce_remove_sample = (
     f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/unlink/{collection_exercise_id}'
     f"/sample/1a11543f-eb19-41f5-825f-e41aca15e724"
 )
-
-url_ce_by_survey = f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/survey/' f"{survey_id}"
+url_ce_by_survey = f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/survey/{survey_id}'
+url_get_collection_exercises = (
+    f'{app.config["COLLECTION_EXERCISE_URL"]}'
+    f'/collectionexercises/survey/{survey_id}'
+)
+url_get_collection_exercise_events = (
+    f'{app.config["COLLECTION_EXERCISE_URL"]}'
+    f'/collectionexercises/{collection_exercise_id}/events'
+)
+url_get_collection_exercises_link = (
+    f'{app.config["COLLECTION_EXERCISE_URL"]}'
+    f'/collectionexercises/link/{collection_exercise_id}'
+)
+url_get_sample_summary = (
+    f'{app.config["SAMPLE_URL"]}'
+    f'/samples/samplesummary/{sample_summary_id}'
+)
 
 
 class TestCollectionExercise(unittest.TestCase):
@@ -99,14 +103,41 @@ class TestCollectionExercise(unittest.TestCase):
         app.login_manager.init_app(app)
         self.app = app.test_client()
         self.headers = {"Authorization": "test_jwt", "Content-Type": "application/json"}
+        self.survey_data = {"id": survey_id}
+        self.survey = {
+            "id": survey_id,
+            "longName": "Business Register and Employment Survey",
+            "shortName": "BRES",
+            "surveyRef": "221"
+        }
         self.collection_exercises = [
             {
-                "id": "c6467711-21eb-4e78-804c-1db8392f93fb",
-                "exerciseRef": "201601",
+                "id": collection_exercise_id,
+                "name": "201601",
                 "scheduledExecutionDateTime": "2017-05-15T00:00:00Z",
+                "state": "PUBLISHED",
+                "exerciseRef": "000000"
             }
         ]
-        self.survey_data = {"id": "af6ddd8f-7bd0-4c51-b879-ff4b367461c5"}
+        self.collection_exercises_events = [
+            {
+                "id": collection_exercise_event_id,
+                "collectionExerciseId": collection_exercise_id,
+                "tag": "mps",
+                "timestamp": "2018-03-16T00:00:00.000Z"
+            }
+        ]
+        self.collection_exercises_link = [sample_summary_id]
+        self.sample_summary = {
+            "id": sample_summary_id,
+            "effectiveStartDateTime": "",
+            "effectiveEndDateTime": "",
+            "surveyRef": "",
+            "ingestDateTime": "2018-03-14T14:29:51.325Z",
+            "state": "ACTIVE",
+            "totalSampleUnits": 5,
+            "expectedCollectionInstruments": 1
+        }
 
     @requests_mock.mock()
     def test_collection_exercise_view(self, mock_request):
@@ -131,9 +162,10 @@ class TestCollectionExercise(unittest.TestCase):
     def test_upload_collection_instrument(self, mock_request):
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_0001.xlsx"), "load-ci": ""}
         mock_request.post(url_collection_instrument, status_code=201)
-        mock_request.get(url_survey_shortname, status_code=200, json=self.survey_data)
         mock_request.get(url_collection_exercise_survey_id, status_code=200, json=exercise_data)
+        mock_request.get(url_survey_shortname, status_code=200, json=self.survey_data)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_get_collection_exercises, json=self.collection_exercises)
 
         response = self.app.post("/surveys/test/000000", data=post_data, follow_redirects=True)
 
@@ -178,7 +210,13 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.post(url_collection_instrument, status_code=201)
         mock_request.get(url_survey_shortname, status_code=200, json=self.survey_data)
         mock_request.get(url_collection_exercise_survey_id, status_code=200, json=exercise_data)
+        mock_request.get(url_get_collection_exercises, json=self.collection_exercises)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+
+        # mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        # mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        # mock_request.get(url_get_sample_summary, json=self.sample_summary)
+        # mock_request.get(url_get_survey_by_short_name, json=survey_info['survey'])
 
         response = self.app.post("/surveys/test/000000", data=post_data, follow_redirects=True)
 
@@ -192,6 +230,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_survey_shortname, status_code=200, json=self.survey_data)
         mock_request.get(url_collection_exercise_survey_id, status_code=200, json=exercise_data)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_get_collection_exercises, json=self.collection_exercises)
 
         response = self.app.post("/surveys/test/000000", data=post_data, follow_redirects=True)
 
@@ -300,6 +339,7 @@ class TestCollectionExercise(unittest.TestCase):
         collection_exercise_link = {"id": ""}
 
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_get_collection_exercises, json=self.collection_exercises)
         mock_request.get(url_survey_shortname, status_code=200, json=self.survey_data)
         mock_request.get(
             url_collection_exercise_survey_id, status_code=200, json=exercise_data
@@ -468,13 +508,19 @@ class TestCollectionExercise(unittest.TestCase):
         changed_ce_details = {
             "collection_exercise_id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
             "user_description": "16th June 2019",
-            "period": "201906",
+            "period": "201907",  # NB: slight difference in value to avoid validation error
             "hidden_survey_id": survey_id,
         }
+        # update survey
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info['survey'])
         mock_request.put(url_update_ce)
-        mock_request.get(url_ce_by_survey, json=self.collection_exercises)
-        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
+        # redirect to survey details
+        mock_request.get(url_get_collection_exercises, json=updated_survey_info['collection_exercises'])
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
+
         response = self.app.post(
             f"/surveys/test/000000/edit-collection-exercise-details",
             data=changed_ce_details,
@@ -507,7 +553,11 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_get_ce_details(self, mock_request):
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
-        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
+        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info['survey'])
+        mock_request.get(url_get_collection_exercises, json=updated_survey_info['collection_exercises'])
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
         response = self.app.get(
             f"/surveys/test/000000/edit-collection-exercise-details", follow_redirects=True
         )
@@ -556,7 +606,10 @@ class TestCollectionExercise(unittest.TestCase):
             "period": "123456",
         }
         mock_request.get(url_ce_by_survey, json=self.collection_exercises)
-        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
         mock_request.post(url_create_collection_exercise, status_code=200)
 
         response = self.app.post(
@@ -589,7 +642,11 @@ class TestCollectionExercise(unittest.TestCase):
 
     @requests_mock.mock()
     def test_get_create_ce_form(self, mock_request):
-        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
+        mock_request.get(url_ce_by_survey, json=self.collection_exercises)
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
         response = self.app.get(
             f"/surveys/141-test/create-collection-exercise", follow_redirects=True
         )
@@ -599,14 +656,20 @@ class TestCollectionExercise(unittest.TestCase):
 
     @requests_mock.mock()
     def test_failed_create_ce_validation_period_exists(self, mock_request):
+        taken_period = '12345'
         new_collection_exercise_details = {
             "hidden_survey_name": "BRES",
             "hidden_survey_id": survey_id,
             "user_description": "New collection exercise",
-            "period": "201601",
+            "period": taken_period,
         }
-        mock_request.get(url_ce_by_survey, json=self.collection_exercises)
-        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
+        ces = self.collection_exercises
+        ces[0]['exerciseRef'] = taken_period
+        mock_request.get(url_ce_by_survey, json=ces)
+        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info['survey'])
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
         mock_request.post(url_create_collection_exercise, status_code=200)
 
         response = self.app.post(
@@ -642,16 +705,27 @@ class TestCollectionExercise(unittest.TestCase):
 
     @requests_mock.mock()
     def test_failed_edit_ce_validation_period_exists(self, mock_request):
+        taken_period = '12345'
         changed_ce_details = {
             "collection_exercise_id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
             "user_description": "16th June 2019",
-            "period": "201601",
+            "period": taken_period,
             "hidden_survey_id": survey_id,
         }
+
+        # update survey
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info['survey'])
         mock_request.put(url_update_ce)
-        mock_request.get(url_ce_by_survey, json=self.collection_exercises)
-        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
+
+        # failed validation
+        ces = self.collection_exercises
+        ces[0]['exerciseRef'] = taken_period
+        mock_request.get(url_get_collection_exercises, json=ces)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
+
         response = self.app.post(
             f"/surveys/test/000000/edit-collection-exercise-details",
             data=changed_ce_details,
@@ -672,10 +746,17 @@ class TestCollectionExercise(unittest.TestCase):
             "period": "hello",
             "hidden_survey_id": survey_id,
         }
+        # update survey
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info['survey'])
         mock_request.put(url_update_ce)
-        mock_request.get(url_ce_by_survey, json=self.collection_exercises)
-        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
+
+        # failed validation
+        mock_request.get(url_get_collection_exercises, json=self.collection_exercises)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
+
         response = self.app.post(
             f"/surveys/test/000000/edit-collection-exercise-details",
             data=changed_ce_details,

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -124,7 +124,6 @@ class TestCollectionExercise(unittest.TestCase):
             {
                 "id": collection_exercise_id,
                 "name": "201601",
-                "exerciseRef": "201601",
                 "scheduledExecutionDateTime": "2017-05-15T00:00:00Z",
                 "state": "PUBLISHED",
                 "exerciseRef": "000000"

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -12,7 +12,7 @@ from response_operations_ui.controllers.message_controllers import get_conversat
 from response_operations_ui.exceptions.exceptions import InternalError
 from response_operations_ui.views.messages import _get_unread_status
 
-shortname_url = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/shortname'
+shortname_url = f'{app.config["SURVEY_URL"]}/surveys/shortname'
 url_sign_in_data = f'{app.config["UAA_SERVICE_URL"]}/oauth/token'
 url_get_surveys_list = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/surveys'
 url_get_thread = f'{app.config["SECURE_MESSAGE_URL"]}/v2/threads/fb0e79bd-e132-4f4f-a7fd-5e8c6b41b9af'
@@ -81,7 +81,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=thread_list)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE")
 
@@ -115,7 +115,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE")
 
@@ -132,7 +132,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE")
 
@@ -149,7 +149,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE")
 
@@ -166,7 +166,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE")
 
@@ -183,7 +183,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE")
 
@@ -200,7 +200,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE")
 
@@ -214,7 +214,7 @@ class TestMessage(unittest.TestCase):
         mock_get_jwt.return_value = "blah"
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, status_code=500)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE", follow_redirects=True)
 
@@ -230,7 +230,7 @@ class TestMessage(unittest.TestCase):
 
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json={"messages": []})
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE")
 
@@ -245,7 +245,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
         params = "?survey=6aa8896f-ced5-4694-800c-6cd661b0c8b2&page=1&limit=10"
         mock_request.get(url_get_threads_list + params, json=threads_unread_list)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE", follow_redirects=True)
 
@@ -257,7 +257,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
         mock_request.get(url_get_threads_list, json=threads_no_unread_list)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE")
 
@@ -272,7 +272,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
         params = "?survey=6aa8896f-ced5-4694-800c-6cd661b0c8b2&page=1&limit=10"
         mock_request.get(url_get_threads_list + params, json=threads_unread_list)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.get("/messages/ASHE")
 
@@ -340,7 +340,7 @@ class TestMessage(unittest.TestCase):
         mock_get_jwt.return_value = "blah"
         mock_request.get(url_get_threads_list, json={})
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
         response = self.app.get("/messages/ASHE")
 
         self.assertEqual(response.status_code, 200)
@@ -391,7 +391,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         with app.app_context():
             response = self.app.post("/messages/create-message", data=self.message_form, follow_redirects=True)
@@ -468,7 +468,7 @@ class TestMessage(unittest.TestCase):
         mock_request.post(url_send_message, json=threads_no_unread_list, status_code=201)
 
         # Conversation list
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
         mock_request.get(url_get_threads_list, json=thread_list)
         mock_request.get(url_get_surveys_list, json=survey_list)
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
@@ -552,7 +552,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=thread_list)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
         response = self.app.post("/messages/select-survey",
                                  follow_redirects=True,
@@ -605,7 +605,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_get_thread, json=thread_json)
         mock_request.get(url_get_surveys_list, json=survey_list)
         mock_request.patch(url_get_thread, json=thread_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=thread_list)
 
@@ -639,7 +639,7 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_get_thread, json=thread_json)
         mock_request.get(url_get_surveys_list, json=survey_list)
         mock_request.patch(url_get_thread, json=thread_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=thread_list)
 

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -466,7 +466,7 @@ class TestSurvey(unittest.TestCase):
                                            '48b6c58a-bf5b-4bb3-8d7d-5e205ff3a0fd'])
 
     def test_format_shortname(self):
-        from response_operations_ui.controllers.survey_controllers import format_short_name
+        from response_operations_ui.common.mappers import format_short_name
 
         self.assertEqual(format_short_name('QBS'), 'QBS')
         self.assertEqual(format_short_name('Sand&Gravel'), 'Sand & Gravel')

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -11,6 +11,12 @@ from response_operations_ui import app
 from response_operations_ui.controllers.survey_controllers import get_survey_short_name_by_id
 from response_operations_ui.views.surveys import _sort_collection_exercise
 
+
+collection_exercise_id = '14fb3e68-4dca-46db-bf49-04b84e07e77c'
+collection_exercise_event_id = 'b4a36392-a21f-485b-9dc4-d151a8fcd565'
+sample_summary_id = 'b9487b59-2ac7-4fbf-b734-5a4c260ff235'
+survey_id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+
 url_get_survey_list = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/surveys'
 url_get_legal_basis_list = f'{app.config["SURVEY_URL"]}/legal-bases'
 url_create_survey = f'{app.config["SURVEY_URL"]}/surveys'
@@ -19,8 +25,9 @@ with open('tests/test_data/survey/survey_list.json') as f:
     survey_list = json.load(f)
 with open('tests/test_data/survey/legal_basis_list.json') as f:
     legal_basis_list = json.load(f)
-url_get_survey_by_short_name = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/shortname/bres'
-url_get_survey_by_qbs = f'{app.config["BACKSTAGE_API_URL"]}/v1/survey/shortname/QBS'
+
+url_get_survey_by_short_name = f'{app.config["SURVEY_URL"]}/surveys/shortname/bres'
+url_get_survey_by_qbs = f'{app.config["SURVEY_URL"]}/surveys/shortname/QBS'
 with open('tests/test_data/survey/survey.json') as f:
     survey_info = json.load(f)
 with open('tests/test_data/survey/survey_states.json') as f:
@@ -30,6 +37,22 @@ with open('tests/test_data/survey/updated_survey_list.json') as f:
     updated_survey_list = json.load(f)
 with open('tests/test_data/survey/create_survey_response.json') as f:
     create_survey_response = json.load(f)
+url_get_collection_exercises = (
+    f'{app.config["COLLECTION_EXERCISE_URL"]}'
+    f'/collectionexercises/survey/{survey_info["survey"]["id"]}'
+)
+url_get_collection_exercise_events = (
+    f'{app.config["COLLECTION_EXERCISE_URL"]}'
+    f'/collectionexercises/{collection_exercise_id}/events'
+)
+url_get_collection_exercises_link = (
+    f'{app.config["COLLECTION_EXERCISE_URL"]}'
+    f'/collectionexercises/link/{collection_exercise_id}'
+)
+url_get_sample_summary = (
+    f'{app.config["SAMPLE_URL"]}'
+    f'/samples/samplesummary/{sample_summary_id}'
+)
 
 
 class TestSurvey(unittest.TestCase):
@@ -39,6 +62,39 @@ class TestSurvey(unittest.TestCase):
         app.config.from_object(app_config)
         app.login_manager.init_app(app)
         self.app = app.test_client()
+        self.survey = {
+            "id": survey_id,
+            "longName": "Business Register and Employment Survey",
+            "shortName": "BRES",
+            "surveyRef": "221"
+        }
+        self.collection_exercises = [
+            {
+                "id": collection_exercise_id,
+                "name": "201601",
+                "scheduledExecutionDateTime": "2017-05-15T00:00:00Z",
+                "state": "PUBLISHED"
+            }
+        ]
+        self.collection_exercises_events = [
+            {
+                "id": collection_exercise_event_id,
+                "collectionExerciseId": collection_exercise_id,
+                "tag": "mps",
+                "timestamp": "2018-03-16T00:00:00.000Z"
+            }
+        ]
+        self.collection_exercises_link = [sample_summary_id]
+        self.sample_summary = {
+            "id": sample_summary_id,
+            "effectiveStartDateTime": "",
+            "effectiveEndDateTime": "",
+            "surveyRef": "",
+            "ingestDateTime": "2018-03-14T14:29:51.325Z",
+            "state": "ACTIVE",
+            "totalSampleUnits": 5,
+            "expectedCollectionInstruments": 1
+        }
 
     @requests_mock.mock()
     def test_home(self, mock_request):
@@ -79,7 +135,11 @@ class TestSurvey(unittest.TestCase):
 
     @requests_mock.mock()
     def test_survey_view(self, mock_request):
-        mock_request.get(url_get_survey_by_short_name, json=survey_info)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises, json=self.collection_exercises)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
+        mock_request.get(url_get_survey_by_short_name, json=survey_info['survey'])
 
         response = self.app.get("/surveys/bres", follow_redirects=True)
 
@@ -96,7 +156,11 @@ class TestSurvey(unittest.TestCase):
 
     @requests_mock.mock()
     def test_survey_state_mapping(self, mock_request):
-        mock_request.get(url_get_survey_by_short_name, json=survey_info_states)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises, json=survey_info_states['collection_exercises'])
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
+        mock_request.get(url_get_survey_by_short_name, json=survey_info_states['survey'])
 
         response = self.app.get("/surveys/bres")
         self.assertIn(b'Created', response.data)
@@ -208,7 +272,11 @@ class TestSurvey(unittest.TestCase):
         mock_request.get(url_get_survey_list, json=survey_list)
         mock_request.put(url_update_survey_details)
         mock_request.get(url_get_survey_list, json=updated_survey_list)
-        mock_request.get(url_get_survey_by_qbs, json=survey_info)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises, json=self.collection_exercises)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
+        mock_request.get(url_get_survey_by_qbs, json=survey_info['survey'])
         response = self.app.post(f"/surveys/edit-survey-details/QBS", data=changed_survey_details,
                                  follow_redirects=True)
         self.assertIn("Error updating survey details".encode(), response.data)
@@ -217,7 +285,11 @@ class TestSurvey(unittest.TestCase):
     @requests_mock.mock()
     def test_get_survey_details(self, mock_request):
         mock_request.get(url_get_survey_list, json=survey_list)
-        mock_request.get(url_get_survey_by_short_name, json=survey_info)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises, json=self.collection_exercises)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
+        mock_request.get(url_get_survey_by_short_name, json=survey_info['survey'])
         response = self.app.get(f"surveys/edit-survey-details/bres", follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         self.assertIn("221".encode(), response.data)
@@ -359,7 +431,11 @@ class TestSurvey(unittest.TestCase):
         mock_request.get(url_get_survey_list, json=survey_list)
         mock_request.put(url_update_survey_details)
         mock_request.get(url_get_survey_list, json=updated_survey_list)
-        mock_request.get(url_get_survey_by_short_name, json=survey_info)
+        mock_request.get(url_get_survey_by_short_name, json=survey_info['survey'])
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercises, json=self.collection_exercises)
+        mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
         response = self.app.post(f"/surveys/edit-survey-details/bres", data=changed_survey_details,
                                  follow_redirects=True)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes the proxying call to backstage and ports the logic which builds a survey's details to this service.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Porting the get_survey from backstage had a knock-on effect for the various views (mostly at a test level) that rely on building and formatting everything related to a survey and its details. In other words there was more than just the survey controller that needed updating :)

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the unit and acceptance tests for  ✨🍰✨ 
Assess whether the coverage is adequate and that the changes ported from backstage are all valid.

