### PR TITLE
Fix resend verification email and only allow change response status for non-complete

### DIFF
--- a/response_operations_ui/controllers/reporting_units_controllers.py
+++ b/response_operations_ui/controllers/reporting_units_controllers.py
@@ -93,7 +93,7 @@ def generate_new_enrolment_code(case_id):
 def resend_verification_email(party_id):
     logger.debug('Re-sending verification email', party_id=party_id)
     url = f'{app.config["PARTY_URL"]}/party-api/v1/resend-verification-email/{party_id}'
-    response = requests.get(url, auth=app.config['PARTY_AUTH'])
+    response = requests.post(url, auth=app.config['PARTY_AUTH'])
 
     try:
         response.raise_for_status()

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -78,7 +78,7 @@
               </td>
               <td name="tbl-ce-status" class="table--cell">
                 {{ ce.responseStatus }}
-                {% if ce.statuses|length > 0 %}
+                {% if ce.statuses|length > 0 and (ce.responseStatus == 'Not started' or ce.responseStatus == 'In progress')  %}
                 &nbsp;<a href="{{ url_for('case_bp.get_response_statuses', ru_ref=ru.sampleUnitRef, survey=survey.shortName, period=ce.exerciseRef) }}">Change</a>
                 {% endif %}
               </td>

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -401,7 +401,7 @@ class TestReportingUnits(ViewTestCase):
 
     @requests_mock.mock()
     def test_resent_verification_email(self, mock_request):
-        mock_request.get(url_resend_verification_email)
+        mock_request.post(url_resend_verification_email)
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A change was made in party service to change the resend verification email endpoint to a post this adds these changes to ROps. Also at the moment we only allow changing of response status for non-complete responses (In progress or Not started) this removes the link to change if response status is complete.

# What has changed
<!--- What code changes has been made -->
Change request to party for resend verification email to post instead of get. If response status is complete remove the link to change the response status.
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
I ran the acceptance tests attempted to resend verification email it worked and uploaded a SEFT so the response status is complete the change link should no longer appear.
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
