### PR TITLE
Improve ROps test coverage

### DIFF
--- a/config.py
+++ b/config.py
@@ -134,3 +134,4 @@ class TestingConfig(DevelopmentConfig):
     SESSION_PERMANENT = False
     UAA_PUBLIC_KEY = 'Test'
     SECRET_KEY = 'sekrit!'
+

--- a/response_operations_ui/cloud/cloudfoundry.py
+++ b/response_operations_ui/cloud/cloudfoundry.py
@@ -1,13 +1,15 @@
 import cfenv
+from flask import current_app
 
 
 class ONSCloudFoundry(object):
-
     def __init__(self):
         self._cf_env = cfenv.AppEnv()
 
-    def __bool__(self):
-        return True if self._cf_env.app else False
+    @property
+    def detected(self):
+        return self._cf_env.app
 
-    def redis(self, service_name):
-        return self._cf_env.get_service(name=service_name)
+    @property
+    def redis(self):
+        return self._cf_env.get_service(name=current_app.config['REDIS_SERVICE'])

--- a/tests/views/test_create_app.py
+++ b/tests/views/test_create_app.py
@@ -1,0 +1,30 @@
+import os
+
+import unittest
+from unittest.mock import patch
+from response_operations_ui import create_app
+from flask import app
+
+
+class TestCreateApp(unittest.TestCase):
+
+    def setUp(self):
+        app.testing = True
+        os.environ['APP_SETTINGS'] = 'TestingConfig'
+
+    # Check that we can initialise app and access it's config
+    def test_create_app(self):
+        test_app = create_app('TestingConfig')
+        self.assertEqual(test_app.config['REDIS_HOST'], 'localhost')
+
+    @patch('response_operations_ui.cf')
+    def test_create_app_with_cf(self, mock_cf):
+        mock_cf.detected.return_value = False
+        mock_cf.redis.credentials = {
+            'host': 'test_host',
+            'port': 'test_port'
+        }
+
+        test_app = create_app()
+        self.assertEqual(test_app.config['REDIS_HOST'], 'test_host')
+        self.assertEqual(test_app.config['REDIS_PORT'], 'test_port')


### PR DESCRIPTION
### What is the context of this PR?
This is a resurrected PR where the initial one passed locally/travis etc. but failed when it came to concourse somehow

We were missing a test for when we deploy to a cloud foundry env and using its Redis instance rather then the default one.

Card: https://trello.com/c/kkO8qp4j/308-improve-rops-test-coverage-s

### How to review
Just check all tests pass and the previous untested code has been covered.

If you have access to the `dev` space in Cloud Foundry you can push this branch up and check that the app builds successfully on there.