### PR TITLE
Fix for guarding against an unexpected empty response from survey

### DIFF
--- a/response_operations_ui/controllers/survey_controllers.py
+++ b/response_operations_ui/controllers/survey_controllers.py
@@ -53,6 +53,9 @@ def get_survey_ci_classifier(survey_id):
     url = f'{app.config["SURVEY_URL"]}/surveys/{survey_id}/classifiertypeselectors'
     response = requests.get(url, auth=app.config['SURVEY_AUTH'])
 
+    if response.status_code is 204:
+        logger.error('classifiers missing for survey', survey_id=survey_id)
+        raise ApiError(response)
     try:
         response.raise_for_status()
     except HTTPError:

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -293,6 +293,25 @@ class TestCollectionExercise(ViewTestCase):
         self.assertApiError(url_get_classifier_type, 400)
 
     @requests_mock.mock()
+    def test_collection_exercise_view_classifiers_204(self, mock_request):
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_ces_by_survey, json=self.collection_exercises)
+        mock_request.get(url_ce_by_id, json=collection_exercise_details['collection_exercise'])
+        mock_request.get(url_get_collection_exercise_events, json=self.collection_exercise_events)
+        mock_request.get(f'{url_get_collection_instrument}?{ci_search_string}', json=self.collection_instruments,
+                         complete_qs=True)
+        mock_request.get(f'{url_get_collection_instrument}?{ci_type_search_string}', json=self.eq_ci_selectors,
+                         complete_qs=True)
+        mock_request.get(url_link_sample, json=[sample_summary_id])
+        mock_request.get(url_get_sample_summary, json=self.sample_summary)
+        mock_request.get(url_get_classifier_type_selectors, status_code=204)
+        mock_request.get(url_get_classifier_type, json=classifier_types)
+
+        self.app.get(f'/surveys/{short_name}/{period}')
+
+        self.assertApiError(url_get_classifier_type_selectors, 204)
+
+    @requests_mock.mock()
     def test_collection_exercise_view_selectors_fail(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)


### PR DESCRIPTION
# Motivation and Context
If the survey service returns a 204 (empty response) when fetching classifiers (viewing a CE) the JSON decoder raises an unexpected exception for trying to decode an empty string.  This adds more context and logging why it should fail hard (and early) when missing classifiers.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Update to the survey controller as well as a new test for 204.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the unit tests.  ✨🍰✨ 
 
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
