### PR TITLE
Mock the ApiError handler to prevent false positives

### DIFF
--- a/config.py
+++ b/config.py
@@ -134,3 +134,5 @@ class TestingConfig(DevelopmentConfig):
     WTF_CSRF_ENABLED = False
     SESSION_TYPE = "filesystem"
     SESSION_PERMANENT = False
+    UAA_PUBLIC_KEY = 'Test'
+    SECRET_KEY = 'sekrit!'

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -22,7 +22,7 @@ assets.register('scss_all', scss_min)
 js_min = Bundle('js/*', filters='jsmin', output='minimised/all.min.js')
 assets.register('js_all', js_min)
 
-app_config = 'config.{}'.format(os.environ.get('APP_SETTINGS', 'Config'))
+app_config = f'config.{os.environ.get("APP_SETTINGS", "Config")}'
 app.config.from_object(app_config)
 
 app.url_map.strict_slashes = False

--- a/response_operations_ui/controllers/case_controller.py
+++ b/response_operations_ui/controllers/case_controller.py
@@ -36,7 +36,7 @@ def get_available_case_group_statuses_direct(collection_exercise_id, ru_ref):
     except requests.exceptions.HTTPError:
         if response.status_code == 404:
             logger.debug('No statuses found', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
-            return []
+            return {}
         logger.exception('Error retrieving statuses', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
         raise ApiError(response)
 

--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -117,7 +117,7 @@ def search_respondent_by_email(email):
     try:
         response.raise_for_status()
     except (HTTPError, RequestException):
-        log_level = logger.warning if response.status_code in 400 else logger.exception
+        log_level = logger.warning if response.status_code is 400 else logger.exception
         log_level("Respondent retrieval failed")
         raise ApiError(response)
     logger.debug("Respondent retrieved successfully")

--- a/tests/test_uaa.py
+++ b/tests/test_uaa.py
@@ -3,6 +3,7 @@ import unittest
 import requests_mock
 from requests import HTTPError
 
+from config import TestingConfig
 from response_operations_ui import app
 from response_operations_ui.common import uaa
 
@@ -10,8 +11,8 @@ from response_operations_ui.common import uaa
 class TestUaa(unittest.TestCase):
 
     def setUp(self):
+        app.config.from_object(TestingConfig)
         self.app = app
-        app.config["UAA_PUBLIC_KEY"] = "Test"
 
     def test_get_uaa_public_key_with_config_set(self):
         with self.app.app_context():

--- a/tests/views/__init__.py
+++ b/tests/views/__init__.py
@@ -15,9 +15,9 @@ class ViewTestCase(TestCase):
         app.login_manager.init_app(app)
         self._create_apierror_handler_mock()
         self.app = app.test_client()
-        self.init_data()
+        self.setup_data()
 
-    def init_data(self):
+    def setup_data(self):
         raise NotImplementedError
 
     def tearDown(self):

--- a/tests/views/__init__.py
+++ b/tests/views/__init__.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from flask import Response
+
+from config import TestingConfig
+from response_operations_ui import app
+from response_operations_ui.exceptions.exceptions import ApiError
+
+
+class ViewTestCase(TestCase):
+
+    def setUp(self):
+        app.config.from_object(TestingConfig)
+        app.login_manager.init_app(app)
+        self._create_apierror_handler_mock()
+        self.app = app.test_client()
+        self.init_data()
+
+    def init_data(self):
+        raise NotImplementedError
+
+    def tearDown(self):
+        self._reset_apierror_handler_mock()
+
+    def _reset_apierror_handler_mock(self):
+        # NB: each of test cases use the same app object.
+        app._error_handlers[None][ApiError] = self._old_handler
+
+    def _create_apierror_handler_mock(self, mock=None):
+        """
+        This mocks the Flask error handler so we can validate that an ApiError was raised.
+        """
+        self._mocked_handler = mock or MagicMock(return_value=Response(''))
+        self._old_handler = app._error_handlers[None][ApiError]
+        app._error_handlers[None][ApiError] = self._mocked_handler
+
+    def assertApiError(self, url, status_code):
+        """
+        Helper method for asserting the cause of an ApiError.
+        """
+        self._mocked_handler.assert_called()
+        self.assertEqual(self._mocked_handler.call_args[0][0].status_code, status_code)
+        self.assertEqual(self._mocked_handler.call_args[0][0].url, url)

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -50,9 +50,20 @@ with open('tests/test_data/message/thread_unread.json') as json_data:
 
 class TestMessage(ViewTestCase):
 
+    def setup_data(self):
+        self.surveys_list_json = [
+            {
+                "id": "f235e99c-8edf-489a-9c72-6cabe6c387fc",
+                "shortName": "ASHE",
+                "longName": "ASHE long name",
+                "surveyRef": "123"
+
+            }
+        ]
+        self.before()
+
     @requests_mock.mock()
-    def init_data(self, mock_request=None):
-        app.config["UAA_PUBLIC_KEY"] = 'Test'
+    def before(self, mock_request):
         payload = {'user_id': 'test-id',
                    'aud': 'response_operations'}
 
@@ -60,16 +71,6 @@ class TestMessage(ViewTestCase):
         mock_request.post(url_sign_in_data, json={"access_token": access_token.decode()}, status_code=201)
         # sign-in to setup the user in the session
         self.app.post("/sign-in", follow_redirects=True, data={"username": "user", "password": "pass"})
-
-    surveys_list_json = [
-        {
-            "id": "f235e99c-8edf-489a-9c72-6cabe6c387fc",
-            "shortName": "ASHE",
-            "longName": "ASHE long name",
-            "surveyRef": "123"
-
-        }
-    ]
 
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -1,16 +1,16 @@
 import json
 from unittest.mock import patch
-import unittest
 
 import jwt
 import requests_mock
 
-from config import TestingConfig
 from response_operations_ui import app
 from response_operations_ui.views.messages import _get_to_id
 from response_operations_ui.controllers.message_controllers import get_conversation, send_message
 from response_operations_ui.exceptions.exceptions import InternalError
 from response_operations_ui.views.messages import _get_unread_status
+from tests.views import ViewTestCase
+
 
 shortname_url = f'{app.config["SURVEY_URL"]}/surveys/shortname'
 url_sign_in_data = f'{app.config["UAA_SERVICE_URL"]}/oauth/token'
@@ -19,6 +19,9 @@ url_get_thread = f'{app.config["SECURE_MESSAGE_URL"]}/v2/threads/fb0e79bd-e132-4
 url_get_threads_list = f'{app.config["SECURE_MESSAGE_URL"]}/threads'
 url_send_message = f'{app.config["SECURE_MESSAGE_URL"]}/v2/messages'
 url_update_label = f'{app.config["SECURE_MESSAGE_URL"]}/v2/messages/modify/ae46748b-c6e6-4859-a57a-86e01db2dcbc'
+
+survey_id = '6aa8896f-ced5-4694-800c-6cd661b0c8b2'
+params = f'?survey={survey_id}&page=1&limit=10'
 
 with open('tests/test_data/message/thread.json') as json_data:
     thread_json = json.load(json_data)
@@ -45,17 +48,11 @@ with open('tests/test_data/message/thread_unread.json') as json_data:
     thread_unread_json = json.load(json_data)
 
 
-class TestMessage(unittest.TestCase):
-
-    def setUp(self):
-        self.app = app.test_client()
-        self.app.testing = True
-        app.config.from_object(TestingConfig)
-        app.config["UAA_PUBLIC_KEY"] = 'Test'
-        self.before()
+class TestMessage(ViewTestCase):
 
     @requests_mock.mock()
-    def before(self, mock_request=None):
+    def init_data(self, mock_request=None):
+        app.config["UAA_PUBLIC_KEY"] = 'Test'
         payload = {'user_id': 'test-id',
                    'aud': 'response_operations'}
 
@@ -101,10 +98,9 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
         mock_request.get(shortname_url + "/ASHE", status_code=500)
 
-        response = self.app.get("/messages/ASHE", follow_redirects=True)
+        self.app.get("/messages/ASHE", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Something has gone wrong with the website.".encode(), response.data)
+        self.assertApiError(shortname_url + "/ASHE", 500)
 
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
@@ -216,10 +212,9 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_get_threads_list, status_code=500)
         mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
-        response = self.app.get("/messages/ASHE", follow_redirects=True)
+        self.app.get("/messages/ASHE", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(f'{url_get_threads_list}{params}', 500)
 
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
@@ -243,14 +238,12 @@ class TestMessage(unittest.TestCase):
         mock_get_jwt.return_value = "blah"
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=500)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        params = "?survey=6aa8896f-ced5-4694-800c-6cd661b0c8b2&page=1&limit=10"
         mock_request.get(url_get_threads_list + params, json=threads_unread_list)
         mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
-        response = self.app.get("/messages/ASHE", follow_redirects=True)
+        self.app.get("/messages/ASHE", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(f'{url_send_message}/count?survey={survey_id}', 500)
 
     @requests_mock.mock()
     def test_read_messages_are_displayed_correctly(self, mock_request):
@@ -270,7 +263,6 @@ class TestMessage(unittest.TestCase):
         mock_get_jwt.return_value = "blah"
         mock_request.get(url_send_message + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        params = "?survey=6aa8896f-ced5-4694-800c-6cd661b0c8b2&page=1&limit=10"
         mock_request.get(url_get_threads_list + params, json=threads_unread_list)
         mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
 
@@ -453,11 +445,10 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_get_thread, json=thread_json, status_code=500)
         mock_request.get(url_get_surveys_list, json=survey_list)
 
-        response = self.app.post("/messages/threads/fb0e79bd-e132-4f4f-a7fd-5e8c6b41b9af",
-                                 follow_redirects=True)
+        self.app.post("/messages/threads/fb0e79bd-e132-4f4f-a7fd-5e8c6b41b9af",
+                      follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_get_thread, 500)
 
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
@@ -489,10 +480,9 @@ class TestMessage(unittest.TestCase):
         mock_request.get(url_get_thread, status_code=500)
         mock_request.get(url_get_surveys_list, json=survey_list)
 
-        response = self.app.get("/messages/threads/fb0e79bd-e132-4f4f-a7fd-5e8c6b41b9af", follow_redirects=True)
+        self.app.get("/messages/threads/fb0e79bd-e132-4f4f-a7fd-5e8c6b41b9af", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_get_thread, 500)
 
     @requests_mock.mock()
     def test_conversation_decode_error(self, mock_request):
@@ -624,11 +614,10 @@ class TestMessage(unittest.TestCase):
         mock_get_jwt.return_value = "blah"
         mock_request.patch(url_get_thread, json=thread_json, status_code=500)
 
-        response = self.app.post("/messages/threads/fb0e79bd-e132-4f4f-a7fd-5e8c6b41b9af/close-conversation",
-                                 follow_redirects=True)
+        self.app.post("/messages/threads/fb0e79bd-e132-4f4f-a7fd-5e8c6b41b9af/close-conversation",
+                      follow_redirects=True)
 
-        self.assertEqual(500, response.status_code)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_get_thread, 500)
 
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -1,10 +1,9 @@
 import json
-import unittest
 
 import requests_mock
 
-from config import TestingConfig
 from response_operations_ui import app
+from tests.views import ViewTestCase
 
 respondent_party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
 business_party_id = 'b3ba864b-7cbc-4f44-84fe-88dc018a1a4c'
@@ -62,13 +61,9 @@ with open('tests/test_data/iac/iac.json') as fp:
     iac = json.load(fp)
 
 
-class TestReportingUnits(unittest.TestCase):
+class TestReportingUnits(ViewTestCase):
 
-    def setUp(self):
-        app_config = TestingConfig()
-        app.config.from_object(app_config)
-        app.login_manager.init_app(app)
-        self.app = app.test_client()
+    def init_data(self):
         self.case_group_status = {
             "ru_ref": "19000001",
             "ru_name": "RU Name",
@@ -111,30 +106,29 @@ class TestReportingUnits(unittest.TestCase):
     def test_get_reporting_unit_party_ru_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, status_code=500)
 
-        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+        self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_get_party_by_ru_ref, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_cases_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, status_code=500)
 
-        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+        self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(f'{url_get_cases_by_business_party_id}?iac=True', 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_cases_404(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, status_code=404)
+        mock_request.get(url_get_casegroups_by_business_party_id, json=[])
+        mock_request.get(url_get_respondent_party_by_party_id, json=[])
 
-        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.app.get("/reporting-units/50012345678")
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertEqual(response.status_code, 200)
 
     @requests_mock.mock()
     def test_get_reporting_unit_casegroups_fail(self, mock_request):
@@ -142,33 +136,32 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(url_get_casegroups_by_business_party_id, status_code=500)
 
-        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+        self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_get_casegroups_by_business_party_id, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_casegroups_404(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
-        mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
+        mock_request.get(url_get_cases_by_business_party_id, json=[])
         mock_request.get(url_get_casegroups_by_business_party_id, status_code=404)
+        mock_request.get(url_get_respondent_party_by_party_id, json=[])
 
         response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertEqual(response.status_code, 200)
 
     @requests_mock.mock()
     def test_get_reporting_unit_collection_exercise_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
-        mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', status_code=500)
+        mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=[])
+        mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', status_code=500)
 
-        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+        self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_party_id_fail(self, mock_request):
@@ -179,10 +172,10 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, status_code=500)
 
-        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+        self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        params = f'?collection_exercise_id={collection_exercise_id_1}&verbose=True'
+        self.assertApiError(f'{url_get_business_party_by_party_id}{params}', 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_casegroup_status_fail(self, mock_request):
@@ -194,10 +187,9 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, status_code=500)
 
-        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+        self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_get_available_case_group_statuses_direct, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_casegroup_status_404(self, mock_request):
@@ -208,11 +200,14 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, status_code=404)
+        mock_request.get(url_get_survey_by_id, json=survey)
+        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
+        mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
         response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertEqual(response.status_code, 200)
 
     @requests_mock.mock()
     def test_get_reporting_unit_survey_fail(self, mock_request):
@@ -225,10 +220,9 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, status_code=500)
 
-        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+        self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_get_survey_by_id, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_respondent_party_fail(self, mock_request):
@@ -242,10 +236,9 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_survey_by_id, json=survey)
         mock_request.get(url_get_respondent_party_by_party_id, status_code=500)
 
-        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+        self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_get_respondent_party_by_party_id, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_iac_fail(self, mock_request):
@@ -260,10 +253,9 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
         mock_request.get(f'{url_get_iac}/{iac_1}', status_code=500)
 
-        response = self.app.get("/reporting-units/50012345678", follow_redirects=True)
+        self.app.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(f'{url_get_iac}/{iac_1}', 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_iac_404(self, mock_request):
@@ -356,10 +348,9 @@ class TestReportingUnits(unittest.TestCase):
     def test_search_reporting_units_fail(self, mock_request):
         mock_request.get(url_search_reporting_units, status_code=500)
 
-        response = self.app.post("/reporting-units", follow_redirects=True)
+        self.app.post("/reporting-units", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_search_reporting_units, 500)
 
     @requests_mock.mock()
     def test_resend_verification_email(self, mock_request):
@@ -391,9 +382,8 @@ class TestReportingUnits(unittest.TestCase):
     @requests_mock.mock()
     def test_fail_resent_verification_email(self, mock_request):
         mock_request.get(url_resend_verification_email, status_code=500)
-        response = self.app.post(
-            f"reporting-units/resend_verification/50012345678/{respondent_party_id}", follow_redirects=True)
-        self.assertEqual(response.status_code, 500)
+        self.app.post(f"reporting-units/resend_verification/50012345678/{respondent_party_id}", follow_redirects=True)
+        self.assertApiError(url_resend_verification_email, 500)
 
     @requests_mock.mock()
     def test_get_contact_details(self, mock_request):
@@ -410,11 +400,9 @@ class TestReportingUnits(unittest.TestCase):
     def test_get_contact_details_fail(self, mock_request):
         mock_request.get(get_respondent_by_id_url, status_code=500)
 
-        response = self.app.get(f"/reporting-units/50012345678/edit-contact-details/{respondent_party_id}",
-                                follow_redirects=True)
+        self.app.get(f"/reporting-units/50012345678/edit-contact-details/{respondent_party_id}", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(get_respondent_by_id_url, 500)
 
     @requests_mock.mock()
     def test_edit_contact_details(self, mock_request):
@@ -567,11 +555,9 @@ class TestReportingUnits(unittest.TestCase):
     def test_reporting_unit_generate_new_code_fail(self, mock_request):
         mock_request.post(url_generate_new_code, status_code=500)
 
-        response = self.app.get(f"/reporting-units/{ru_ref}/{collection_exercise_id_1}/new_enrolment_code",
-                                follow_redirects=True)
+        self.app.get(f"/reporting-units/{ru_ref}/{collection_exercise_id_1}/new_enrolment_code", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_generate_new_code, 500)
 
     def test_disable_enrolment_view(self):
         response = self.app.get("/reporting-units/ru_ref/change-enrolment-status"
@@ -612,9 +598,8 @@ class TestReportingUnits(unittest.TestCase):
     def test_disable_enrolment_post_fail(self, mock_request):
         mock_request.put(url_change_enrolment_status, status_code=500)
 
-        response = self.app.post("/reporting-units/50012345678/change-enrolment-status"
-                                 "?survey_id=test_id&respondent_id=test_id&business_id=test_id&change_flag=DISABLED",
-                                 follow_redirects=True)
+        self.app.post("/reporting-units/50012345678/change-enrolment-status"
+                      "?survey_id=test_id&respondent_id=test_id&business_id=test_id&change_flag=DISABLED",
+                      follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_change_enrolment_status, 500)

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -63,7 +63,7 @@ with open('tests/test_data/iac/iac.json') as fp:
 
 class TestReportingUnits(ViewTestCase):
 
-    def init_data(self):
+    def setup_data(self):
         self.case_group_status = {
             "ru_ref": "19000001",
             "ru_name": "RU Name",

--- a/tests/views/test_respondents.py
+++ b/tests/views/test_respondents.py
@@ -25,7 +25,7 @@ with open('tests/test_data/survey/survey_by_id.json') as json_data:
 
 class TestRespondents(ViewTestCase):
 
-    def init_data(self):
+    def setup_data(self):
         pass
 
     def test_search_respondent_get(self):

--- a/tests/views/test_respondents.py
+++ b/tests/views/test_respondents.py
@@ -1,11 +1,11 @@
 import json
-import unittest
 
 import requests_mock
 
-from config import TestingConfig
 from response_operations_ui import app
 from response_operations_ui.controllers.party_controller import search_respondent_by_email
+from tests.views import ViewTestCase
+
 
 business_party_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
 party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
@@ -23,13 +23,10 @@ with open('tests/test_data/survey/survey_by_id.json') as json_data:
     survey_by_id = json.load(json_data)
 
 
-class TestRespondents(unittest.TestCase):
+class TestRespondents(ViewTestCase):
 
-    def setUp(self):
-        app_config = TestingConfig()
-        app.config.from_object(app_config)
-        app.login_manager.init_app(app)
-        self.app = app.test_client()
+    def init_data(self):
+        pass
 
     def test_search_respondent_get(self):
         response = self.app.get("/respondents")
@@ -60,10 +57,9 @@ class TestRespondents(unittest.TestCase):
         email = 'Jacky.Turner@email.com'
         mock_request.get(get_respondent_by_email_url, status_code=500)
 
-        response = self.app.post("/respondents/", data={"email": email}, follow_redirects=True)
+        self.app.post("/respondents/", data={"email": email})
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(get_respondent_by_email_url, 500)
 
     @requests_mock.mock()
     def test_search_respondent_by_email_success(self, mock_request):
@@ -94,10 +90,9 @@ class TestRespondents(unittest.TestCase):
         mock_request.get(get_respondent_by_id_url, json=respondent, status_code=200)
         mock_request.get(get_survey_by_id_url, json=survey_by_id, status_code=500)
 
-        response = self.app.post("/respondents", data={"query": email}, follow_redirects=True)
+        self.app.post("/respondents", data={"query": email}, follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(get_survey_by_id_url, 500)
 
     @requests_mock.mock()
     def test_search_respondent_by_email_unable_to_get_respondent_details(self, mock_request):
@@ -107,10 +102,9 @@ class TestRespondents(unittest.TestCase):
         mock_request.get(get_respondent_by_id_url, json=respondent, status_code=500)
         mock_request.get(get_survey_by_id_url, json=survey_by_id, status_code=200)
 
-        response = self.app.post("/respondents", data={"query": email}, follow_redirects=True)
+        self.app.post("/respondents", data={"query": email}, follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(get_respondent_by_id_url, 500)
 
     @requests_mock.mock()
     def test_search_respondent_by_email_unable_to_get_business_details(self, mock_request):
@@ -120,7 +114,6 @@ class TestRespondents(unittest.TestCase):
         mock_request.get(get_respondent_by_id_url, json=respondent, status_code=200)
         mock_request.get(get_survey_by_id_url, json=survey_by_id, status_code=200)
 
-        response = self.app.post("/respondents", data={"query": email}, follow_redirects=True)
+        self.app.post("/respondents", data={"query": email}, follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(f'{get_business_by_id_url}?verbose=True', 500)

--- a/tests/views/test_sign_in.py
+++ b/tests/views/test_sign_in.py
@@ -11,10 +11,6 @@ url_surveys = f'{app.config["SURVEY_URL"]}/surveys'
 
 class TestSignIn(unittest.TestCase):
     def setUp(self):
-        app.config['SECRET_KEY'] = 'sekrit!'
-        app.config['WTF_CSRF_ENABLED'] = False
-        app.config["UAA_PUBLIC_KEY"] = "Test"
-
         payload = {'user_id': 'test-id',
                    'aud': 'response_operations'}
 

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -1,15 +1,15 @@
 from contextlib import suppress
 import json
-import unittest
 from unittest.mock import MagicMock
 
 from requests import RequestException
 import requests_mock
 
-from config import TestingConfig
 from response_operations_ui import app
 from response_operations_ui.controllers.survey_controllers import get_survey_short_name_by_id
 from response_operations_ui.views.surveys import _sort_collection_exercise
+from tests.views import ViewTestCase
+
 
 collection_exercise_id = '14fb3e68-4dca-46db-bf49-04b84e07e77c'
 collection_exercise_event_id = 'b4a36392-a21f-485b-9dc4-d151a8fcd565'
@@ -54,13 +54,9 @@ url_get_sample_summary = (
 )
 
 
-class TestSurvey(unittest.TestCase):
+class TestSurvey(ViewTestCase):
 
-    def setUp(self):
-        app_config = TestingConfig()
-        app.config.from_object(app_config)
-        app.login_manager.init_app(app)
-        self.app = app.test_client()
+    def init_data(self):
         self.survey = {
             "id": survey_id,
             "longName": "Business Register and Employment Survey",
@@ -126,10 +122,9 @@ class TestSurvey(unittest.TestCase):
     def test_survey_list_fail(self, mock_request):
         mock_request.get(url_get_survey_list, status_code=500)
 
-        response = self.app.get("/surveys", follow_redirects=True)
+        self.app.get("/surveys")
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_get_survey_list, 500)
 
     @requests_mock.mock()
     def test_survey_list_connection_error(self, mock_request):
@@ -138,7 +133,6 @@ class TestSurvey(unittest.TestCase):
         response = self.app.get("/surveys", follow_redirects=True)
 
         self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
 
     @requests_mock.mock()
     def test_survey_view(self, mock_request):
@@ -156,10 +150,9 @@ class TestSurvey(unittest.TestCase):
     def test_survey_view_fail(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, status_code=500)
 
-        response = self.app.get("/surveys/bres", follow_redirects=True)
+        self.app.get("/surveys/bres")
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_get_survey_by_short_name, 500)
 
     @requests_mock.mock()
     def test_survey_state_mapping(self, mock_request):
@@ -263,10 +256,8 @@ class TestSurvey(unittest.TestCase):
         mock_request.get(url_get_survey_list, json=survey_list)
         mock_request.put(url_update_survey_details, status_code=500)
         mock_request.get(url_get_survey_list, json=updated_survey_list)
-        response = self.app.post(f"/surveys/edit-survey-details/QBS", data=changed_survey_details,
-                                 follow_redirects=True)
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Server error (Error 500)".encode(), response.data)
+        self.app.post(f"/surveys/edit-survey-details/QBS", data=changed_survey_details)
+        self.assertApiError(url_update_survey_details, 500)
 
     @requests_mock.mock()
     def test_update_survey_details_failed_validation(self, mock_request):
@@ -430,10 +421,9 @@ class TestSurvey(unittest.TestCase):
         mock_request.get(url_get_legal_basis_list, json=legal_basis_list)
         mock_request.post(url_create_survey, text="Internal server error", status_code=500)
 
-        response = self.app.post(f"surveys/create", data=create_survey_request, follow_redirects=True)
+        self.app.post(f"surveys/create", data=create_survey_request)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Error 500 - Server error".encode(), response.data)
+        self.assertApiError(url_create_survey, 500)
 
     @requests_mock.mock()
     def test_update_survey_details_failed_validation_short_name_has_spaces(self, mock_request):

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -56,7 +56,7 @@ url_get_sample_summary = (
 
 class TestSurvey(ViewTestCase):
 
-    def init_data(self):
+    def setup_data(self):
         self.survey = {
             "id": survey_id,
             "longName": "Business Register and Employment Survey",


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This mocks the Flask error handler so we can validate that an ApiError was raised rather than asserting false positives from other 500s.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Creates a new ViewTestCase class that the other test cases are then derived from which mocks the error handler for ApiError at setUp time.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the unit tests and check that we're testing everything accurately ✨🍰 ✨ 

