### PR TITLE
bumping version to 0.6.1

### DIFF
--- a/response_operations_ui/views/info.py
+++ b/response_operations_ui/views/info.py
@@ -24,7 +24,7 @@ def get_info():
 
     info = {
         "name": 'response-operations-ui',
-        "version": '0.6.0',
+        "version": '0.6.1',
     }
     info = {**_health_check, **info}
 


### PR DESCRIPTION
# Motivation and Context
bumping version to 0.6.1 for release

# What has changed
version number in info endpoint

# How to test?
curl the info endpoint and the version should be 0.6.1

