### PR TITLE
Display closed at time in bst

### DIFF
--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -9,7 +9,7 @@ from flask_paginate import get_parameter, Pagination
 from structlog import wrap_logger
 
 from response_operations_ui import app
-from response_operations_ui.common.dates import get_formatted_date
+from response_operations_ui.common.dates import get_formatted_date, convert_to_bst
 from response_operations_ui.common.mappers import format_short_name
 from response_operations_ui.common.surveys import Surveys, FDISurveys
 from response_operations_ui.controllers import message_controllers, survey_controllers
@@ -71,7 +71,7 @@ def view_conversation(thread_id):
     refined_thread = [_refine(message) for message in reversed(thread_conversation['messages'])]
 
     try:
-        closed_time = datetime.strptime(thread_conversation['closed_at'], "%Y-%m-%dT%H:%M:%S.%f")
+        closed_time = convert_to_bst(datetime.strptime(thread_conversation['closed_at'], "%Y-%m-%dT%H:%M:%S.%f"))
         closed_at = closed_time.strftime("%d/%m/%Y" + " at %H:%M")
     except KeyError:
         closed_at = None


### PR DESCRIPTION
# Motivation and Context
close at time in closed conversations displaying incorrect time (time in utc), this just converts it to bst before when its rendered

# How to test?
close a conversation should be correct time

