### PR TITLE
Stop redirecting to error pages in ROps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ coverage.xml
 *,cover
 .hypothesis/
 flask_session/
-pytest_cache
+.pytest_cache
 
 # Translations
 *.mo

--- a/response_operations_ui/views/sign_in.py
+++ b/response_operations_ui/views/sign_in.py
@@ -20,7 +20,6 @@ sign_in_bp = Blueprint('sign_in_bp', __name__, static_folder='static', template_
 @sign_in_bp.route('/', methods=['GET', 'POST'])
 def sign_in():
     form = LoginForm(request.form)
-
     if current_user.is_authenticated:
         return redirect(url_for('home_bp.home'))
 


### PR DESCRIPTION
### What is the context of this PR?
Redirecting to an error page caused us issues previously when it came to tracking/diagnosing problems.
This should now allow us to receive an URL to know exactly where an issue has occurred rather then just the error page.

Card: https://trello.com/c/odV0qjxk/272-stop-redirecting-to-error-pages-in-rops-s

### How to Review
Ensure it now renders the correct error pages and unnecessary redirects are removed.
Just `raise exception` somewhere in the code to test it displays the error pages.
Check that all functionality works as per norm and tests pass.