### PR TITLE
Add survey type

### DIFF
--- a/response_operations_ui/controllers/survey_controllers.py
+++ b/response_operations_ui/controllers/survey_controllers.py
@@ -202,7 +202,8 @@ def create_survey(survey_ref, short_name, long_name, legal_basis):
         "surveyRef": survey_ref,
         "shortName": short_name,
         "longName": long_name,
-        "legalBasisRef": legal_basis
+        "legalBasisRef": legal_basis,
+        "surveyType": "Business"
     }
 
     response = requests.post(url, json=survey_details, auth=app.config['SURVEY_AUTH'])

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -11,7 +11,6 @@ from response_operations_ui import app
 from response_operations_ui.controllers.survey_controllers import get_survey_short_name_by_id
 from response_operations_ui.views.surveys import _sort_collection_exercise
 
-
 collection_exercise_id = '14fb3e68-4dca-46db-bf49-04b84e07e77c'
 collection_exercise_event_id = 'b4a36392-a21f-485b-9dc4-d151a8fcd565'
 sample_summary_id = 'b9487b59-2ac7-4fbf-b734-5a4c260ff235'
@@ -202,7 +201,6 @@ class TestSurvey(unittest.TestCase):
 
     @requests_mock.mock()
     def test_get_survey_short_name_by_id_when_get_list_fails(self, mock_request):
-
         # Delete any existing survey cache
         with suppress(AttributeError):
             del app.surveys_dict
@@ -332,7 +330,15 @@ class TestSurvey(unittest.TestCase):
             "legal_basis": "STA1947"
         }
         mock_request.get(url_get_legal_basis_list, json=legal_basis_list)
-        mock_request.post(url_create_survey, json=create_survey_response, status_code=201)
+        expected_survey_request = {
+            "surveyRef": "999",
+            "shortName": "TEST",
+            "longName": "Test Survey",
+            "legalBasisRef": "STA1947",
+            "surveyType": 'Business'
+        }
+        mock_request.post(url_create_survey, additional_matcher=lambda req: req.json() == expected_survey_request,
+                          status_code=201)
         mock_request.get(url_get_survey_list, json=updated_survey_list)
 
         response = self.app.post(f"surveys/create", data=create_survey_request, follow_redirects=True)


### PR DESCRIPTION
# Motivation and Context
Survey type has been added to the survey API when creating new surveys
to allow identification of whether the survey is Social, Business or
Census. Hardcoding the survey type to Business whilst until we've
considered how social surveys will be created.

# What has changed
* Passing survey type in the create survey API call

# How to test?
* This change should be backwards compatible so the acceptance tests should pass without the survey service changes

# Links
https://trello.com/c/ZFF7x8Za/102-dev-task-3b-int-create-action-service-to-retrieve-new-sample-attributes-13
https://github.com/ONSdigital/rm-survey-service/pull/41

# Screenshots (if appropriate):
No UI changes
