### PR TITLE
Update flask version to 1.0.2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ python_version = "3.6"
 
 [packages]
 
-flask = "==0.12"
+flask = "*"
 flask-login = "==0.4.1"
 flask-wtf = "==0.14.2"
 structlog = "==17.2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,20 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ff3d92ffd9b9d8f98b0c3f8329b76a56a376052cff47aee32212d51a2a67bb23"
+            "sha256": "cc6dcf277e0075d476320706d01b248aa47f0b8671cca85a0f68a9aff0dbfae3"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.6.3",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "16.7.0",
+            "platform_system": "Darwin",
+            "platform_version": "Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64",
+            "python_full_version": "3.6.3",
+            "python_version": "3.6",
+            "sys_platform": "darwin"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,60 +38,59 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
-                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
+                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a",
+                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638"
             ],
-            "version": "==2018.8.13"
+            "version": "==2018.8.24"
         },
         "cfenv": {
             "hashes": [
                 "sha256:7815bffcc4a3db350f92517157fafc577c11b5a7ff172dc5632f1042b93073e8",
                 "sha256:c7a91a4c82431acfc35db664c194d5e6cc7f4df3dcb692d0f836a6ceb0156167"
             ],
-            "index": "pypi",
             "version": "==0.5.3"
         },
         "cffi": {
             "hashes": [
-                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
-                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
                 "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
-                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
-                "sha256:3bb6bd7266598f318063e584378b8e27c67de998a43362e8fce664c54ee52d30",
-                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
-                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
-                "sha256:495c5c2d43bf6cebe0178eb3e88f9c4aa48d8934aa6e3cddb865c058da76756b",
-                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
-                "sha256:57b2533356cb2d8fac1555815929f7f5f14d68ac77b085d2326b571310f34f6e",
-                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
-                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
-                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
-                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
                 "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
-                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
-                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
-                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
-                "sha256:a6a5cb8809091ec9ac03edde9304b3ad82ad4466333432b16d78ef40e0cce0d5",
-                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
-                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
-                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
-                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
-                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
-                "sha256:ca1bd81f40adc59011f58159e4aa6445fc585a32bb8ac9badf7a2c1aa23822f2",
-                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
-                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
-                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
-                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
-                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
+                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
+                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
                 "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
-                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
+                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
+                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
+                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
+                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
+                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
+                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
+                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
+                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
+                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb",
+                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
+                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
+                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
+                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
+                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
+                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
+                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
+                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
+                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
+                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
+                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
+                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
+                "sha256:ca1bd81f40adc59011f58159e4aa6445fc585a32bb8ac9badf7a2c1aa23822f2",
+                "sha256:3bb6bd7266598f318063e584378b8e27c67de998a43362e8fce664c54ee52d30",
+                "sha256:a6a5cb8809091ec9ac03edde9304b3ad82ad4466333432b16d78ef40e0cce0d5",
+                "sha256:57b2533356cb2d8fac1555815929f7f5f14d68ac77b085d2326b571310f34f6e",
+                "sha256:495c5c2d43bf6cebe0178eb3e88f9c4aa48d8934aa6e3cddb865c058da76756b",
+                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4"
             ],
             "version": "==1.11.5"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
             ],
             "version": "==3.0.4"
         },
@@ -91,87 +103,78 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:21af753934f2f6d1a10fe8f4c0a64315af209ef6adeaee63ca349797d747d687",
-                "sha256:27bb401a20a838d6d0ea380f08c6ead3ccd8c9d8a0232dc9adcc0e4994576a66",
-                "sha256:29720c4253263cff9aea64585adbbe85013ba647f6e98367efff9db2d7193ded",
-                "sha256:2a35b7570d8f247889784010aac8b384fd2e4a47b33e15c4a60b45a7c1944120",
-                "sha256:42c531a6a354407f42ee07fda5c2c0dc822cf6d52744949c182f2b295fbd4183",
-                "sha256:5eb86f03f9c4f0ac2336ac5431271072ddf7ecc76b338e26366732cfac58aa19",
-                "sha256:67f7f57eae8dede577f3f7775957f5bec93edd6bdb6ce597bb5b28e1bdf3d4fb",
-                "sha256:6ec84edcbc966ae460560a51a90046503ff0b5b66157a9efc61515c68059f6c8",
-                "sha256:7ba834564daef87557e7fcd35c3c3183a4147b0b3a57314e53317360b9b201b3",
-                "sha256:7d7f084cbe1fdb82be5a0545062b59b1ad3637bc5a48612ac2eb428ff31b31ea",
-                "sha256:82409f5150e529d699e5c33fa8fd85e965104db03bc564f5f4b6a9199e591f7c",
                 "sha256:87d092a7c2a44e5f7414ab02fb4145723ebba411425e1a99773531dd4c0e9b8d",
-                "sha256:8c56ef989342e42b9fcaba7c74b446f0cc9bed546dd00034fa7ad66fc00307ef",
-                "sha256:9449f5d4d7c516a6118fa9210c4a00f34384cb1d2028672100ee0c6cce49d7f6",
-                "sha256:bc2301170986ad82d9349a91eb8884e0e191209c45f5541b16aa7c0cfb135978",
-                "sha256:c132bab45d4bd0fff1d3fe294d92b0a6eb8404e93337b3127bdec9f21de117e6",
+                "sha256:67f7f57eae8dede577f3f7775957f5bec93edd6bdb6ce597bb5b28e1bdf3d4fb",
+                "sha256:27bb401a20a838d6d0ea380f08c6ead3ccd8c9d8a0232dc9adcc0e4994576a66",
                 "sha256:c3d945b7b577f07a477700f618f46cbc287af3a9222cd73035c6ef527ef2c363",
+                "sha256:bc2301170986ad82d9349a91eb8884e0e191209c45f5541b16aa7c0cfb135978",
+                "sha256:7ba834564daef87557e7fcd35c3c3183a4147b0b3a57314e53317360b9b201b3",
+                "sha256:9449f5d4d7c516a6118fa9210c4a00f34384cb1d2028672100ee0c6cce49d7f6",
+                "sha256:d01dfc5c2b3495184f683574e03c70022674ca9a7be88589c5aba130d835ea90",
+                "sha256:2a35b7570d8f247889784010aac8b384fd2e4a47b33e15c4a60b45a7c1944120",
+                "sha256:5eb86f03f9c4f0ac2336ac5431271072ddf7ecc76b338e26366732cfac58aa19",
+                "sha256:29720c4253263cff9aea64585adbbe85013ba647f6e98367efff9db2d7193ded",
+                "sha256:82409f5150e529d699e5c33fa8fd85e965104db03bc564f5f4b6a9199e591f7c",
+                "sha256:7d7f084cbe1fdb82be5a0545062b59b1ad3637bc5a48612ac2eb428ff31b31ea",
+                "sha256:6ec84edcbc966ae460560a51a90046503ff0b5b66157a9efc61515c68059f6c8",
+                "sha256:8c56ef989342e42b9fcaba7c74b446f0cc9bed546dd00034fa7ad66fc00307ef",
+                "sha256:42c531a6a354407f42ee07fda5c2c0dc822cf6d52744949c182f2b295fbd4183",
+                "sha256:21af753934f2f6d1a10fe8f4c0a64315af209ef6adeaee63ca349797d747d687",
                 "sha256:cee18beb4c807b5c0b178f4fa2fae03cef9d51821a358c6890f8b23465b7e5d2",
-                "sha256:d01dfc5c2b3495184f683574e03c70022674ca9a7be88589c5aba130d835ea90"
+                "sha256:c132bab45d4bd0fff1d3fe294d92b0a6eb8404e93337b3127bdec9f21de117e6"
             ],
-            "index": "pypi",
             "version": "==2.3"
         },
         "cssmin": {
             "hashes": [
                 "sha256:e012f0cc8401efcf2620332339011564738ae32be8c84b2e43ce8beaec1067b6"
             ],
-            "index": "pypi",
             "version": "==0.2.0"
         },
         "flask": {
             "hashes": [
-                "sha256:7f03bb2c255452444f7265eddb51601806e5447b6f8a2d50bbc77a654a14c118",
-                "sha256:93e803cdbe326a61ebd5c5d353959397c85f829bec610d59cb635c9f97d7ca8b"
+                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05",
+                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48"
             ],
-            "index": "pypi",
-            "version": "==0.12"
+            "version": "==1.0.2"
         },
         "flask-assets": {
             "hashes": [
                 "sha256:6031527b89fb3509d1581d932affa5a79dd348cfffb58d0aef99a43461d47847"
             ],
-            "index": "pypi",
             "version": "==0.12"
         },
         "flask-login": {
             "hashes": [
                 "sha256:c815c1ac7b3e35e2081685e389a665f2c74d7e077cb93cecabaea352da4752ec"
             ],
-            "index": "pypi",
             "version": "==0.4.1"
         },
         "flask-paginate": {
             "hashes": [
                 "sha256:b68e8d7664419ad53728514139811bce9c3f2e56199a6c057ef4c08f9f35f35d"
             ],
-            "index": "pypi",
             "version": "==0.5.1"
         },
         "flask-session": {
             "hashes": [
-                "sha256:a31c27e0c3287f00c825b3d9625aba585f4df4cccedb1e7dd5a69a215881a731",
-                "sha256:b9b32126bfc52c3169089f2ed9a40e34b589527bda48b633428e07d39d9c8792"
+                "sha256:b9b32126bfc52c3169089f2ed9a40e34b589527bda48b633428e07d39d9c8792",
+                "sha256:a31c27e0c3287f00c825b3d9625aba585f4df4cccedb1e7dd5a69a215881a731"
             ],
-            "index": "pypi",
             "version": "==0.3.1"
         },
         "flask-wtf": {
             "hashes": [
-                "sha256:5d14d55cfd35f613d99ee7cba0fc3fbbe63ba02f544d349158c14ca15561cc36",
-                "sha256:d9a9e366b32dcbb98ef17228e76be15702cd2600675668bca23f63a7947fd5ac"
+                "sha256:d9a9e366b32dcbb98ef17228e76be15702cd2600675668bca23f63a7947fd5ac",
+                "sha256:5d14d55cfd35f613d99ee7cba0fc3fbbe63ba02f544d349158c14ca15561cc36"
             ],
-            "index": "pypi",
             "version": "==0.14.2"
         },
         "flask-zipkin": {
             "hashes": [
-                "sha256:402bed9a98d3507d82db98a8f7437fb52ef3684af33c58a241b37779f9013d74",
-                "sha256:fbd3e3c41ceeda922701eebbfce88c8fccb7bc849289d772f5186a14a49827bd"
+                "sha256:fbd3e3c41ceeda922701eebbfce88c8fccb7bc849289d772f5186a14a49827bd",
+                "sha256:402bed9a98d3507d82db98a8f7437fb52ef3684af33c58a241b37779f9013d74"
             ],
-            "index": "pypi",
             "version": "==0.0.4"
         },
         "furl": {
@@ -185,23 +188,21 @@
                 "sha256:75af03c99389535f218cc596c7de74df4763803f7b63eb09d77e92b3956b36c6",
                 "sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622"
             ],
-            "index": "pypi",
             "version": "==19.7.1"
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
             ],
             "version": "==2.6"
         },
         "iso8601": {
             "hashes": [
                 "sha256:210e0134677cc0d02f6028087fee1df1e1d76d372ee1db0bf30bf66c5c1c89a3",
-                "sha256:49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82",
-                "sha256:bbbae5fb4a7abfe71d4688fd64bff70b91bbd74ef6a99d964bab18f7fdf286dd"
+                "sha256:bbbae5fb4a7abfe71d4688fd64bff70b91bbd74ef6a99d964bab18f7fdf286dd",
+                "sha256:49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82"
             ],
-            "index": "pypi",
             "version": "==0.1.12"
         },
         "itsdangerous": {
@@ -221,7 +222,6 @@
             "hashes": [
                 "sha256:b6df99b2cd1c75d9d342e4335b535789b8da9107ec748212706ef7bbe5c2553b"
             ],
-            "index": "pypi",
             "version": "==2.2.2"
         },
         "markupsafe": {
@@ -238,8 +238,8 @@
         },
         "ply": {
             "hashes": [
-                "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3",
-                "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"
+                "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce",
+                "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"
             ],
             "version": "==3.11"
         },
@@ -257,17 +257,15 @@
         },
         "pyjwt": {
             "hashes": [
-                "sha256:500be75b17a63f70072416843dc80c8821109030be824f4d14758f114978bae7",
-                "sha256:a4e5f1441e3ca7b382fd0c0b416777ced1f97c64ef0c33bfa39daf38505cfd2f"
+                "sha256:a4e5f1441e3ca7b382fd0c0b416777ced1f97c64ef0c33bfa39daf38505cfd2f",
+                "sha256:500be75b17a63f70072416843dc80c8821109030be824f4d14758f114978bae7"
             ],
-            "index": "pypi",
             "version": "==1.5.3"
         },
         "pyscss": {
             "hashes": [
                 "sha256:14a25c33c221a66bb1f000a6a067f376528d3df2f9333cee9c95709a9280cdb0"
             ],
-            "index": "pypi",
             "version": "==1.3.5"
         },
         "python-dateutil": {
@@ -275,7 +273,6 @@
                 "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
                 "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
             ],
-            "index": "pypi",
             "version": "==2.7.3"
         },
         "redis": {
@@ -283,7 +280,6 @@
                 "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
                 "sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f"
             ],
-            "index": "pypi",
             "version": "==2.10.6"
         },
         "requests": {
@@ -291,30 +287,26 @@
                 "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
                 "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
             ],
-            "index": "pypi",
             "version": "==2.18.4"
         },
         "requestsdefaulter": {
             "hashes": [
-                "sha256:5e185d9b38f29215c78446188afd70765a8e876244eec6a5f0e71ae437fdb128",
-                "sha256:bb83e7f96009be470d1dea55c270c9dad06fb231dd33dda483ab3d8ffb6b8102"
+                "sha256:5682733d391af907d8e5e95a5470b3b785275f1089a7a7113f1bb288b9d4631a"
             ],
-            "index": "pypi",
-            "version": "==0.1.0"
+            "version": "==0.1.1"
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
             ],
             "version": "==1.11.0"
         },
         "structlog": {
             "hashes": [
-                "sha256:6980001045abd235fa12582222627c19b89109e58b85eb77d5a5abc778df6e20",
-                "sha256:9947d12d904529e6133384e52091ce92d0541472a722460cfcb4bcc8d02340b0"
+                "sha256:9947d12d904529e6133384e52091ce92d0541472a722460cfcb4bcc8d02340b0",
+                "sha256:6980001045abd235fa12582222627c19b89109e58b85eb77d5a5abc778df6e20"
             ],
-            "index": "pypi",
             "version": "==17.2.0"
         },
         "thriftpy": {
@@ -338,15 +330,15 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b",
+                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c"
             ],
             "version": "==0.14.1"
         },
         "wtforms": {
             "hashes": [
-                "sha256:0cdbac3e7f6878086c334aa25dc5a33869a3954e9d1e015130d65a69309b3b61",
-                "sha256:e3ee092c827582c50877cdbd49e9ce6d2c5c1f6561f849b3b068c1b8029626f1"
+                "sha256:e3ee092c827582c50877cdbd49e9ce6d2c5c1f6561f849b3b068c1b8029626f1",
+                "sha256:0cdbac3e7f6878086c334aa25dc5a33869a3954e9d1e015130d65a69309b3b61"
             ],
             "version": "==2.2.1"
         }
@@ -354,8 +346,8 @@
     "develop": {
         "atomicwrites": {
             "hashes": [
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6",
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585"
             ],
             "version": "==1.1.5"
         },
@@ -368,15 +360,15 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
-                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
+                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a",
+                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638"
             ],
-            "version": "==2018.8.13"
+            "version": "==2018.8.24"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
             ],
             "version": "==3.0.4"
         },
@@ -385,7 +377,6 @@
                 "sha256:ad82f054837b02081f86ed1eb6c04cddc029fbc734eaf92ff73da1db3a79188b",
                 "sha256:db1c182ca896244d8644d8410a33f6f6dd1cc24d80209907a65077445923f00c"
             ],
-            "index": "pypi",
             "version": "==2.0.9"
         },
         "cookies": {
@@ -397,62 +388,61 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
-                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
-                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
-                "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
-                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
-                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
-                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
-                "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
-                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
-                "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
-                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
-                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
-                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
-                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
-                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
-                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
-                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
-                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
-                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
-                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
-                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
-                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
                 "sha256:7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc",
-                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
-                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
-                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
-                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
-                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
-                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
-                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
-                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
-                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
-                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
-                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
-                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
-                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
-                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
+                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
                 "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
+                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
+                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
+                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
+                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
+                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
+                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
+                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
+                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
+                "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
+                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
+                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
+                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
+                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
+                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
+                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
+                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
+                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
+                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
+                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
+                "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
+                "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
+                "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
+                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
+                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
+                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
                 "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
             "version": "==4.5.1"
         },
         "flake8": {
             "hashes": [
-                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
-                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37"
+                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37",
+                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0"
             ],
-            "index": "pypi",
             "version": "==3.5.0"
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "mccabe": {
             "hashes": [
@@ -466,21 +456,20 @@
                 "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
                 "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
             ],
-            "index": "pypi",
             "version": "==2.0.0"
         },
         "more-itertools": {
             "hashes": [
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d",
                 "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
-                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
-                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e"
             ],
             "version": "==4.3.0"
         },
         "pbr": {
             "hashes": [
-                "sha256:1b8be50d938c9bb75d0eaf7eda111eec1bf6dc88a62a6412e33bf077457e0f45",
-                "sha256:b486975c0cafb6beeb50ca0e17ba047647f229087bd74e37f4a7e2cac17d2caa"
+                "sha256:b486975c0cafb6beeb50ca0e17ba047647f229087bd74e37f4a7e2cac17d2caa",
+                "sha256:1b8be50d938c9bb75d0eaf7eda111eec1bf6dc88a62a6412e33bf077457e0f45"
             ],
             "version": "==4.2.0"
         },
@@ -493,15 +482,15 @@
         },
         "py": {
             "hashes": [
-                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
-                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e",
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7"
             ],
             "version": "==1.5.4"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
-                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
+                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9",
+                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766"
             ],
             "version": "==2.3.1"
         },
@@ -514,48 +503,43 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:3459a123ad5532852d36f6f4501dfe1acf4af1dd9541834a164666aa40395b02",
-                "sha256:96bfd45dbe863b447a3054145cd78a9d7f31475d2bce6111b133c0cc4f305118"
+                "sha256:96bfd45dbe863b447a3054145cd78a9d7f31475d2bce6111b133c0cc4f305118",
+                "sha256:3459a123ad5532852d36f6f4501dfe1acf4af1dd9541834a164666aa40395b02"
             ],
-            "index": "pypi",
             "version": "==3.7.2"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
-                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
+                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec",
+                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d"
             ],
-            "index": "pypi",
             "version": "==2.5.1"
         },
         "requests": {
             "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
-            "index": "pypi",
-            "version": "==2.18.4"
+            "version": "==2.19.1"
         },
         "requests-mock": {
             "hashes": [
-                "sha256:2931887853c42e1d73879983d5bf03041109472991c5b4b8dba5d11ed23b9d0b",
-                "sha256:96a1e45b1c0bd18d14fcb2d55b3b09d6d46237e37bcae3155df4cb75bc42619e"
+                "sha256:96a1e45b1c0bd18d14fcb2d55b3b09d6d46237e37bcae3155df4cb75bc42619e",
+                "sha256:2931887853c42e1d73879983d5bf03041109472991c5b4b8dba5d11ed23b9d0b"
             ],
-            "index": "pypi",
             "version": "==1.4.0"
         },
         "responses": {
             "hashes": [
-                "sha256:c6082710f4abfb60793899ca5f21e7ceb25aabf321560cc0726f8b59006811c9",
-                "sha256:f23a29dca18b815d9d64a516b4a0abb1fbdccff6141d988ad8100facb81cf7b3"
+                "sha256:f23a29dca18b815d9d64a516b4a0abb1fbdccff6141d988ad8100facb81cf7b3",
+                "sha256:c6082710f4abfb60793899ca5f21e7ceb25aabf321560cc0726f8b59006811c9"
             ],
-            "index": "pypi",
             "version": "==0.9.0"
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
             ],
             "version": "==1.11.0"
         },
@@ -564,15 +548,14 @@
                 "sha256:41360bceecfdb2dff9e327a49caaff8b1b4a984ed2cff761658ec2c31e5afbd9",
                 "sha256:670ade9410b7132278209e6a2e893caf098b040c4ba4d5ea848367a9c5588728"
             ],
-            "index": "pypi",
             "version": "==5.3.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5",
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf"
             ],
-            "version": "==1.22"
+            "version": "==1.23"
         }
     }
 }

--- a/response_operations_ui/views/errors.py
+++ b/response_operations_ui/views/errors.py
@@ -17,7 +17,7 @@ def api_error(error):
                  status_code=500,
                  api_url=error.url,
                  api_status_code=error.status_code)
-    return render_template('errors/500-error.html')
+    return render_template('errors/500-error.html'), 500
 
 
 @error_bp.app_errorhandler(UpdateContactDetailsException)

--- a/tests/views/__init__.py
+++ b/tests/views/__init__.py
@@ -1,42 +1,14 @@
 from unittest import TestCase
-from unittest.mock import MagicMock
-
-from flask import Response
 
 from response_operations_ui import create_app
-from response_operations_ui.exceptions.exceptions import ApiError
 
 
 class ViewTestCase(TestCase):
 
     def setUp(self):
         self.app = create_app('TestingConfig')
-        self._create_apierror_handler_mock()
         self.client = self.app.test_client()
         self.setup_data()
 
     def setup_data(self):
         raise NotImplementedError
-
-    def tearDown(self):
-        self._reset_apierror_handler_mock()
-
-    def _reset_apierror_handler_mock(self):
-        # NB: each of test cases use the same app object.
-        self.app._error_handlers[None][ApiError] = self._old_handler
-
-    def _create_apierror_handler_mock(self, mock=None):
-        """
-        This mocks the Flask error handler so we can validate that an ApiError was raised.
-        """
-        self._mocked_handler = mock or MagicMock(return_value=Response(''))
-        self._old_handler = self.app._error_handlers[None][ApiError]
-        self.app._error_handlers[None][ApiError] = self._mocked_handler
-
-    def assertApiError(self, url, status_code):
-        """
-        Helper method for asserting the cause of an ApiError.
-        """
-        self._mocked_handler.assert_called()
-        self.assertEqual(self._mocked_handler.call_args[0][0].status_code, status_code)
-        self.assertEqual(self._mocked_handler.call_args[0][0].url, url)

--- a/tests/views/test_info.py
+++ b/tests/views/test_info.py
@@ -25,8 +25,8 @@ class TestInfo(unittest.TestCase):
         response = self.client.get("/info")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn('"name": "response-operations-ui"'.encode(), response.data)
-        self.assertNotIn('"test": "test"'.encode(), response.data)
+        self.assertIn('"name":"response-operations-ui"'.encode(), response.data)
+        self.assertNotIn('"test":"test"'.encode(), response.data)
 
     def test_info_with_git_info(self):
         with open('git_info', 'w') as outfile:
@@ -35,7 +35,7 @@ class TestInfo(unittest.TestCase):
         response = self.client.get("/info")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn('"name": "response-operations-ui"'.encode(), response.data)
+        self.assertIn('"name":"response-operations-ui"'.encode(), response.data)
 
     def test_info_with_non_json_git_info(self):
         with open('git_info', 'w') as outfile:
@@ -44,5 +44,5 @@ class TestInfo(unittest.TestCase):
         response = self.client.get("/info")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn('"name": "response-operations-ui"'.encode(), response.data)
-        self.assertNotIn('"test": "test"'.encode(), response.data)
+        self.assertIn('"name":"response-operations-ui"'.encode(), response.data)
+        self.assertNotIn('"test":"test"'.encode(), response.data)

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -111,18 +111,22 @@ class TestReportingUnits(ViewTestCase):
     def test_get_reporting_unit_party_ru_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, status_code=500)
 
-        self.client.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertApiError(url_get_party_by_ru_ref, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_cases_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, status_code=500)
 
-        self.client.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertApiError(f'{url_get_cases_by_business_party_id}?iac=True', 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 2)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_cases_404(self, mock_request):
@@ -141,32 +145,37 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(url_get_casegroups_by_business_party_id, status_code=500)
 
-        self.client.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertApiError(url_get_casegroups_by_business_party_id, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 3)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_casegroups_404(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=[])
         mock_request.get(url_get_casegroups_by_business_party_id, status_code=404)
-        mock_request.get(url_get_respondent_party_by_party_id, json=[])
 
         response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 200)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 3)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_collection_exercise_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
-        mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=[])
+        mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', status_code=500)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', status_code=500)
 
-        self.client.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertApiError(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 4)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_party_id_fail(self, mock_request):
@@ -177,10 +186,11 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, status_code=500)
 
-        self.client.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
-        params = f'?collection_exercise_id={collection_exercise_id_1}&verbose=True'
-        self.assertApiError(f'{url_get_business_party_by_party_id}{params}', 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 6)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_casegroup_status_fail(self, mock_request):
@@ -192,9 +202,11 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, status_code=500)
 
-        self.client.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertApiError(url_get_available_case_group_statuses_direct, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 7)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_casegroup_status_404(self, mock_request):
@@ -225,9 +237,13 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, status_code=500)
 
-        self.client.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertApiError(url_get_survey_by_id, 500)
+        request_history = mock_request.request_history
+        # TODO: url_get_business_party_by_party_id and url_get_available_case_group_statuses_direct are called twice
+        # duplicated calls should probably be refactored out
+        self.assertEqual(len(request_history), 10)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_respondent_party_fail(self, mock_request):
@@ -241,9 +257,13 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_survey_by_id, json=survey)
         mock_request.get(url_get_respondent_party_by_party_id, status_code=500)
 
-        self.client.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertApiError(url_get_respondent_party_by_party_id, 500)
+        request_history = mock_request.request_history
+        # TODO: url_get_business_party_by_party_id and url_get_available_case_group_statuses_direct are called twice
+        # duplicated calls should probably be refactored out
+        self.assertEqual(len(request_history), 11)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_iac_fail(self, mock_request):
@@ -258,9 +278,13 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
         mock_request.get(f'{url_get_iac}/{iac_1}', status_code=500)
 
-        self.client.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
-        self.assertApiError(f'{url_get_iac}/{iac_1}', 500)
+        request_history = mock_request.request_history
+        # TODO: url_get_business_party_by_party_id and url_get_available_case_group_statuses_direct are called twice
+        # duplicated calls should probably be refactored out
+        self.assertEqual(len(request_history), 12)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_iac_404(self, mock_request):
@@ -353,9 +377,11 @@ class TestReportingUnits(ViewTestCase):
     def test_search_reporting_units_fail(self, mock_request):
         mock_request.get(url_search_reporting_units, status_code=500)
 
-        self.client.post("/reporting-units", follow_redirects=True)
+        response = self.client.post("/reporting-units", follow_redirects=True)
 
-        self.assertApiError(url_search_reporting_units, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_resend_verification_email(self, mock_request):
@@ -394,9 +420,12 @@ class TestReportingUnits(ViewTestCase):
     @requests_mock.mock()
     def test_fail_resent_verification_email(self, mock_request):
         mock_request.get(url_resend_verification_email, status_code=500)
-        self.client.post(f"reporting-units/resend_verification/50012345678/{respondent_party_id}",
-                         follow_redirects=True)
-        self.assertApiError(url_resend_verification_email, 500)
+        response = self.client.post(f"reporting-units/resend_verification/50012345678/{respondent_party_id}",
+                                    follow_redirects=True)
+
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_contact_details(self, mock_request):
@@ -413,10 +442,12 @@ class TestReportingUnits(ViewTestCase):
     def test_get_contact_details_fail(self, mock_request):
         mock_request.get(get_respondent_by_id_url, status_code=500)
 
-        self.client.get(f"/reporting-units/50012345678/edit-contact-details/{respondent_party_id}",
-                        follow_redirects=True)
+        response = self.client.get(f"/reporting-units/50012345678/edit-contact-details/{respondent_party_id}",
+                                   follow_redirects=True)
 
-        self.assertApiError(get_respondent_by_id_url, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_edit_contact_details(self, mock_request):
@@ -570,21 +601,25 @@ class TestReportingUnits(ViewTestCase):
     def test_reporting_unit_generate_new_code_event_fail(self, mock_request):
         mock_request.post(url_post_case_event, status_code=500)
 
-        self.client.get(f"/reporting-units/{ru_ref}/new_enrolment_code?case_id={case['id']}",
-                        follow_redirects=True)
+        response = self.client.get(f"/reporting-units/{ru_ref}/new_enrolment_code?case_id={case['id']}",
+                                   follow_redirects=True)
 
-        self.assertApiError(url_post_case_event, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_reporting_unit_generate_new_code_case_fail(self, mock_request):
         mock_request.post(url_post_case_event)
         mock_request.get(url_get_case, status_code=500)
 
-        self.client.get(f"/reporting-units/{ru_ref}/new_enrolment_code?case_id={case['id']}&"
-                        "survey_name=test_survey_name&trading_as=trading_name&ru_name=test_ru_name",
-                        follow_redirects=True)
+        response = self.client.get(f"/reporting-units/{ru_ref}/new_enrolment_code?case_id={case['id']}&"
+                                   "survey_name=test_survey_name&trading_as=trading_name&ru_name=test_ru_name",
+                                   follow_redirects=True)
 
-        self.assertApiError(url_get_case, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 2)
+        self.assertEqual(response.status_code, 500)
 
     def test_disable_enrolment_view(self):
         response = self.client.get("/reporting-units/ru_ref/change-enrolment-status"
@@ -626,8 +661,10 @@ class TestReportingUnits(ViewTestCase):
     def test_disable_enrolment_post_fail(self, mock_request):
         mock_request.put(url_change_enrolment_status, status_code=500)
 
-        self.client.post("/reporting-units/50012345678/change-enrolment-status"
-                         "?survey_id=test_id&respondent_id=test_id&business_id=test_id&change_flag=DISABLED",
-                         follow_redirects=True)
+        response = self.client.post("/reporting-units/50012345678/change-enrolment-status"
+                                    "?survey_id=test_id&respondent_id=test_id&business_id=test_id&change_flag=DISABLED",
+                                    follow_redirects=True)
 
-        self.assertApiError(url_change_enrolment_status, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)

--- a/tests/views/test_respondents.py
+++ b/tests/views/test_respondents.py
@@ -59,9 +59,11 @@ class TestRespondents(ViewTestCase):
         email = 'Jacky.Turner@email.com'
         mock_request.get(get_respondent_by_email_url, status_code=500)
 
-        self.client.post("/respondents/", data={"email": email})
+        response = self.client.post("/respondents/", data={"email": email})
 
-        self.assertApiError(get_respondent_by_email_url, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_search_respondent_by_email_success(self, mock_request):
@@ -92,30 +94,33 @@ class TestRespondents(ViewTestCase):
         mock_request.get(get_respondent_by_id_url, json=respondent, status_code=200)
         mock_request.get(get_survey_by_id_url, json=survey_by_id, status_code=500)
 
-        self.client.post("/respondents", data={"query": email}, follow_redirects=True)
+        response = self.client.post("/respondents", data={"query": email}, follow_redirects=True)
 
-        self.assertApiError(get_survey_by_id_url, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 4)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_search_respondent_by_email_unable_to_get_respondent_details(self, mock_request):
         email = 'Jacky.Turner@email.com'
-        mock_request.get(get_business_by_id_url, json=reporting_unit, status_code=200)
         mock_request.get(get_respondent_by_email_url, json=respondent, status_code=200)
         mock_request.get(get_respondent_by_id_url, json=respondent, status_code=500)
-        mock_request.get(get_survey_by_id_url, json=survey_by_id, status_code=200)
 
-        self.client.post("/respondents", data={"query": email}, follow_redirects=True)
+        response = self.client.post("/respondents", data={"query": email}, follow_redirects=True)
 
-        self.assertApiError(get_respondent_by_id_url, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 2)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_search_respondent_by_email_unable_to_get_business_details(self, mock_request):
         email = 'Jacky.Turner@email.com'
-        mock_request.get(get_business_by_id_url, json=reporting_unit, status_code=500)
         mock_request.get(get_respondent_by_email_url, json=respondent, status_code=200)
         mock_request.get(get_respondent_by_id_url, json=respondent, status_code=200)
-        mock_request.get(get_survey_by_id_url, json=survey_by_id, status_code=200)
+        mock_request.get(get_business_by_id_url, json=reporting_unit, status_code=500)
 
-        self.client.post("/respondents", data={"query": email}, follow_redirects=True)
+        response = self.client.post("/respondents", data={"query": email}, follow_redirects=True)
 
-        self.assertApiError(f'{get_business_by_id_url}?verbose=True', 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 3)
+        self.assertEqual(response.status_code, 500)

--- a/tests/views/test_sign_in.py
+++ b/tests/views/test_sign_in.py
@@ -54,6 +54,8 @@ class TestSignIn(unittest.TestCase):
         response = self.client.post("/sign-in", follow_redirects=True,
                                     data={"username": "user", "password": "pass"})
 
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
         self.assertEqual(response.status_code, 500)
         self.assertIn(b'Error 500 - Server error', response.data)
 
@@ -86,6 +88,8 @@ class TestSignIn(unittest.TestCase):
         response = self.client.post("/sign-in", follow_redirects=True,
                                     data={"username": "user", "password": "pass"})
 
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
         self.assertEqual(response.status_code, 500)
         self.assertIn(b'Error 500 - Server error', response.data)
 

--- a/tests/views/test_social_case.py
+++ b/tests/views/test_social_case.py
@@ -40,6 +40,8 @@ class TestSocialCase(ViewTestCase):
         mock_request.get(get_case_by_id_url, json=mocked_case_details)
         mock_request.get(get_sample_by_id_url, status_code=500)
 
-        self.client.get(f'/social/case/{case_id}', follow_redirects=True)
+        response = self.client.get(f'/social/case/{case_id}', follow_redirects=True)
 
-        self.assertApiError(get_sample_by_id_url, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 2)
+        self.assertEqual(response.status_code, 500)

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -122,9 +122,11 @@ class TestSurvey(ViewTestCase):
     def test_survey_list_fail(self, mock_request):
         mock_request.get(url_get_survey_list, status_code=500)
 
-        self.client.get("/surveys")
+        response = self.client.get("/surveys")
 
-        self.assertApiError(url_get_survey_list, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_survey_list_connection_error(self, mock_request):
@@ -132,6 +134,8 @@ class TestSurvey(ViewTestCase):
 
         response = self.client.get("/surveys", follow_redirects=True)
 
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
         self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
@@ -150,9 +154,11 @@ class TestSurvey(ViewTestCase):
     def test_survey_view_fail(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, status_code=500)
 
-        self.client.get("/surveys/bres")
+        response = self.client.get("/surveys/bres")
 
-        self.assertApiError(url_get_survey_by_short_name, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_survey_state_mapping(self, mock_request):
@@ -260,13 +266,13 @@ class TestSurvey(ViewTestCase):
             "long_name": 'New Survey Long Name',
             "short_name": 'QBX'
         }
-        mock_request.get(url_get_survey_list, json=survey_list)
         mock_request.put(url_update_survey_details, status_code=500)
-        mock_request.get(url_get_survey_list, json=updated_survey_list)
 
-        self.client.post(f"/surveys/edit-survey-details/QBS", data=changed_survey_details)
+        response = self.client.post(f"/surveys/edit-survey-details/QBS", data=changed_survey_details)
 
-        self.assertApiError(url_update_survey_details, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_update_survey_details_failed_validation(self, mock_request):
@@ -429,9 +435,11 @@ class TestSurvey(ViewTestCase):
         mock_request.get(url_get_legal_basis_list, json=legal_basis_list)
         mock_request.post(url_create_survey, text="Internal server error", status_code=500)
 
-        self.client.post(f"surveys/create", data=create_survey_request)
+        response = self.client.post(f"surveys/create", data=create_survey_request)
 
-        self.assertApiError(url_create_survey, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 2)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_update_survey_details_failed_validation_short_name_has_spaces(self, mock_request):

--- a/tests/views/test_update_event_date.py
+++ b/tests/views/test_update_event_date.py
@@ -76,19 +76,22 @@ class TestUpdateEventDate(ViewTestCase):
     def test_update_event_no_collection_exercise(self, mock_request):
         mock_request.get(url_survey_shortname, json=survey)
         mock_request.get(url_collection_exercise_survey_id, json=[])
-        mock_request.get(url_get_collection_exercise_events, json=events)
 
         response = self.client.get(f"/surveys/{survey_short_name}/{period}/event/go_live")
 
-        self.assertEqual(response.status_code, 404)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 2)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_update_event_date_service_fail(self, mock_request):
         mock_request.get(url_survey_shortname, status_code=500)
 
-        self.client.get(f"/surveys/{survey_short_name}/{period}/event/go_live", follow_redirects=True)
+        response = self.client.get(f"/surveys/{survey_short_name}/{period}/event/go_live", follow_redirects=True)
 
-        self.assertApiError(url_survey_shortname, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 1)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_put_update_event_date(self, mock_request):
@@ -106,12 +109,13 @@ class TestUpdateEventDate(ViewTestCase):
     def test_put_update_event_date_no_collection_exercise(self, mock_request):
         mock_request.get(url_survey_shortname, json=survey)
         mock_request.get(url_collection_exercise_survey_id, json=[])
-        mock_request.get(url_get_collection_exercise_events, json=events)
 
         response = self.client.post(f"/surveys/{survey_short_name}/{period}/event/go_live",
                                     data=self.update_event_form, follow_redirects=True)
 
-        self.assertEqual(response.status_code, 404)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 2)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_put_update_event_date_invalid_form(self, mock_request):
@@ -145,10 +149,11 @@ class TestUpdateEventDate(ViewTestCase):
     def test_put_update_event_date_update_service_fail(self, mock_request):
         mock_request.get(url_survey_shortname, json=survey)
         mock_request.get(url_collection_exercise_survey_id, json=[collection_exercise])
-        mock_request.get(url_get_collection_exercise_events, json=events)
         mock_request.put(url_put_update_event_date, status_code=500)
 
-        self.client.post(f"/surveys/{survey_short_name}/{period}/event/go_live",
-                         data=self.update_event_form, follow_redirects=True)
+        response = self.client.post(f"/surveys/{survey_short_name}/{period}/event/go_live",
+                                    data=self.update_event_form, follow_redirects=True)
 
-        self.assertApiError(url_put_update_event_date, 500)
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 3)
+        self.assertEqual(response.status_code, 500)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Flask version Before 0.12.3 contains a CWE-20: Improper Input
Validation vulnerability in flask. So this PR is to update the flask
version and fix any breaking changes.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Upgrade Flask version
- Fix breaking changes: remove mocking of error handlers and replace with asserting mock requests called

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Ran Unit tests (not many of...), ITs and ATs

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
