### PR TITLE
[TBL] Update a collection exercise direct

### DIFF
--- a/response_operations_ui/controllers/collection_exercise_controllers.py
+++ b/response_operations_ui/controllers/collection_exercise_controllers.py
@@ -127,31 +127,45 @@ def execute_collection_exercise(short_name, period):
     )
 
 
-def update_collection_exercise_details(
-    collection_exercise_id, user_description, period
-):
-    logger.debug(
-        "Updating collection exercise details",
-        collection_exercise_id=collection_exercise_id,
-    )
-    url = (
-        f'{app.config["BACKSTAGE_API_URL"]}/v1/collection-exercise/'
-        f"update-collection-exercise-details/{collection_exercise_id}"
-    )
+def update_collection_exercise_user_description(collection_exercise_id, user_description):
+    logger.debug('Updating collection exercise user description',
+                 collection_exercise_id=collection_exercise_id)
 
-    collection_exercise_details = {
-        "user_description": user_description,
-        "period": period,
-    }
+    header = {'Content-Type': "text/plain"}
+    url = f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/{collection_exercise_id}/userDescription'
+    response = requests.put(url, headers=header, data=user_description, auth=app.config['COLLECTION_EXERCISE_AUTH'])
 
-    response = requests.put(url, json=collection_exercise_details)
-    if response.status_code != 200:
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        if response.status_code == 404:
+            logger.error('Error retrieving collection exercise', collection_exercise_id=collection_exercise_id)
+        else:
+            logger.error('Failed to update collection exercise user description',
+                         collection_exercise_id=collection_exercise_id)
         raise ApiError(response)
 
-    logger.debug(
-        "Successfully updated collection exercise details",
-        collection_exercise_id=collection_exercise_id,
-    )
+    logger.debug('Successfully updated collection exercise user description',
+                 collection_exercise_id=collection_exercise_id)
+
+
+def update_collection_exercise_period(collection_exercise_id, period):
+    logger.debug('Updating collection exercise period', collection_exercise_id=collection_exercise_id, period=period)
+
+    header = {'Content-Type': "text/plain"}
+    url = f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/{collection_exercise_id}/exerciseRef'
+    response = requests.put(url, headers=header, data=period, auth=app.config['COLLECTION_EXERCISE_AUTH'])
+
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        if response.status_code == 404:
+            logger.error('Error retrieving collection exercise', collection_exercise_id=collection_exercise_id)
+        else:
+            logger.error('Failed to update collection exercise period', collection_exercise_id=collection_exercise_id)
+        raise ApiError(response)
+
+    logger.debug('Successfully updated collection exercise period', collection_exercise_id=collection_exercise_id)
 
 
 def get_collection_exercise_by_id(collection_exercise_id):

--- a/response_operations_ui/forms.py
+++ b/response_operations_ui/forms.py
@@ -75,11 +75,14 @@ class EditCollectionExerciseDetailsForm(FlaskForm):
     @staticmethod
     def validate_period(form, field):
         hidden_survey_id = form.hidden_survey_id.data
+        hidden_ce_id = form.collection_exercise_id.data
         ce_details = collection_exercise_controllers.get_collection_exercises_by_survey(hidden_survey_id)
         inputted_period = field.data
         if inputted_period is None:
             raise ValidationError('Please enter numbers only for the period')
         for ce in ce_details:
+            if ce['id'] == str(hidden_ce_id):
+                continue
             if ce['exerciseRef'] == str(inputted_period):
                 raise ValidationError('Please enter a period not in use')
 

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -353,9 +353,12 @@ def edit_collection_exercise_details(short_name, period):
     else:
         logger.info("Updating collection exercise details", short_name=short_name, period=period)
         form = request.form
-        collection_exercise_controllers.update_collection_exercise_details(form.get('collection_exercise_id'),
-                                                                           form.get('user_description'),
-                                                                           form.get('period'))
+        collection_exercise_controllers.update_collection_exercise_user_description(form.get('collection_exercise_id'),
+                                                                                    form.get('user_description'))
+
+        if form.get('period') != period:
+            collection_exercise_controllers.update_collection_exercise_period(form.get('collection_exercise_id'),
+                                                                              form.get('period'))
 
         return redirect(url_for('surveys_bp.view_survey', short_name=short_name, ce_updated='True'))
 

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -90,6 +90,7 @@ url_update_ce_user_details = (
 url_update_ce_period = (
     f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises'
     f'/{collection_exercise_id}/exerciseRef'
+)
 url_get_classifier_type_selectors = (
     f'{app.config["SURVEY_URL"]}/surveys/{survey_id}/classifiertypeselectors'
 )
@@ -702,6 +703,7 @@ class TestCollectionExercise(ViewTestCase):
             "period": "201906",
             "hidden_survey_id": survey_id,
         }
+        mock_request.get(url_ces_by_survey, json=updated_survey_info['collection_exercises'])
         mock_request.put(url_update_ce_user_details)
 
         response = self.app.post(
@@ -721,6 +723,7 @@ class TestCollectionExercise(ViewTestCase):
             "period": "201906",
             "hidden_survey_id": survey_id,
         }
+        mock_request.get(url_ces_by_survey, json=updated_survey_info['collection_exercises'])
         mock_request.put(url_update_ce_user_details, status_code=500)
 
         self.app.post(
@@ -738,8 +741,8 @@ class TestCollectionExercise(ViewTestCase):
             "period": "201906",
             "hidden_survey_id": survey_id,
         }
+        mock_request.get(url_ces_by_survey, json=updated_survey_info['collection_exercises'])
         mock_request.put(url_update_ce_user_details, status_code=404)
-
 
         self.app.post(
             f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
@@ -756,6 +759,7 @@ class TestCollectionExercise(ViewTestCase):
             "period": "201907",
             "hidden_survey_id": survey_id,
         }
+        mock_request.get(url_ces_by_survey, json=updated_survey_info['collection_exercises'])
         mock_request.put(url_update_ce_user_details, status_code=200)
         mock_request.put(url_update_ce_period, status_code=500)
 
@@ -775,6 +779,7 @@ class TestCollectionExercise(ViewTestCase):
             "period": "201907",
             "hidden_survey_id": survey_id,
         }
+        mock_request.get(url_ces_by_survey, json=updated_survey_info['collection_exercises'])
         mock_request.put(url_update_ce_user_details, status_code=200)
         mock_request.put(url_update_ce_period, status_code=404)
 
@@ -965,7 +970,7 @@ class TestCollectionExercise(ViewTestCase):
         ces[1]['id'] = survey_id  # new id
         ces[1]['exerciseRef'] = taken_period
         mock_request.get(url_ces_by_survey, json=ces)
-        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercises_events)
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
         mock_request.get(url_get_collection_exercises_link, json=self.collection_exercises_link)
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
 

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -163,7 +163,7 @@ class TestCollectionExercise(ViewTestCase):
     def test_collection_exercise_view_fail(self, mock_request):
         mock_request.get(url_get_collection_exercise, status_code=500)
 
-        response = self.app.get(f'/surveys/{short_name}/{period}', follow_redirects=True)
+        self.app.get(f'/surveys/{short_name}/{period}', follow_redirects=True)
 
         self.assertApiError(url_get_collection_exercise, 500)
 
@@ -377,7 +377,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.post(url_sample_service_upload, status_code=200, json=sample_data)
         mock_request.put(url_collection_exercise_link, status_code=500, json=collection_exercise_link)
 
-        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data, follow_redirects=True)
+        self.app.post(f'/surveys/{short_name}/{period}', data=post_data, follow_redirects=True)
 
         self.assertApiError(url_collection_exercise_link, 500)
 
@@ -393,7 +393,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.post(url_sample_service_upload, status_code=500, json=sample_data)
         mock_request.put(url_collection_exercise_link, status_code=200, json=collection_exercise_link)
 
-        response = self.app.post(f'/surveys/{short_name}/{period}', data=post_data, follow_redirects=True)
+        self.app.post(f'/surveys/{short_name}/{period}', data=post_data, follow_redirects=True)
 
         self.assertApiError(url_sample_service_upload, 500)
 
@@ -563,7 +563,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.get(url_get_collection_exercises, json=updated_survey_info['collection_exercises'])
         mock_request.put(url_update_ce_user_details, status_code=500)
 
-        response = self.app.post(
+        self.app.post(
             f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
             data=changed_ce_details
         )
@@ -582,7 +582,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.get(url_get_collection_exercises, json=updated_survey_info['collection_exercises'])
         mock_request.put(url_update_ce_user_details, status_code=404)
 
-        response = self.app.post(
+        self.app.post(
             f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
             data=changed_ce_details,
             follow_redirects=True,
@@ -603,7 +603,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.put(url_update_ce_user_details, status_code=200)
         mock_request.put(url_update_ce_period, status_code=500)
 
-        response = self.app.post(
+        self.app.post(
             f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
             data=changed_ce_details,
             follow_redirects=True,
@@ -624,7 +624,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.put(url_update_ce_user_details, status_code=200)
         mock_request.put(url_update_ce_period, status_code=404)
 
-        response = self.app.post(
+        self.app.post(
             f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
             data=changed_ce_details,
             follow_redirects=True,
@@ -714,7 +714,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.get(url_get_survey_by_short_name, json=updated_survey_info)
         mock_request.post(url_create_collection_exercise, status_code=500)
 
-        response = self.app.post(
+        self.app.post(
             f"/surveys/{survey_ref}-{short_name}/create-collection-exercise",
             data=new_collection_exercise_details,
             follow_redirects=True,

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -592,6 +592,65 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertIn("Server error (Error 500)".encode(), response.data)
 
     @requests_mock.mock()
+    def test_update_collection_exercise_details_404(self, mock_request):
+        changed_ce_details = {
+            "collection_exercise_id": collection_exercise_id,
+            "user_description": "16th June 2019",
+            "period": "201906",
+            "hidden_survey_id": survey_id,
+        }
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.put(url_update_ce_user_details, status_code=404)
+
+        response = self.app.post(
+            f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
+            data=changed_ce_details,
+            follow_redirects=True,
+        )
+
+        self.assertIn("Server error (Error 500)".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_update_collection_exercise_period_fail(self, mock_request):
+        changed_ce_details = {
+            "collection_exercise_id": collection_exercise_id,
+            "user_description": "16th June 2019",
+            "period": "201907",
+            "hidden_survey_id": survey_id,
+        }
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.put(url_update_ce_user_details, status_code=200)
+        mock_request.put(url_update_ce_period, status_code=500)
+
+        response = self.app.post(
+            f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
+            data=changed_ce_details,
+            follow_redirects=True,
+        )
+
+        self.assertIn("Server error (Error 500)".encode(), response.data)
+
+    @requests_mock.mock()
+    def test_update_collection_exercise_period_404(self, mock_request):
+        changed_ce_details = {
+            "collection_exercise_id": collection_exercise_id,
+            "user_description": "16th June 2019",
+            "period": "201907",
+            "hidden_survey_id": survey_id,
+        }
+        mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
+        mock_request.put(url_update_ce_user_details, status_code=200)
+        mock_request.put(url_update_ce_period, status_code=404)
+
+        response = self.app.post(
+            f"/surveys/{short_name}/{period}/edit-collection-exercise-details",
+            data=changed_ce_details,
+            follow_redirects=True,
+        )
+
+        self.assertIn("Server error (Error 500)".encode(), response.data)
+
+    @requests_mock.mock()
     def test_get_ce_details(self, mock_request):
         mock_request.get(url_get_collection_exercise, json=collection_exercise_details)
         mock_request.get(url_get_survey_by_short_name, json=updated_survey_info['survey'])


### PR DESCRIPTION
# Motivation and Context
Removing proxying network requests to backstage by calling the services directly.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Change to update a collection exercise's details direct through the collection exercise service rather than proxying through the backstage service.

This also updates the form logic to fix an issue where validation would fail unless the user entered a new period.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the unit and acceptance tests for  ✨🍰✨ 
Assess whether the coverage is adequate and that the changes ported from backstage are all valid.
