### PR TITLE
remove hard coded page and use request referrer

### DIFF
--- a/response_operations_ui/templates/change-response-status.html
+++ b/response_operations_ui/templates/change-response-status.html
@@ -71,7 +71,7 @@
                                 </div>
                                 <button type="submit" id="response-status-change-confirm-button" class="btn btn--primary u-mt-s">Confirm</button>
                                 <div>
-                                    <a href="/reporting-units/49900000118/" onclick="history.back(); return false;">Cancel</a>
+                                    <a href="{{ request.referrer }}" onclick="history.back(); return false;">Cancel</a>
                                 </div>
                             </form>
                         </div>


### PR DESCRIPTION
# Motivation and Context
Without JS the hardcoded page wouldn't work. I.e. 5xx's

# What has changed
Use request.referrer

# How to test?
Disable JS and click cancel on change response status page
