### PR TITLE
Fixed a typo on respondents page when an email is changed

### DIFF
--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -144,7 +144,7 @@
                 </dd>
                 {% if respondent.pendingEmailAddress %}
                 <dt>
-                  New Emailenrolment_changed
+                  New Email
                 </dt>
                 <dd name="tbl-respondent-pending-email">
                   {{ respondent.pendingEmailAddress }}


### PR DESCRIPTION
# Motivation and Context
A typo was found in the reporting unit template, where `new email` should have been

# What has changed
Removed typo

# How to test?
Change email on reporting units page and view `New Email` instead of the screen shot below

# Screenshots (if appropriate):

![](https://trello-attachments.s3.amazonaws.com/5b2a1bff9cadfc7f0a0e1654/5b97a9dea13ee83c246c4efd/9086bb63b4312ff25e8ee36e1d166d7d/response-ops_display_bug.png)
