### PR TITLE
Change dockerfile to use smaller base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3.6
+FROM python:3.6-slim
 
 WORKDIR /app
 COPY . /app
 EXPOSE 8085
+RUN apt-get update -y && apt-get install -y python-pip && apt-get update -y && apt-get install -y curl
 RUN pip3 install pipenv && pipenv install --deploy --system
 
 ENTRYPOINT ["python3"]


### PR DESCRIPTION
# Motivation and Context
Python Docker Images are ~1GB.  This is because of the base image.

# What has changed
Starting using python:3.6-slim instead

# How to test?
System should behave as before, acceptance tests should workfinr

# Links
https://trello.com/c/x0swxIs4/358-tbl358-review-base-docker-images
