### PR TITLE
Implementation of renablement

### DIFF
--- a/response_operations_ui/templates/confirm-enrolment-change.html
+++ b/response_operations_ui/templates/confirm-enrolment-change.html
@@ -5,7 +5,7 @@
   <div class="spoke__header">
     <div class="spoke__header__title">
       <h1 class="jupiter">
-        {% if change_flag == 'DISABLED' %}Disable{% else %}Enable{% endif %} enrolment
+        {% if change_flag == 'DISABLED' %}Disable{% else %}Re-enable{% endif %} enrolment
       </h1>
     </div>
   </div>
@@ -51,7 +51,7 @@
       </dl>
 
       <button type="submit" id="confirm-btn" class="btn u-mb-s">
-        {% if change_flag == 'DISABLED' %}Disable{% else %}Enable{% endif %} enrolment
+        {% if change_flag == 'DISABLED' %}Disable{% else %}Re-enable{% endif %} enrolment
       </button>
 
       <div class="u-mt-xs">

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -199,6 +199,11 @@
                     id="change-enrolment-status">Disable</a>
                   {% elif respondent.enrolmentStatus == 'PENDING' %}
                   <a href="{{ url_for('reporting_unit_bp.view_resend_verification', ru_ref=ru_ref, party_id=respondent.id) }}">Re-send verification email</a>
+                  {% elif respondent.enrolmentStatus == 'DISABLED' %}
+                  <a href="{{ url_for('reporting_unit_bp.confirm_change_enrolment_status', ru_ref=ru.sampleUnitRef, ru_name=ru.name, survey_id=survey.id,
+                                      survey_name=survey.shortName, respondent_id=respondent.id, respondent_first_name=respondent.firstName,
+                                      respondent_last_name=respondent.lastName, business_id=ru.id, trading_as=ru.trading_as, change_flag='ENABLED')}}"
+                    id="change-enrolment-status">Re-enable</a>
                   {% endif %}
                 </div>
               </td>


### PR DESCRIPTION
# Motivation and Context
US023 asks for the ability to re-enable enrolment in cases where it has been disabled.  This provides that

# What has changed
* Re-enable button added to RU view
* Re-enable button added to change enrolment view

# How to test?
* Pull branch
* Run response-ops and all services it relies on
* With adequate example data in place (an RU, with an enrolled respondent), ensure you can toggle the enrolment between enabled and disabled.
* Ensure acceptance tests run against this change - they have their own branch `alterations-for-us023

# Links
https://trello.com/c/StCt8X1m
