### PR TITLE
[TBL] Get collection exercise details direct

### DIFF
--- a/response_operations_ui/controllers/collection_exercise_controllers.py
+++ b/response_operations_ui/controllers/collection_exercise_controllers.py
@@ -109,9 +109,7 @@ def execute_collection_exercise(short_name, period):
     )
 
 
-def update_collection_exercise_details(
-    collection_exercise_id, user_description, period
-):
+def update_collection_exercise_details(collection_exercise_id, user_description, period):
     logger.debug(
         "Updating collection exercise details",
         collection_exercise_id=collection_exercise_id,
@@ -305,9 +303,7 @@ def get_linked_sample_summary_id(collection_exercise_id):
     return sample_summary_id
 
 
-def link_sample_summary_to_collection_exercise(
-    collection_exercise_id, sample_summary_id
-):
+def link_sample_summary_to_collection_exercise(collection_exercise_id, sample_summary_id):
     logger.debug(
         "Linking sample summary to collection exercise",
         collection_exercise_id=collection_exercise_id,

--- a/response_operations_ui/controllers/collection_exercise_controllers.py
+++ b/response_operations_ui/controllers/collection_exercise_controllers.py
@@ -1,17 +1,10 @@
 import logging
 
-from flask import abort
 import requests
 from requests.exceptions import HTTPError
 from structlog import wrap_logger
 
 from response_operations_ui import app
-from response_operations_ui.common.filters import get_collection_exercise_by_period
-from response_operations_ui.common.mappers import format_short_name
-from response_operations_ui.controllers import (
-    collection_instrument_controllers as ci,
-    sample_controllers,
-    survey_controllers)
 from response_operations_ui.exceptions.exceptions import ApiError
 
 
@@ -47,50 +40,6 @@ def download_report(collection_exercise_id, survey_id):
         survey_id=survey_id,
     )
     return response
-
-
-def get_collection_exercise_details(short_name, period):
-    logger.debug(
-        "Retrieving collection exercise details", short_name=short_name, period=period
-    )
-    survey = survey_controllers.get_survey_by_shortname(short_name)
-    survey_id = survey['id']
-    exercises = get_collection_exercises_by_survey(survey_id)
-    exercise = get_collection_exercise_by_period(exercises, period)
-    if not exercise:
-        logger.error('Failed to find collection exercise by period',
-                     short_name=short_name, period=period)
-        abort(404)
-    collection_exercise_id = exercise['id']
-    survey['shortName'] = format_short_name(survey['shortName'])
-    full_exercise = get_collection_exercise_by_id(collection_exercise_id)
-    exercise_events = get_collection_exercise_events(collection_exercise_id)
-    collection_instruments = ci.get_collection_instruments_by_classifier(survey_id=survey_id,
-                                                                         collection_exercise_id=collection_exercise_id)
-
-    eq_ci_selectors = ci.get_collection_instruments_by_classifier(survey_id=survey_id,
-                                                                  ci_type='EQ')
-
-    summary_id = get_linked_sample_summary_id(collection_exercise_id)
-    sample_summary = sample_controllers.get_sample_summary(summary_id) if summary_id else None
-    ci_classifiers = survey_controllers.get_survey_ci_classifier(survey_id)
-
-    response_json = {
-        "survey": survey,
-        "collection_exercise": full_exercise,
-        "events": exercise_events,
-        "collection_instruments": collection_instruments,
-        "eq_ci_selectors": eq_ci_selectors,
-        "sample_summary": sample_summary,
-        "ci_classifiers": ci_classifiers
-    }
-
-    logger.debug(
-        "Successfully retrieved collection exercise details",
-        short_name=short_name,
-        period=period,
-    )
-    return response_json
 
 
 def get_collection_exercise_event_page_info(short_name, period):

--- a/response_operations_ui/controllers/survey_controllers.py
+++ b/response_operations_ui/controllers/survey_controllers.py
@@ -48,6 +48,43 @@ def get_survey_by_shortname(short_name):
     return response.json()
 
 
+def get_survey_ci_classifier(survey_id):
+    logger.debug('Retrieving classifier type selectors', survey_id=survey_id)
+    url = f'{app.config["SURVEY_URL"]}/surveys/{survey_id}/classifiertypeselectors'
+    response = requests.get(url, auth=app.config['SURVEY_AUTH'])
+
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        logger.error('Error classifier type selectors', survey_id=survey_id)
+        raise ApiError(response)
+
+    logger.debug('Successfully retrieved classifier type selectors', survey_id=survey_id)
+
+    classifier_type_selectors = response.json()
+    ci_selector = None
+    for selector in classifier_type_selectors:
+        if selector['name'] == "COLLECTION_INSTRUMENT":
+            ci_selector = selector
+            break
+
+    logger.debug('Retrieving classifiers for CI selector type', survey_id=survey_id, ci_selector=ci_selector['id'])
+    url = f'{app.config["SURVEY_URL"]}/surveys/{survey_id}/classifiertypeselectors/{ci_selector["id"]}'
+    response = requests.get(url, auth=app.config['SURVEY_AUTH'])
+
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        logger.error('Error retrieving classifiers for CI selector type', survey_id=survey_id,
+                     ci_selector=ci_selector['id'])
+        raise ApiError(response)
+
+    logger.debug('Successfully retrieved classifiers for CI selector type', survey_id=survey_id,
+                 ci_selector=ci_selector['id'])
+
+    return response.json()
+
+
 def get_surveys_list():
     logger.debug('Retrieving surveys list')
     url = f'{app.config["SURVEY_URL"]}/surveys'

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -1,12 +1,13 @@
 import iso8601
 import logging
 
-from flask import Blueprint, render_template, request, redirect, url_for
+from flask import Blueprint, abort, render_template, request, redirect, url_for
 from flask_login import login_required
 from flask import jsonify, make_response
 from structlog import wrap_logger
 from response_operations_ui.common.filters import get_collection_exercise_by_period
-from response_operations_ui.common.mappers import convert_events_to_new_format, map_collection_exercise_state
+from response_operations_ui.common.mappers import convert_events_to_new_format, format_short_name, \
+    map_collection_exercise_state
 from response_operations_ui.controllers import collection_instrument_controllers, sample_controllers, \
     collection_exercise_controllers, survey_controllers
 from response_operations_ui.forms import EditCollectionExerciseDetailsForm, CreateCollectionExerciseDetailsForm, \
@@ -31,13 +32,47 @@ def get_error_message(error_key):
     }.get(error_key, None)
 
 
+def build_collection_exercise_details(short_name, period):
+    survey = survey_controllers.get_survey_by_shortname(short_name)
+    survey_id = survey['id']
+    exercises = collection_exercise_controllers.get_collection_exercises_by_survey(survey_id)
+    exercise = get_collection_exercise_by_period(exercises, period)
+    if not exercise:
+        logger.error('Failed to find collection exercise by period',
+                     short_name=short_name, period=period)
+        abort(404)
+    collection_exercise_id = exercise['id']
+    survey['shortName'] = format_short_name(survey['shortName'])
+    full_exercise = collection_exercise_controllers.get_collection_exercise_by_id(collection_exercise_id)
+    exercise_events = collection_exercise_controllers.get_collection_exercise_events(collection_exercise_id)
+    collection_instruments = collection_instrument_controllers.get_collection_instruments_by_classifier(
+        collection_exercise_id=collection_exercise_id,
+        survey_id=survey_id)
+
+    eq_ci_selectors = collection_instrument_controllers.get_collection_instruments_by_classifier(
+        ci_type='EQ',
+        survey_id=survey_id)
+
+    summary_id = collection_exercise_controllers.get_linked_sample_summary_id(collection_exercise_id)
+    sample_summary = sample_controllers.get_sample_summary(summary_id) if summary_id else None
+    ci_classifiers = survey_controllers.get_survey_ci_classifier(survey_id)
+
+    return {
+        "survey": survey,
+        "collection_exercise": full_exercise,
+        "events": convert_events_to_new_format(exercise_events),
+        "collection_instruments": collection_instruments,
+        "eq_ci_selectors": eq_ci_selectors,
+        "sample_summary": _format_sample_summary(sample_summary),
+        "ci_classifiers": ci_classifiers
+    }
+
+
 @collection_exercise_bp.route('/<short_name>/<period>', methods=['GET'])
 @login_required
 def view_collection_exercise(short_name, period, error=None, success_message=None, error_message=None,
                              success_panel=None, show_msg=None):
-    ce_details = collection_exercise_controllers.get_collection_exercise_details(short_name, period)
-    ce_details['sample_summary'] = _format_sample_summary(ce_details['sample_summary'])
-    formatted_events = convert_events_to_new_format(ce_details['events'])
+    ce_details = build_collection_exercise_details(short_name, period)
     breadcrumbs = [
         {
             "title": "Surveys",
@@ -78,7 +113,7 @@ def view_collection_exercise(short_name, period, error=None, success_message=Non
                            collection_instruments=ce_details['collection_instruments'],
                            eq_ci_selectors=ce_details['eq_ci_selectors'],
                            error=error,
-                           events=formatted_events,
+                           events=ce_details['events'],
                            locked=locked,
                            missing_ci=missing_ci,
                            processing=processing,
@@ -317,7 +352,7 @@ def _get_form_type(file_name):
 @login_required
 def view_collection_exercise_details(short_name, period):
     logger.info("Retrieving collection exercise data for form", short_name=short_name, period=period)
-    ce_details = collection_exercise_controllers.get_collection_exercise_details(short_name, period)
+    ce_details = build_collection_exercise_details(short_name, period)
     form = EditCollectionExerciseDetailsForm(form=request.form)
     survey_details = survey_controllers.get_survey(short_name)
     ce_state = ce_details['collection_exercise']['state']
@@ -338,7 +373,7 @@ def edit_collection_exercise_details(short_name, period):
     if not form.validate():
         logger.info("Failed validation, retrieving collection exercise data for form",
                     short_name=short_name, period=period)
-        ce_details = collection_exercise_controllers.get_collection_exercise_details(short_name, period)
+        ce_details = build_collection_exercise_details(short_name, period)
         ce_state = ce_details['collection_exercise']['state']
         survey_id = survey_controllers.get_survey_id_by_short_name(short_name)
         locked = ce_state in ('LIVE', 'READY_FOR_LIVE', 'EXECUTION_STARTED', 'VALIDATED', 'EXECUTED')
@@ -423,8 +458,7 @@ def get_confirm_remove_sample(short_name, period):
 @collection_exercise_bp.route('/<short_name>/<period>/confirm-remove-sample', methods=['POST'])
 @login_required
 def remove_loaded_sample(short_name, period):
-    ce_details = collection_exercise_controllers.get_collection_exercise_details(short_name, period)
-    ce_details['sample_summary'] = _format_sample_summary(ce_details['sample_summary'])
+    ce_details = build_collection_exercise_details(short_name, period)
     sample_summary_id = ce_details['sample_summary']['id']
     collection_exercise_id = ce_details['collection_exercise']['id']
 

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -35,7 +35,7 @@ def get_error_message(error_key):
 @login_required
 def view_collection_exercise(short_name, period, error=None, success_message=None, error_message=None,
                              success_panel=None, show_msg=None):
-    ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
+    ce_details = collection_exercise_controllers.get_collection_exercise_details(short_name, period)
     ce_details['sample_summary'] = _format_sample_summary(ce_details['sample_summary'])
     formatted_events = convert_events_to_new_format(ce_details['events'])
     breadcrumbs = [
@@ -317,7 +317,7 @@ def _get_form_type(file_name):
 @login_required
 def view_collection_exercise_details(short_name, period):
     logger.info("Retrieving collection exercise data for form", short_name=short_name, period=period)
-    ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
+    ce_details = collection_exercise_controllers.get_collection_exercise_details(short_name, period)
     form = EditCollectionExerciseDetailsForm(form=request.form)
     survey_details = survey_controllers.get_survey(short_name)
     ce_state = ce_details['collection_exercise']['state']
@@ -338,7 +338,7 @@ def edit_collection_exercise_details(short_name, period):
     if not form.validate():
         logger.info("Failed validation, retrieving collection exercise data for form",
                     short_name=short_name, period=period)
-        ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
+        ce_details = collection_exercise_controllers.get_collection_exercise_details(short_name, period)
         ce_state = ce_details['collection_exercise']['state']
         survey_id = survey_controllers.get_survey_id_by_short_name(short_name)
         locked = ce_state in ('LIVE', 'READY_FOR_LIVE', 'EXECUTION_STARTED', 'VALIDATED', 'EXECUTED')
@@ -423,7 +423,7 @@ def get_confirm_remove_sample(short_name, period):
 @collection_exercise_bp.route('/<short_name>/<period>/confirm-remove-sample', methods=['POST'])
 @login_required
 def remove_loaded_sample(short_name, period):
-    ce_details = collection_exercise_controllers.get_collection_exercise(short_name, period)
+    ce_details = collection_exercise_controllers.get_collection_exercise_details(short_name, period)
     ce_details['sample_summary'] = _format_sample_summary(ce_details['sample_summary'])
     sample_summary_id = ce_details['sample_summary']['id']
     collection_exercise_id = ce_details['collection_exercise']['id']

--- a/tests/test_data/survey/classifier_type_selectors.json
+++ b/tests/test_data/survey/classifier_type_selectors.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "efa868fb-fb80-44c7-9f33-d6800a17c4da",
+    "name": "COLLECTION_INSTRUMENT"
+  },
+  {
+    "id": "e119ffd6-6fc1-426c-ae81-67a96f9a71ba",
+    "name": "COMMUNICATION_TEMPLATE"
+  }
+]

--- a/tests/test_data/survey/classifier_types.json
+++ b/tests/test_data/survey/classifier_types.json
@@ -1,0 +1,7 @@
+{
+  "id": "efa868fb-fb80-44c7-9f33-d6800a17c4da",
+  "name": "COLLECTION_INSTRUMENT",
+  "classifierTypes": [
+    "FORM_TYPE"
+  ]
+}

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -273,7 +273,7 @@ class TestCollectionExercise(unittest.TestCase):
     def test_collection_exercise_view_service_fail(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, status_code=500)
 
-        response = self.app.get(f'/surveys/{short_name}/{period}')
+        self.app.get(f'/surveys/{short_name}/{period}')
 
         self.mocked_handler.assert_called()
         self.assertEqual(self.mocked_handler.call_args[0][0].status_code, 500)
@@ -287,7 +287,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
         mock_request.get(f'{url_get_collection_instrument}?{ci_search_string}', status_code=400)
 
-        response = self.app.get(f'/surveys/{short_name}/{period}')
+        self.app.get(f'/surveys/{short_name}/{period}')
 
         self.mocked_handler.assert_called()
         self.assertEqual(self.mocked_handler.call_args[0][0].status_code, 400)
@@ -308,7 +308,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_get_classifier_type_selectors, json=classifier_type_selectors)
         mock_request.get(url_get_classifier_type, status_code=400)
 
-        response = self.app.get(f'/surveys/{short_name}/{period}')
+        self.app.get(f'/surveys/{short_name}/{period}')
 
         self.mocked_handler.assert_called()
         self.assertEqual(self.mocked_handler.call_args[0][0].status_code, 400)
@@ -328,7 +328,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
         mock_request.get(url_get_classifier_type_selectors, status_code=400)
 
-        response = self.app.get(f'/surveys/{short_name}/{period}')
+        self.app.get(f'/surveys/{short_name}/{period}')
 
         self.mocked_handler.assert_called()
         self.assertEqual(self.mocked_handler.call_args[0][0].status_code, 400)
@@ -565,7 +565,7 @@ class TestCollectionExercise(unittest.TestCase):
             url_collection_exercise_link, status_code=500, json=collection_exercise_link
         )
 
-        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
+        self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
 
         self.mocked_handler.assert_called()
         self.assertEqual(self.mocked_handler.call_args[0][0].status_code, 500)
@@ -590,7 +590,7 @@ class TestCollectionExercise(unittest.TestCase):
             url_collection_exercise_link, status_code=200, json=collection_exercise_link
         )
 
-        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
+        self.app.post(f'/surveys/{short_name}/{period}', data=post_data)
 
         self.mocked_handler.assert_called()
         self.assertEqual(self.mocked_handler.call_args[0][0].status_code, 500)
@@ -606,7 +606,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.post(url_sample_service_upload, status_code=500)
         mock_details.return_value = collection_exercise_details
 
-        response = self.app.post(f'/surveys/{short_name}/{period}', data=data)
+        self.app.post(f'/surveys/{short_name}/{period}', data=data)
 
         self.mocked_handler.assert_called()
         self.assertEqual(self.mocked_handler.call_args[0][0].status_code, 500)
@@ -739,15 +739,18 @@ class TestCollectionExercise(unittest.TestCase):
             "hidden_survey_id": survey_id,
         }
         mock_details.return_value = collection_exercise_details
+        mock_request.get(url_get_survey_by_short_name, json=updated_survey_info['survey'])
+        mock_request.get(url_ces_by_survey, json=[])
         mock_request.put(url_update_ce, status_code=500)
 
-        response = self.app.post(
+        self.app.post(
             f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
-            data=changed_ce_details,
-            follow_redirects=True,
+            data=changed_ce_details
         )
 
-        self.assertIn("Server error (Error 500)".encode(), response.data)
+        self.mocked_handler.assert_called()
+        self.assertEqual(self.mocked_handler.call_args[0][0].status_code, 500)
+        self.assertEqual(self.mocked_handler.call_args[0][0].url, url_update_ce)
 
     @requests_mock.mock()
     @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
@@ -837,7 +840,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
         mock_request.post(url_create_collection_exercise, status_code=500)
 
-        response = self.app.post(
+        self.app.post(
             f"/surveys/{survey_ref}-{short_name}/create-collection-exercise",
             data=new_collection_exercise_details
         )

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -259,7 +259,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error 500 - Server error".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_upload_collection_instrument(self, mock_request, mock_details):
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_0001.xlsx"), "load-ci": ""}
         mock_request.post(url_collection_instrument, status_code=201)
@@ -273,7 +273,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Collection instrument loaded".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_select_collection_instrument(self, mock_request, mock_details):
         post_data = {
             "checkbox-answer": [collection_instrument_id],
@@ -289,7 +289,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Collection instruments added".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_failed_select_collection_instrument(self, mock_request, mock_details):
         post_data = {"checkbox-answer": [collection_instrument_id], "ce_id": collection_exercise_id, "select-ci": ""}
         mock_request.post(url_collection_instrument_link, status_code=500)
@@ -301,7 +301,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error: Failed to add collection instrument(s)".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_failed_no_selected_collection_instrument(self, mock_request, mock_details):
         post_data = {"checkbox-answer": [], "ce_id": "000000", "select-ci": ""}
         mock_details.return_value = collection_exercise_details
@@ -312,7 +312,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error: No collection instruments selected".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_view_collection_instrument_after_upload(self, mock_request, mock_details):
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_0001.xlsx"), "load-ci": ""}
         mock_request.post(url_collection_instrument, status_code=201)
@@ -326,7 +326,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("collection_instrument.xlsx".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_failed_upload_collection_instrument(self, mock_request, mock_details):
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_0001.xlsx"), "load-ci": ""}
         mock_request.post(url_collection_instrument, status_code=500)
@@ -340,7 +340,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error: Failed to upload collection instrument".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_no_upload_collection_instrument_when_bad_extension(self, mock_request, mock_details):
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_0001.html"), "load-ci": ""}
         mock_details.return_value = collection_exercise_details
@@ -352,7 +352,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error: wrong file type for collection instrument".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_no_upload_collection_instrument_when_bad_form_type_format(self, mock_request, mock_details):
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_xxxxx.xlsx"), "load-ci": ""}
         mock_details.return_value = collection_exercise_details
@@ -366,7 +366,7 @@ class TestCollectionExercise(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_no_upload_collection_instrument_bad_file_name_format(self, mock_request, mock_details):
         post_data = {"ciFile": (BytesIO(b"data"), "064201803_xxxxx.xlsx"), "load-ci": ""}
         mock_details.return_value = collection_exercise_details
@@ -380,7 +380,7 @@ class TestCollectionExercise(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_no_upload_collection_instrument_form_type_not_integer(self, mock_request, mock_details):
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_123E.xlsx"), "load-ci": ""}
         mock_details.return_value = collection_exercise_details
@@ -394,7 +394,7 @@ class TestCollectionExercise(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_no_upload_collection_instrument_when_no_file(self, mock_request, mock_details):
         post_data = {"load-ci": ""}
         mock_details.return_value = collection_exercise_details
@@ -406,7 +406,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error: No collection instrument supplied".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_view_collection_instrument(self, mock_request, mock_details):
         mock_details.return_value = collection_exercise_details
 
@@ -416,7 +416,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("collection_instrument.xlsx".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_choose_collection_instrument_when_first(self, mock_request, mock_details):
         with open(
             "tests/test_data/collection_exercise/collection_exercise_details_no_ci.json"
@@ -429,7 +429,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Add a collection instrument. Must be XLSX".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_add_another_collection_instrument_when_already_uploaded(self, mock_request, mock_details):
         mock_details.return_value = collection_exercise_details
 
@@ -439,7 +439,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Add another collection instrument. Must be XLSX".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_upload_sample(self, mock_request, mock_details):
         post_data = {"sampleFile": (BytesIO(b"data"), "test.csv"), "load-sample": ""}
 
@@ -469,7 +469,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("5\n".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_upload_sample_link_failure(self, mock_request, mock_details):
         post_data = {"sampleFile": (BytesIO(b"data"), "test.csv"), "load-sample": ""}
 
@@ -495,7 +495,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error 500 - Server error".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_upload_sample_exception(self, mock_request, mock_details):
         post_data = {"sampleFile": (BytesIO(b"data"), "test.csv"), "load-sample": ""}
 
@@ -519,7 +519,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error 500 - Server error".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_failed_upload_sample(self, mock_request, mock_details):
         data = {"sampleFile": (BytesIO(b"data"), "test.csv"), "load-sample": ""}
 
@@ -532,7 +532,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Error 500 - Server error".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_no_upload_sample_when_bad_extension(self, mock_request, mock_details):
         data = {"sampleFile": (BytesIO(b"data"), "test.html"), "load-sample": ""}
         mock_details.return_value = collection_exercise_details_no_sample
@@ -548,7 +548,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertNotIn("Loaded sample summary".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_no_upload_sample_when_no_file(self, mock_request, mock_details):
         data = {"load-sample": ""}
 
@@ -566,7 +566,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertNotIn("Loaded sample summary".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_post_ready_for_live(self, mock_request, mock_details):
         post_data = {"ready-for-live": ""}
         details = collection_exercise_details.copy()
@@ -582,7 +582,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Processing collection exercise".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_post_ready_for_live_failed(self, mock_request, mock_details):
         post_data = {"ready-for-live": ""}
         mock_request.post(url_execute, status_code=500)
@@ -596,7 +596,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Failed to execute Collection Exercise".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_get_processing(self, mock_request, mock_details):
         details = collection_exercise_details.copy()
         details["collection_exercise"]["state"] = "EXECUTION_STARTED"
@@ -608,7 +608,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Processing collection exercise".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_failed_execution(self, mock_request, mock_details):
         mock_details.return_value = collection_exercise_details_failedvalidation
 
@@ -620,7 +620,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Check collection instruments".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_update_collection_exercise_details_success(self, mock_request, mock_details):
         changed_ce_details = {
             "collection_exercise_id": collection_exercise_id,
@@ -634,7 +634,7 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.put(url_update_ce)
         # redirect to survey details
         mock_request.get(url_ces_by_survey, json=updated_survey_info['collection_exercises'])
-        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
         mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
 
@@ -649,7 +649,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("201906".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_update_collection_exercise_details_fail(self, mock_request, mock_details):
         changed_ce_details = {
             "collection_exercise_id": collection_exercise_id,
@@ -669,12 +669,12 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Server error (Error 500)".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_get_ce_details(self, mock_request, mock_details):
         mock_details.return_value = collection_exercise_details
         mock_request.get(url_get_survey_by_short_name, json=updated_survey_info['survey'])
         mock_request.get(url_ces_by_survey, json=updated_survey_info['collection_exercises'])
-        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
         mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
         response = self.app.get(
@@ -685,7 +685,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn(collection_exercise_id.encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_unlink_collection_instrument(self, mock_request, mock_details):
         post_data = {
             "ci_id": collection_instrument_id,
@@ -702,7 +702,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Collection instrument removed".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_failed_unlink_collection_instrument(self, mock_request, mock_details):
         post_data = {
             "ci_id": collection_instrument_id,
@@ -728,7 +728,7 @@ class TestCollectionExercise(unittest.TestCase):
         }
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
-        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
         mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
         mock_request.post(url_create_collection_exercise, status_code=200)
@@ -751,7 +751,7 @@ class TestCollectionExercise(unittest.TestCase):
         }
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
-        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
         mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
         mock_request.post(url_create_collection_exercise, status_code=500)
@@ -768,7 +768,7 @@ class TestCollectionExercise(unittest.TestCase):
     def test_get_create_ce_form(self, mock_request):
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
-        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
         mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
         response = self.app.get(
@@ -791,7 +791,7 @@ class TestCollectionExercise(unittest.TestCase):
         ces[0]['exerciseRef'] = taken_period
         mock_request.get(url_ces_by_survey, json=ces)
         mock_request.get(url_get_survey_by_short_name, json=updated_survey_info['survey'])
-        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
         mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
         mock_request.post(url_create_collection_exercise, status_code=200)
@@ -828,7 +828,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Please enter numbers only for the period".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_failed_edit_ce_validation_period_exists(self, mock_request, mock_details):
         taken_period = '12345'
         changed_ce_details = {
@@ -847,7 +847,7 @@ class TestCollectionExercise(unittest.TestCase):
         ces = self.collection_exercises
         ces[0]['exerciseRef'] = taken_period
         mock_request.get(url_ces_by_survey, json=ces)
-        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
         mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
 
@@ -864,7 +864,7 @@ class TestCollectionExercise(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_failed_edit_ce_validation_letters_in_period_fails_validation(self, mock_request, mock_details):
         changed_ce_details = {
             "collection_exercise_id": collection_exercise_id,
@@ -879,7 +879,7 @@ class TestCollectionExercise(unittest.TestCase):
 
         # failed validation
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)
-        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
         mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
 
@@ -893,7 +893,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Please enter numbers only for the period".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_remove_loaded_sample_success(self, mock_request, mock_details):
         mock_details.return_value = collection_exercise_details
         mock_request.delete(url_ce_remove_sample, status_code=200)
@@ -905,7 +905,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Sample removed".encode(), response.data)
 
     @requests_mock.mock()
-    @patch('response_operations_ui.controllers.collection_exercise_controllers.get_collection_exercise_details')
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_remove_loaded_sample_failed(self, mock_request, mock_details):
         mock_details.return_value = collection_exercise_details
         mock_request.delete(url_ce_remove_sample, status_code=500)

--- a/tests/views/test_update_event_date.py
+++ b/tests/views/test_update_event_date.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from unittest.mock import patch
 
 import requests_mock
 
@@ -71,9 +72,10 @@ class TestUpdateEventDate(unittest.TestCase):
         self.assertIn("Error 500 - Server error".encode(), response.data)
 
     @requests_mock.mock()
-    def test_put_update_event_date(self, mock_request):
+    @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
+    def test_put_update_event_date(self, mock_request, mock_details):
         mock_request.put(url_put_update_event_date, status_code=201)
-        mock_request.get(url_get_collection_exercise, json=collection_exercise)
+        mock_details.return_value = collection_exercise
 
         response = self.app.post(f"/surveys/{survey_short_name}/{period}/event/go_live",
                                  data=self.update_event_form, follow_redirects=True)


### PR DESCRIPTION
# Motivation and Context
Removing proxying network requests to backstage by calling the services directly.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Change to get a collection exercise's details direct through the various services rather than proxying through the backstage service.

Big changes to the tests to accommodate the changes to how a ce details will be built.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the unit and acceptance tests for  ✨🍰✨ 
Assess whether the coverage is adequate and that the changes ported from backstage are all valid.
