### PR TITLE
Remove bi/generate enrolment code using event

### DIFF
--- a/response_operations_ui/controllers/case_controller.py
+++ b/response_operations_ui/controllers/case_controller.py
@@ -11,7 +11,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 def get_case_by_id(case_id):
     logger.debug('Retrieving case', case_id=case_id)
-    url = f'{app.config["CASE_URL"]}/cases/{case_id}'
+    url = f'{app.config["CASE_URL"]}/cases/{case_id}?iac=true'
     response = requests.get(url, auth=app.config['CASE_AUTH'])
 
     try:

--- a/response_operations_ui/controllers/case_controller.py
+++ b/response_operations_ui/controllers/case_controller.py
@@ -9,6 +9,21 @@ from response_operations_ui.exceptions.exceptions import ApiError
 logger = wrap_logger(logging.getLogger(__name__))
 
 
+def get_case_by_id(case_id):
+    logger.debug('Retrieving case', case_id=case_id)
+    url = f'{app.config["CASE_URL"]}/cases/{case_id}'
+    response = requests.get(url, auth=app.config['CASE_AUTH'])
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.exception('Error retrieving case', case_id=case_id)
+        raise ApiError(response)
+
+    logger.debug('Successfully retrieved case', case_id=case_id)
+    return response.json()
+
+
 def update_case_group_status(collection_exercise_id, ru_ref, case_group_event):
     logger.debug('Updating status', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref,
                  case_group_event=case_group_event)

--- a/response_operations_ui/controllers/iac_controller.py
+++ b/response_operations_ui/controllers/iac_controller.py
@@ -32,17 +32,6 @@ def get_iac_details(iac):
     return response.json()
 
 
-def get_latest_case(cases, collection_exercises):
-    ces_ids = [ce['id'] for ce in collection_exercises]
-    cases_for_survey = [case
-                        for case in cases
-                        if case.get('caseGroup', {}).get('collectionExerciseId') in ces_ids]
-    cases_for_survey_ordered = sorted(cases_for_survey, key=lambda c: c['createdDateTime'], reverse=True)
-    case = next((case for case in cases_for_survey_ordered), None)
-    case['activeIAC'] = _is_iac_active(case['iac'])
-    return case
-
-
-def _is_iac_active(iac):
+def is_iac_active(iac):
     iac_response = get_iac_details(iac)
     return iac_response.get('active') if iac_response else None

--- a/response_operations_ui/controllers/iac_controller.py
+++ b/response_operations_ui/controllers/iac_controller.py
@@ -32,16 +32,15 @@ def get_iac_details(iac):
     return response.json()
 
 
-def get_latest_active_iac_code(cases, collection_exercises):
+def get_latest_case(cases, collection_exercises):
     ces_ids = [ce['id'] for ce in collection_exercises]
     cases_for_survey = [case
                         for case in cases
                         if case.get('caseGroup', {}).get('collectionExerciseId') in ces_ids]
     cases_for_survey_ordered = sorted(cases_for_survey, key=lambda c: c['createdDateTime'], reverse=True)
-    iac = next((case.get('iac')
-                for case in cases_for_survey_ordered
-                if _is_iac_active(case.get('iac'))), None)
-    return iac
+    case = next((case for case in cases_for_survey_ordered), None)
+    case['activeIAC'] = _is_iac_active(case['iac'])
+    return case
 
 
 def _is_iac_active(iac):

--- a/response_operations_ui/controllers/reporting_units_controllers.py
+++ b/response_operations_ui/controllers/reporting_units_controllers.py
@@ -48,20 +48,25 @@ def change_enrolment_status(business_id, respondent_id, survey_id, change_flag):
                  business_id=business_id, respondent_id=respondent_id, survey_id=survey_id, change_flag=change_flag)
 
 
-def generate_new_enrolment_code(collection_exercise_id, ru_ref):
-    logger.debug('Generating new enrolment code', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
-    url = f'{app.config["CASE_URL"]}/cases/iac/{collection_exercise_id}/{ru_ref}'
-    response = requests.post(url, auth=app.config['CASE_AUTH'])
+def generate_new_enrolment_code(case_id):
+    logger.debug('Generating new enrolment code', case_id=case_id)
+    url = f'{app.config["CASE_URL"]}/cases/{case_id}/events'
+    case_event = {
+        "description": "Generating new enrolment code",
+        "category": "GENERATE_ENROLMENT_CODE",
+        "subCategory": None,
+        "createdBy": "ROPS"
+    }
+
+    response = requests.post(url, json=case_event, auth=app.config['CASE_AUTH'])
 
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
-        logger.error('Failed to generate new enrolment code',
-                     collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+        logger.error('Failed to generate new enrolment code', case_id=case_id)
         raise ApiError(response)
 
-    logger.debug('Successfully generated new enrolment code',
-                 collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+    logger.debug('Successfully generated new enrolment code', case_id=case_id)
     return response.json()
 
 

--- a/response_operations_ui/controllers/reporting_units_controllers.py
+++ b/response_operations_ui/controllers/reporting_units_controllers.py
@@ -67,7 +67,6 @@ def generate_new_enrolment_code(case_id):
         raise ApiError(response)
 
     logger.debug('Successfully generated new enrolment code', case_id=case_id)
-    return response.json()
 
 
 def resend_verification_email(party_id):

--- a/response_operations_ui/templates/new-enrolment-code.html
+++ b/response_operations_ui/templates/new-enrolment-code.html
@@ -38,7 +38,7 @@
 
       <div class="u-mt-l u-mb-m">
         <div class="mars">New enrolment code:</div>
-        <div id="IAC" class="saturn u-mt-s u-mb-s">{{case.iac}}</div>
+        <div id="IAC" class="saturn u-mt-s u-mb-s">{{iac}}</div>
         <div id="copyEnrolmentCode" class="mars">
           You might want to make a note of this code before continuing
         </div>

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -89,19 +89,20 @@
         <h4 class="neptune">Respondents</h4>
 
         <div class="ru-survey-enrolment-code u-pb-s" name="enrolment-code">
-          {% if survey.activeIacCode %}
+          {% if survey.case.activeIAC %}
           <div id="unused-enrolment-code">
             Unused enrolment code:
-            <code class="mars u-ml-s" id="unused-enrolment-code-{{survey.shortName}}">{{ survey.activeIacCode }}</code>
+            <code class="mars u-ml-s" id="unused-enrolment-code-{{survey.shortName}}">{{ survey.case.iac }}</code>
           </div>
-          {% endif %}
-          <a href="{{ url_for('reporting_unit_bp.generate_new_enrolment_code',
+          {% else %}
+          <a href="{{ url_for('reporting_unit_bp.generate_new_enrolment_code', case_id=survey.case.id,
                               collection_exercise_id=survey.collection_exercises[-1]['id'], ru_name=ru.name,
                               ru_ref=ru.sampleUnitRef, trading_as=ru.trading_as, survey_ref=survey.surveyRef,
                               survey_name=survey.shortName) }}"
              id="generate-new-code">
             Generate new enrolment code
           </a>
+          {% endif %}
         </div>
 
         <table name="tbl-respondents-for-survey" class="table table__dense tbl-ru-survey-respondents" summary="Respondents for {{survey.shortName}} for {{ ru.sampleUnitRef }}">

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -54,7 +54,7 @@ def view_reporting_unit(ru_ref):
     surveys_with_iacs = [
         {
             **survey,
-            "activeIacCode": iac_controller.get_latest_active_iac_code(cases, survey['collection_exercises'])
+            "case": iac_controller.get_latest_case(cases, survey['collection_exercises'])
         }
         for survey in sorted_linked_surveys
     ]
@@ -181,11 +181,15 @@ def resend_verification(ru_ref, party_id):
                             info='Verification email re-sent'))
 
 
-@reporting_unit_bp.route('/<ru_ref>/<collection_exercise_id>/new_enrolment_code', methods=['GET'])
+@reporting_unit_bp.route('/<ru_ref>/new_enrolment_code', methods=['GET'])
 @login_required
-def generate_new_enrolment_code(ru_ref, collection_exercise_id):
-    case = reporting_units_controllers.generate_new_enrolment_code(collection_exercise_id, ru_ref)
-    return render_template('new-enrolment-code.html', case=case, ru_ref=ru_ref,
+def generate_new_enrolment_code(ru_ref):
+    case_id = request.args.get('case_id')
+    reporting_units_controllers.generate_new_enrolment_code(case_id)
+    case = case_controller.get_case_by_id(case_id)
+    return render_template('new-enrolment-code.html',
+                           iac=case['iac'],
+                           ru_ref=ru_ref,
                            ru_name=request.args.get('ru_name'),
                            trading_as=request.args.get('trading_as'),
                            survey_name=request.args.get('survey_name'),

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -51,10 +51,10 @@ def view_reporting_unit(ru_ref):
     sorted_linked_surveys = sorted(linked_surveys, key=lambda survey: survey['surveyRef'])
 
     # Add latest active iac code to surveys
-    surveys_with_iacs = [
+    surveys_with_latest_case = [
         {
             **survey,
-            "case": iac_controller.get_latest_case(cases, survey['collection_exercises'])
+            "case": get_latest_case_with_ce(cases, survey['collection_exercises'])
         }
         for survey in sorted_linked_surveys
     ]
@@ -87,7 +87,7 @@ def view_reporting_unit(ru_ref):
         }
     ]
     return render_template('reporting-unit.html', ru_ref=ru_ref, ru=reporting_unit,
-                           surveys=surveys_with_iacs, breadcrumbs=breadcrumbs,
+                           surveys=surveys_with_latest_case, breadcrumbs=breadcrumbs,
                            info_message=info_message, enrolment_changed=request.args.get('enrolment_changed'))
 
 
@@ -121,6 +121,19 @@ def survey_with_respondents_and_exercises(survey, respondents, collection_exerci
         'respondents': survey_respondents,
         'collection_exercises': sorted_survey_exercises
     }
+
+
+def get_latest_case_with_ce(cases, collection_exercises):
+    # Takes in a list of cases and a list of collection exercises and
+    # returns the latest case which is in one of the collection exercises
+    ces_ids = [ce['id'] for ce in collection_exercises]
+    cases_for_survey = [case
+                        for case in cases
+                        if case.get('caseGroup', {}).get('collectionExerciseId') in ces_ids]
+    cases_for_survey_ordered = sorted(cases_for_survey, key=lambda c: c['createdDateTime'], reverse=True)
+    case = next((case for case in cases_for_survey_ordered), None)
+    case['activeIAC'] = iac_controller.is_iac_active(case['iac'])
+    return case
 
 
 @reporting_unit_bp.route('/<ru_ref>/edit-contact-details/<respondent_id>', methods=['GET'])

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -555,13 +555,24 @@ class TestReportingUnits(ViewTestCase):
         self.assertIn("test_survey_name".encode(), response.data)
 
     @requests_mock.mock()
-    def test_reporting_unit_generate_new_code_fail(self, mock_request):
+    def test_reporting_unit_generate_new_code_event_fail(self, mock_request):
         mock_request.post(url_post_case_event, status_code=500)
 
         self.app.get(f"/reporting-units/{ru_ref}/new_enrolment_code?case_id={case['id']}",
                      follow_redirects=True)
 
         self.assertApiError(url_post_case_event, 500)
+
+    @requests_mock.mock()
+    def test_reporting_unit_generate_new_code_case_fail(self, mock_request):
+        mock_request.post(url_post_case_event)
+        mock_request.get(url_get_case, status_code=500)
+
+        self.app.get(f"/reporting-units/{ru_ref}/new_enrolment_code?case_id={case['id']}&"
+                     "survey_name=test_survey_name&trading_as=trading_name&ru_name=test_ru_name",
+                     follow_redirects=True)
+
+        self.assertApiError(url_get_case, 500)
 
     def test_disable_enrolment_view(self):
         response = self.app.get("/reporting-units/ru_ref/change-enrolment-status"

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -13,12 +13,13 @@ collection_exercise_id_2 = '9af403f8-5fc5-43b1-9fca-afbd9c65da5c'
 iac_1 = 'jkbvyklkwj88'
 iac_2 = 'ljbgg3kgstr4'
 survey_id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+case_id = '10b04906-f478-47f9-a985-783400dd8482'
 CONNECTION_ERROR = 'Connection error'
 
 url_search_reporting_units = f'{app.config["PARTY_URL"]}/party-api/v1/businesses/search'
 get_respondent_by_id_url = f'{app.config["PARTY_URL"]}/party-api/v1/respondents/id/{respondent_party_id}'
 url_edit_contact_details = f'{app.config["PARTY_URL"]}/party-api/v1/respondents/id/{respondent_party_id}'
-url_generate_new_code = f'{app.config["CASE_URL"]}/cases/iac/{collection_exercise_id_1}/{ru_ref}'
+url_post_case_event = f'{app.config["CASE_URL"]}/cases/{case_id}/events'
 url_change_enrolment_status = f'{app.config["PARTY_URL"]}/party-api/v1/respondents/change_enrolment_status'
 url_resend_verification_email = f'{app.config["PARTY_URL"]}/party-api/v1/resend-verification-email' \
                                 f'/{respondent_party_id}'
@@ -33,6 +34,7 @@ url_get_available_case_group_statuses_direct = f'{app.config["CASE_URL"]}/casegr
 url_get_survey_by_id = f'{app.config["SURVEY_URL"]}/surveys/{survey_id}'
 url_get_respondent_party_by_party_id = f'{app.config["PARTY_URL"]}/party-api/v1/respondents/id/{respondent_party_id}'
 url_get_iac = f'{app.config["IAC_URL"]}/iacs'
+url_get_case = f'{app.config["CASE_URL"]}/cases/{case_id}?iac=true'
 
 with open('tests/test_data/reporting_units/respondent.json') as fp:
     respondent = json.load(fp)
@@ -539,10 +541,11 @@ class TestReportingUnits(ViewTestCase):
 
     @requests_mock.mock()
     def test_reporting_unit_generate_new_code(self, mock_request):
-        mock_request.post(url_generate_new_code, json=case)
+        mock_request.post(url_post_case_event)
+        mock_request.get(url_get_case, json=case)
 
-        response = self.app.get(f"/reporting-units/{ru_ref}/{collection_exercise_id_1}/new_enrolment_code"
-                                "?survey_name=test_survey_name&trading_as=trading_name&ru_name=test_ru_name",
+        response = self.app.get(f"/reporting-units/{ru_ref}/new_enrolment_code?case_id={case['id']}&"
+                                "survey_name=test_survey_name&trading_as=trading_name&ru_name=test_ru_name",
                                 follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
@@ -553,11 +556,12 @@ class TestReportingUnits(ViewTestCase):
 
     @requests_mock.mock()
     def test_reporting_unit_generate_new_code_fail(self, mock_request):
-        mock_request.post(url_generate_new_code, status_code=500)
+        mock_request.post(url_post_case_event, status_code=500)
 
-        self.app.get(f"/reporting-units/{ru_ref}/{collection_exercise_id_1}/new_enrolment_code", follow_redirects=True)
+        self.app.get(f"/reporting-units/{ru_ref}/new_enrolment_code?case_id={case['id']}",
+                     follow_redirects=True)
 
-        self.assertApiError(url_generate_new_code, 500)
+        self.assertApiError(url_post_case_event, 500)
 
     def test_disable_enrolment_view(self):
         response = self.app.get("/reporting-units/ru_ref/change-enrolment-status"


### PR DESCRIPTION
# Motivation and Context
New enrolment codes will now be generated using a case event rather than a the old POST endpoint. The UI has been updated to use this endpoint

# What has changed
Code now uses case event for generating new enrolment code
Can no longer generate a new enrolment code if there is an existing active one for that business/survey

# How to test?
`pipenv run python run_tests.py` should run tests and all pass
Run acceptance tests with associated PR's below
With associated PR's try and generate a new code through the UI and confirm that a new code is created and usable

# Links
[Trello](https://trello.com/c/npXH3s9x/16-retain-current-enrolment-code-functionality-enrolment-codes)
## PR's
[case-service](https://github.com/ONSdigital/rm-case-service/pull/51)
[casesvc-api](https://github.com/ONSdigital/rm-casesvc-api/pull/21)
[rasrm-acceptance-tests](https://github.com/ONSdigital/rasrm-acceptance-tests/pull/147)
