### PR TITLE
Output time as BST for secure message

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ Flask-Session = "==0.3.1"
 cfenv = "==0.5.3"
 cryptography = "*"
 flask-paginate = "*"
+python-dateutil = "*"
 
 [dev-packages]
 codecov = "==2.0.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "00b383dcb290f95047e46d96158f23e99eb42f66acc3f8bebc89677370b02f74"
+            "sha256": "8d64e4e89e3f6fc3325c067c85df0d2439db9dfd6bac1ce84255afd57e940240"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -243,14 +243,6 @@
             "index": "pypi",
             "version": "==1.3.5"
         },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
-                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
-            ],
-            "index": "pypi",
-            "version": "==2.7.3"
-        },
         "redis": {
             "hashes": [
                 "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
@@ -340,6 +332,13 @@
             "index": "pypi",
             "version": "==2.0.9"
         },
+        "configparser": {
+            "hashes": [
+                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.5.0"
+        },
         "coverage": {
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
@@ -380,6 +379,16 @@
                 "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
             "version": "==4.5.1"
+        },
+        "enum34": {
+            "hashes": [
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==1.1.6"
         },
         "flake8": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8d64e4e89e3f6fc3325c067c85df0d2439db9dfd6bac1ce84255afd57e940240"
+            "sha256": "00b383dcb290f95047e46d96158f23e99eb42f66acc3f8bebc89677370b02f74"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -243,6 +243,14 @@
             "index": "pypi",
             "version": "==1.3.5"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+            ],
+            "index": "pypi",
+            "version": "==2.7.3"
+        },
         "redis": {
             "hashes": [
                 "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
@@ -332,13 +340,6 @@
             "index": "pypi",
             "version": "==2.0.9"
         },
-        "configparser": {
-            "hashes": [
-                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
-            ],
-            "markers": "python_version < '3.2'",
-            "version": "==3.5.0"
-        },
         "coverage": {
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
@@ -380,16 +381,6 @@
             ],
             "version": "==4.5.1"
         },
-        "enum34": {
-            "hashes": [
-                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
-                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
-                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
-                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.1.6"
-        },
         "flake8": {
             "hashes": [
                 "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
@@ -422,10 +413,10 @@
         },
         "py": {
             "hashes": [
-                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
-                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "version": "==1.5.3"
+            "version": "==1.5.4"
         },
         "pycodestyle": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8d64e4e89e3f6fc3325c067c85df0d2439db9dfd6bac1ce84255afd57e940240"
+            "sha256": "00b383dcb290f95047e46d96158f23e99eb42f66acc3f8bebc89677370b02f74"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -243,6 +243,14 @@
             "index": "pypi",
             "version": "==1.3.5"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+            ],
+            "index": "pypi",
+            "version": "==2.7.3"
+        },
         "redis": {
             "hashes": [
                 "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
@@ -332,13 +340,6 @@
             "index": "pypi",
             "version": "==2.0.9"
         },
-        "configparser": {
-            "hashes": [
-                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
-            ],
-            "markers": "python_version < '3.2'",
-            "version": "==3.5.0"
-        },
         "coverage": {
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
@@ -379,16 +380,6 @@
                 "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
             "version": "==4.5.1"
-        },
-        "enum34": {
-            "hashes": [
-                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
-                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
-                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
-                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.1.6"
         },
         "flake8": {
             "hashes": [

--- a/response_operations_ui/common/dates.py
+++ b/response_operations_ui/common/dates.py
@@ -1,4 +1,5 @@
 from datetime import datetime, date
+from dateutil import tz
 import logging
 
 from structlog import wrap_logger
@@ -20,8 +21,17 @@ def get_formatted_date(datetime_string, string_format='%Y-%m-%d %H:%M:%S'):
 
     time_difference = datetime.date(datetime_parsed) - date.today()
 
+    time = convert_to_bst(datetime_parsed).strftime('%H:%M')
+
     if time_difference.days == 0:
-        return f"Today at {datetime_parsed.strftime('%H:%M')}"
+        return f"Today at {time}"
     elif time_difference.days == -1:
-        return f"Yesterday at {datetime_parsed.strftime('%H:%M')}"
-    return f"{datetime_parsed.strftime('%d %b %Y').title()} {datetime_parsed.strftime('%H:%M')}"
+        return f"Yesterday at {time}"
+    return f"{datetime_parsed.strftime('%d %b %Y')} {time}"
+
+
+def convert_to_bst(datetime_parsed):
+    """Takes a datetime and adjusts based on BST or GMT.
+    Returns adjusted datetime
+    """
+    return datetime_parsed.replace(tzinfo=tz.gettz('UTC')).astimezone(tz.gettz('Europe/London'))

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,31 +1,30 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, date
 import unittest
+from unittest.mock import patch
 
-from response_operations_ui.common.dates import get_formatted_date
+from response_operations_ui.common.dates import get_formatted_date, convert_to_bst
 
 
 class TestDates(unittest.TestCase):
 
-    def test_get_formatted_date_today(self):
-        today = datetime.now()
-        today_formatted_string = today.strftime('%Y-%m-%d %H:%M:%S')
-        self.assertEqual(get_formatted_date(today_formatted_string),
-                         f'Today at {today_formatted_string[11:16]}')
+    def test_get_formatted_date_today_date(self):
+        with patch('response_operations_ui.common.dates.date') as mock_date:
+            mock_date.today.return_value = date(2018, 6, 12)
+            today_example_date = get_formatted_date('2018-06-12 14:15:12')
+            self.assertEqual(today_example_date, 'Today at 15:15')
 
-    def test_get_formatted_date_yesterday(self):
-        today = datetime.now()
-        yesterday = today - timedelta(days=1)
-        yesterday_formatted_string = yesterday.strftime('%Y-%m-%d %H:%M:%S')
-        self.assertEqual(get_formatted_date(yesterday_formatted_string),
-                         f'Yesterday at {yesterday_formatted_string[11:16]}')
+    def test_get_formatted_date_yesterday_date(self):
+        with patch('response_operations_ui.common.dates.date') as mock_date:
+            mock_date.today.return_value = date(2018, 2, 12)
+            yesterday_example_date = get_formatted_date('2018-02-11 14:15:12')
+            self.assertEqual(yesterday_example_date, 'Yesterday at 14:15')
 
     def test_get_formatted_date_full_dates(self):
         self.assertEqual(get_formatted_date('2000-01-01 00:00:00'), '01 Jan 2000 00:00')
         self.assertEqual(get_formatted_date('2020-01-01 00:00:00'), '01 Jan 2020 00:00')
         self.assertEqual(get_formatted_date('3000-01-01 00:00:00'), '01 Jan 3000 00:00')
         self.assertEqual(get_formatted_date('1999-12-31 23:59:59'), '31 Dec 1999 23:59')
-        self.assertEqual(get_formatted_date('00:00:00 2000-01-01', string_format='%H:%M:%S %Y-%m-%d'),
-                         '01 Jan 2000 00:00')
+        self.assertEqual(get_formatted_date('2000-01-01 00:00:00'), '01 Jan 2000 00:00')
 
     def test_get_formatted_date_29th_feb(self):
         # Check formatting on a valid leap day
@@ -37,3 +36,17 @@ class TestDates(unittest.TestCase):
         # Strings not in the correct format or invalid dates should be returned as given and a exception logged
         self.assertEqual(get_formatted_date(''), '')
         self.assertEqual(get_formatted_date('1999-12-32 23:59:59'), '1999-12-32 23:59:59')
+
+    def test_convert_to_bst_from_utc_during_bst(self):
+        # 13th Jun 2018 at 14.12 should return 13th Jun 2018 at 15.12
+        datetime_parsed = datetime(2018, 6, 13, 14, 12, 0, tzinfo=timezone.utc)
+        returned_datetime = convert_to_bst(datetime_parsed)
+        # Check date returned is in BST format
+        self.assertEqual(datetime.strftime(returned_datetime, '%Y-%m-%d %H:%M:%S'), '2018-06-13 15:12:00')
+
+    def test_convert_to_bst_from_utc_during_gmt(self):
+        # 13th Feb 2018 at 14.12 should return 13th Feb 2018 at 14.12
+        datetime_parsed = datetime(2018, 2, 13, 14, 12, 0, tzinfo=timezone.utc)
+        returned_datetime = convert_to_bst(datetime_parsed)
+        # Check date returned is in BST format
+        self.assertEqual(datetime.strftime(returned_datetime, '%Y-%m-%d %H:%M:%S'), '2018-02-13 14:12:00')

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -164,6 +164,7 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', status_code=500)
+        mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', status_code=500)
 
         response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
 


### PR DESCRIPTION
# Motivation and Context
The Business have been informed that the time stamp for secure messaging doesn't reflect BST.

# What has changed
Time displayed for users in secure message is BST

# How to test?
Run RAS/RM, send a message to an internal user, the message should display the correct time
