### PR TITLE
BUG: Changed external template references to not specify protocol

### DIFF
--- a/response_operations_ui/templates/edit-contact-details.html
+++ b/response_operations_ui/templates/edit-contact-details.html
@@ -7,7 +7,7 @@
 
   <title>Edit contact details</title>
 
-  <link rel=stylesheet type=text/css href="https://cdn.ons.gov.uk/sdc/322aece/css/styles.css">
+  <link rel=stylesheet type=text/css href="//cdn.ons.gov.uk/sdc/322aece/css/styles.css">
   {% assets "scss_all" %}
     <link rel=stylesheet type=text/css href="{{ ASSET_URL }}">
   {% endassets %}

--- a/response_operations_ui/templates/layouts/base-head.html
+++ b/response_operations_ui/templates/layouts/base-head.html
@@ -9,11 +9,11 @@
 
     <title>{% block page_title %}{{ _('Survey Data Collection') }}{% endblock page_title %}</title>
 
-    <link rel=stylesheet type=text/css href="https://cdn.ons.gov.uk/sdc/322aece/css/styles.css">
+    <link rel=stylesheet type=text/css href="//cdn.ons.gov.uk/sdc/322aece/css/styles.css">
     {% assets "scss_all" %}
     <link rel=stylesheet type=text/css href="{{ ASSET_URL }}">
     {% endassets %}
-    <script type="text/javascript" src="http://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script type="text/javascript" src="//code.jquery.com/jquery-3.3.1.min.js"></script>
     {% assets "js_all" %}
     <script type="text/javascript" src="{{ ASSET_URL }}"></script>
     {% endassets %}

--- a/response_operations_ui/templates/layouts/spoke.html
+++ b/response_operations_ui/templates/layouts/spoke.html
@@ -9,11 +9,11 @@
 
     <title>{% block page_title %}{% endblock page_title %}</title>
 
-    <link rel=stylesheet type=text/css href="https://cdn.ons.gov.uk/sdc/322aece/css/styles.css">
+    <link rel=stylesheet type=text/css href="//cdn.ons.gov.uk/sdc/322aece/css/styles.css">
     {% assets "scss_all" %}
     <link rel=stylesheet type=text/css href="{{ ASSET_URL }}">
     {% endassets %}
-    <script type="text/javascript" src="http://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script type="text/javascript" src="//code.jquery.com/jquery-3.3.1.min.js"></script>
     {% assets "js_all" %}
     <script type="text/javascript" src="{{ ASSET_URL }}"></script>
     {% endassets %}


### PR DESCRIPTION
# Motivation and Context
External script references were referring to non-TLS connections, which causes mixed content errors in prod, and the failure of scripts to load

# What has changed
All template references to external scripts have been changed to use `//` prefices, rather than `https://` or `http://`, meaning that they will start to load their requirements over the protocol the page is loaded with.

# How to test?
* Ensure that the external dependencies load using the web tools:
    * In local running
    * In preprod, once there
    * In prod, once there

# Links
https://github.com/ONSdigital/response-operations-ui/issues/254
