### PR TITLE
Remove close-conversation feature flag

### DIFF
--- a/config.py
+++ b/config.py
@@ -72,8 +72,6 @@ class Config(object):
     UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID')
     UAA_CLIENT_SECRET = os.getenv('UAA_CLIENT_SECRET')
 
-    FEATURE_ENABLE_CLOSE_CONVERSATION = strtobool(os.getenv('FEATURE_ENABLE_CLOSE_CONVERSATION', 'False'))
-
 
 class DevelopmentConfig(Config):
     DEBUG = os.getenv('DEBUG', True)
@@ -129,8 +127,6 @@ class DevelopmentConfig(Config):
     UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL', 'http://localhost:9080')
     UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID', 'response_operations')
     UAA_CLIENT_SECRET = os.getenv('UAA_CLIENT_SECRET', 'password')
-
-    FEATURE_ENABLE_CLOSE_CONVERSATION = strtobool(os.getenv('FEATURE_ENABLE_CLOSE_CONVERSATION', 'True'))
 
 
 class TestingConfig(DevelopmentConfig):

--- a/response_operations_ui/templates/conversation-view.html
+++ b/response_operations_ui/templates/conversation-view.html
@@ -102,10 +102,8 @@
                                  cols=80) }}
                 </div>
                 <input class="btn u-mt-s" id="btn-send-message" name="send" type="submit" value="Send" />
-                {% if close_feature_enabled %}
                 <a href="{{ url_for('messages_bp.close_conversation', thread_id=messages[0].thread_id, page=page) }}"
                    class="btn btn--secondary btn--border u-mt-s u-ml-xs" id="btn-close-conversation" >Close conversation</a>
-                {% endif %}
             </form>
         </div>
         {% else %}

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -3,7 +3,7 @@ import logging
 from datetime import datetime
 from distutils.util import strtobool
 
-from flask import Blueprint, current_app as app, flash, g, Markup, render_template, request, redirect, session, url_for
+from flask import Blueprint, flash, g, Markup, render_template, request, redirect, session, url_for
 from flask_login import login_required, current_user
 from flask_paginate import get_parameter, Pagination
 from structlog import wrap_logger
@@ -124,8 +124,7 @@ def view_conversation(thread_id):
                            selected_survey=refined_thread[0]['survey'],
                            page=page,
                            closed_at=closed_at,
-                           thread_data=thread_conversation,
-                           close_feature_enabled=app.config['FEATURE_ENABLE_CLOSE_CONVERSATION'])
+                           thread_data=thread_conversation)
 
 
 @messages_bp.route('/', methods=['GET'])


### PR DESCRIPTION
# Motivation and Context
The 'close conversation' feature has been live for the last few months.  Rather than ensuring that the flag is set to 'true' in every environment, it's better practice to remove the flag altogether.

# What has changed
Removed the `FEATURE_ENABLE_CLOSED_CONVRSATION` flag

# How to test?
Secure message should run as normal and you should still be able to close conversations.

# Links
https://trello.com/c/OGBpdnXv/510-remove-closed-conversation-feature-flag-from-response-ops