### PR TITLE
Fix reminder logic in template

### DIFF
--- a/response_operations_ui/templates/collection_exercise/ce-dates-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-dates-section.html
@@ -104,7 +104,7 @@
           <form action="{{ url_for('collection_exercise_bp.get_create_collection_event_form', short_name=survey.shortName, period=ce.exerciseRef, ce_id=ce.id, tag='reminder')}}" method="get">
             <button class="btn btn--secondary btn--small btn__table-row" id="create-event-date-reminder" type="submit">Add</button>
           </form>
-        {% elif (not locked or events.reminder.is_in_future) and config.EDIT_EVENT_DATES_ENABLED %}
+        {% elif events.reminder and (not locked or events.reminder.is_in_future) and config.EDIT_EVENT_DATES_ENABLED %}
           <form action="{{ url_for('collection_exercise_bp.update_event_date', short_name=survey.shortName, period=ce.exerciseRef, tag='reminder')}}" method="get">
             <a class="edit-icon" href=# id="edit-event-date-reminder" onclick="this.parentNode.submit()"></a>
           </form>
@@ -129,7 +129,7 @@
           <form action="{{ url_for('collection_exercise_bp.get_create_collection_event_form', short_name=survey.shortName, period=ce.exerciseRef, ce_id=ce.id, tag='reminder2')}}" method="get">
             <button class="btn btn--secondary btn--small btn__table-row" id="create-event-date-reminder2" type="submit">Add</button>
           </form>
-        {% elif (not locked or events.reminder2.is_in_future) and config.EDIT_EVENT_DATES_ENABLED %}
+        {% elif events.reminder2 and (not locked or events.reminder2.is_in_future) and config.EDIT_EVENT_DATES_ENABLED %}
           <form action="{{ url_for('collection_exercise_bp.update_event_date', short_name=survey.shortName, period=ce.exerciseRef, tag='reminder2')}}" method="get">
             <a class="edit-icon" href=# id="edit-event-date-reminder2" onclick="this.parentNode.submit()"></a>
           </form>
@@ -155,7 +155,7 @@
           <form action="{{ url_for('collection_exercise_bp.get_create_collection_event_form', short_name=survey.shortName, period=ce.exerciseRef, ce_id=ce.id, tag='reminder3')}}" method="get">
             <button class="btn btn--secondary btn--small btn__table-row" id="create-event-date-reminder3" type="submit">Add</button>
           </form>
-        {% elif (not locked or events.reminder3.is_in_future) and config.EDIT_EVENT_DATES_ENABLED %}
+        {% elif events.reminder3 and (not locked or events.reminder3.is_in_future) and config.EDIT_EVENT_DATES_ENABLED %}
           <form action="{{ url_for('collection_exercise_bp.update_event_date', short_name=survey.shortName, period=ce.exerciseRef, tag='reminder3')}}" method="get">
             <a class="edit-icon" href=# id="edit-event-date-reminder3" onclick="this.parentNode.submit()"></a>
           </form>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When ADD_EVENT_DATES_ENABLED is set to false the logic in the template
breaks as it is trying to find reminder2 in the events dict when
it does not exist. I have added a defensive check before so it doesn't
fall over.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
ACs should run when ADD_EVENT_DATES_ENABLED is set to false

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
