### PR TITLE
Added ability to request list of surveys by type (business or social)

### DIFF
--- a/response_operations_ui/controllers/survey_controllers.py
+++ b/response_operations_ui/controllers/survey_controllers.py
@@ -87,7 +87,7 @@ def get_survey_ci_classifier(survey_id):
 
 def get_surveys_list():
     logger.debug('Retrieving surveys list')
-    url = f'{app.config["SURVEY_URL"]}/surveys'
+    url = f'{app.config["SURVEY_URL"]}/surveys/surveytype/Business'
     response = requests.get(url, auth=app.config['SURVEY_AUTH'])
 
     if response.status_code == 204:

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -13,7 +13,7 @@ from tests.views import ViewTestCase
 
 shortname_url = f'{TestingConfig.SURVEY_URL}/surveys/shortname'
 url_sign_in_data = f'{TestingConfig.UAA_SERVICE_URL}/oauth/token'
-url_get_surveys_list = f'{TestingConfig.SURVEY_URL}/surveys'
+url_get_surveys_list = f'{TestingConfig.SURVEY_URL}/surveys/surveytype/Business'
 url_get_thread = f'{TestingConfig.SECURE_MESSAGE_URL}/v2/threads/fb0e79bd-e132-4f4f-a7fd-5e8c6b41b9af'
 url_get_threads_list = f'{TestingConfig.SECURE_MESSAGE_URL}/threads'
 url_send_message = f'{TestingConfig.SECURE_MESSAGE_URL}/v2/messages'

--- a/tests/views/test_sign_in.py
+++ b/tests/views/test_sign_in.py
@@ -8,7 +8,7 @@ from response_operations_ui import create_app
 
 
 url_sign_in_data = f'{TestingConfig.UAA_SERVICE_URL}/oauth/token'
-url_surveys = f'{TestingConfig.SURVEY_URL}/surveys'
+url_surveys = f'{TestingConfig.SURVEY_URL}/surveys/surveytype/Business'
 
 
 class TestSignIn(unittest.TestCase):

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -16,7 +16,7 @@ collection_exercise_event_id = 'b4a36392-a21f-485b-9dc4-d151a8fcd565'
 sample_summary_id = 'b9487b59-2ac7-4fbf-b734-5a4c260ff235'
 survey_id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 
-url_get_survey_list = f'{TestingConfig.SURVEY_URL}/surveys'
+url_get_survey_list = f'{TestingConfig.SURVEY_URL}/surveys/surveytype/Business'
 url_get_legal_basis_list = f'{TestingConfig.SURVEY_URL}/legal-bases'
 url_create_survey = f'{TestingConfig.SURVEY_URL}/surveys'
 


### PR DESCRIPTION
# Motivation and Context
With the advent of social surveys there is a need to not show social surveys in response_ops_ui

# What has changed
Survey service exposes an endpoint that allows the type of survey to be set. This has ben changed to access that 

# How to test?
Run up gui and look at survey list locally. Modify one survey in DB survey.survey change a survey to 
surveytype ='Social' and reload . Verify does not appear in list. Change back to Business and reload and it now shows

# Links
https://trello.com/c/qY4MVztp# Screenshots (if appropriate):
