### PR TITLE
Return user to original page when conversation closed

### DIFF
--- a/response_operations_ui/templates/close-conversation.html
+++ b/response_operations_ui/templates/close-conversation.html
@@ -36,7 +36,7 @@
         </dd>
       </dl>
 
-      <form action="{{ url_for('messages_bp.close_conversation', thread_id=thread_id) }}" method="post">
+      <form action="{{ url_for('messages_bp.close_conversation', thread_id=thread_id, page=page) }}" method="post">
         <input type="hidden" name="closed" value="True" />
         <button class="btn u-mt-m">Close conversation</button>
       </form>

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -7,7 +7,7 @@ import requests_mock
 from config import TestingConfig
 from response_operations_ui.controllers.message_controllers import get_conversation, send_message
 from response_operations_ui.exceptions.exceptions import InternalError
-from response_operations_ui.views.messages import _get_to_id
+from response_operations_ui.views.messages import _get_to_id, _calculate_page
 from response_operations_ui.views.messages import _get_unread_status
 from tests.views import ViewTestCase
 
@@ -744,3 +744,15 @@ class TestMessage(ViewTestCase):
         self.assertEqual(200, response.status_code)
         self.assertIn("Conversation re-opened.".encode(), response.data)
         self.assertIn("Ashe Messages".encode(), response.data)
+
+    def test_calculate_page_change(self):
+        result = _calculate_page(3, 10, 15)
+        self.assertEqual(2, result)
+
+    def test_calculate_page_no_change(self):
+        result = _calculate_page(1, 10, 15)
+        self.assertEqual(1, result)
+
+    def test_calculate_page_zero_threads(self):
+        result = _calculate_page(1, 10, 0)
+        self.assertEqual(1, result)


### PR DESCRIPTION
# Motivation and Context
When a Response-Ops UI user closes a secure message conversation, they should be returned to the inbox page they were on before they closed the conversation.

# What has changed
Passed through the original page the user was on. If the page no longer exists - because the final conversation on the final page has been closed - then it will redirect to the last available page. Also works if the URL is edited to go to page 999, for example.

# How to test?
Run the acceptance tests on the same branch.

To manually test, create enough secure messages to fill more than one page, and close a conversation - you should be returned to the page you started on.

# Links
Trello: https://trello.com/c/lCfPjUPT

# Screenshots (if appropriate):
