### PR TITLE
Added test to cover CloudFoundry set up

### DIFF
--- a/config.py
+++ b/config.py
@@ -134,3 +134,8 @@ class TestingConfig(DevelopmentConfig):
     SESSION_PERMANENT = False
     UAA_PUBLIC_KEY = 'Test'
     SECRET_KEY = 'sekrit!'
+
+
+class CFTestingConfig(DevelopmentConfig):
+    REDIS_SERVICE = "test"
+

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -12,6 +12,8 @@ from response_operations_ui.logger_config import logger_initial_config
 from response_operations_ui.user import User
 from response_operations_ui.views import setup_blueprints
 
+cf = ONSCloudFoundry()
+
 
 def create_app(config_name=None):
     app = Flask(__name__)
@@ -43,14 +45,11 @@ def create_app(config_name=None):
         return User(user_id)
 
     if app.config['SESSION_TYPE'] == 'redis':
-        cf = ONSCloudFoundry()
-        # If deploying in cloudfoundry set config to use cf redis instance
         if cf:
-            redis_service_name = app.config['REDIS_SERVICE']
+            # If deploying in cloudfoundry set config to use cf redis instance
             logger.info('Cloudfoundry detected, setting service configurations')
-            redis_service = cf.redis(redis_service_name)
-            app.config['REDIS_HOST'] = redis_service.credentials['host']
-            app.config['REDIS_PORT'] = redis_service.credentials['port']
+            app.config['REDIS_HOST'] = cf.redis_service['host']
+            app.config['REDIS_PORT'] = cf.redis_service['port']
 
         # wrap in the flask server side session manager and back it by redis
         app.config['SESSION_REDIS'] = redis.StrictRedis(host=app.config['REDIS_HOST'],

--- a/tests/views/test_create_app.py
+++ b/tests/views/test_create_app.py
@@ -16,11 +16,11 @@ class TestCreateApp(unittest.TestCase):
         mock_cf.redis.return_value = 'REDIS_SERVICE'
 
         mock_cf.redis_service = {
-            'host': 'test',
-            'port': 'test'
+            'host': 'test_host',
+            'port': 'test_port'
         }
 
         test_app = create_app('CFTestingConfig')
 
-        self.assertEqual(test_app.config['REDIS_HOST'], 'test')
-        self.assertEqual(test_app.config['REDIS_PORT'], 'test')
+        self.assertEqual(test_app.config['REDIS_HOST'], 'test_host')
+        self.assertEqual(test_app.config['REDIS_PORT'], 'test_port')

--- a/tests/views/test_create_app.py
+++ b/tests/views/test_create_app.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import patch
+from response_operations_ui import create_app
+
+
+class TestCreateApp(unittest.TestCase):
+
+    # Check that we can initialise app and access it's config
+    def test_create_app(self):
+        test_app = create_app('TestingConfig')
+
+        self.assertEqual(test_app.config['REDIS_HOST'], 'localhost')
+
+    @patch('response_operations_ui.cf')
+    def test_create_app_with_cf(self, mock_cf):
+        mock_cf.redis.return_value = 'REDIS_SERVICE'
+
+        mock_cf.redis_service = {
+            'host': 'test',
+            'port': 'test'
+        }
+
+        test_app = create_app('CFTestingConfig')
+
+        self.assertEqual(test_app.config['REDIS_HOST'], 'test')
+        self.assertEqual(test_app.config['REDIS_PORT'], 'test')


### PR DESCRIPTION
### What is the context of this PR?
We were missing a test for when we deploy to a cloud foundry env and using its redis instance rather then the default one. 

Card: https://trello.com/c/kkO8qp4j/308-improve-rops-test-coverage-s 

### How to review
Just check all tests pass and the previous untested code has been covered.