### PR TITLE
BUG: Unable to add collection exercises to Sand & Gravel

### DIFF
--- a/response_operations_ui/common/mappers.py
+++ b/response_operations_ui/common/mappers.py
@@ -8,8 +8,8 @@ from response_operations_ui.common.dates import localise_datetime
 
 def format_short_name(short_name):
     """
-    This regex function returns a short name value without spaces
-    e.g. Sand & Gravel -> Sand&Gravel
+    This regex function returns a pretty-printed short name value WITH spaces
+    e.g. Sand&Gravel -> Sand & Gravel
     """
     return re.sub('(&)', r' \1 ', short_name)
 

--- a/response_operations_ui/templates/survey.html
+++ b/response_operations_ui/templates/survey.html
@@ -16,7 +16,7 @@
     <div id="created_ce_message" class="panel__body">
       <h1 class="venus">Collection exercise created</h1>
       <p class="mars">
-        <a href="/surveys/{{ survey.shortName }}/{{ newly_created_period }}" id="newly_created_ce_link">View/edit {{survey.shortName}} {{newly_created_period}}</a>
+        <a href="/surveys/{{ survey.shortName.replace(' ', '') }}/{{ newly_created_period }}" id="newly_created_ce_link">View/edit {{survey.shortName}} {{newly_created_period}}</a>
       </p>
     </div>
   </div>
@@ -57,7 +57,7 @@
       <div class="ce-list">
         <h2 class="saturn u-pt-m">Collection exercises for {{survey.shortName}}</h2>
         <div class="u-mb-l">
-          <a href="/surveys/{{survey.surveyRef}}-{{survey.shortName}}/create-collection-exercise"
+          <a href="/surveys/{{survey.surveyRef}}/{{survey.shortName.replace(' ', '')}}/create-collection-exercise"
              name="create-collection-exercise-link" id="create-collection-exercise">Create collection exercise</a>
         </div>
         <table class="table__dense" summary="Collection exercises for the survey" id="tbl-collection-exercise">

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -392,7 +392,7 @@ def edit_collection_exercise_details(short_name, period):
         return redirect(url_for('surveys_bp.view_survey', short_name=short_name, ce_updated='True'))
 
 
-@collection_exercise_bp.route('/<survey_ref>-<short_name>/create-collection-exercise', methods=['GET'])
+@collection_exercise_bp.route('/<survey_ref>/<short_name>/create-collection-exercise', methods=['GET'])
 @login_required
 def get_create_collection_exercise_form(survey_ref, short_name):
     logger.info("Retrieving survey data for form", short_name=short_name, survey_ref=survey_ref)
@@ -403,7 +403,7 @@ def get_create_collection_exercise_form(survey_ref, short_name):
                            survey_name=survey_details['shortName'])
 
 
-@collection_exercise_bp.route('/<survey_ref>-<short_name>/create-collection-exercise', methods=['POST'])
+@collection_exercise_bp.route('/<survey_ref>/<short_name>/create-collection-exercise', methods=['POST'])
 @login_required
 def create_collection_exercise(survey_ref, short_name):
     logger.info("Attempting to create collection exercise", survey_ref=survey_ref, survey=short_name)

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -973,7 +973,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.post(url_create_collection_exercise, status_code=200)
 
         response = self.client.post(
-            f"/surveys/{survey_ref}-{short_name}/create-collection-exercise",
+            f"/surveys/{survey_ref}/{short_name}/create-collection-exercise",
             data=new_collection_exercise_details,
             follow_redirects=True,
         )
@@ -992,7 +992,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.post(url_create_collection_exercise, status_code=500)
 
         response = self.client.post(
-            f"/surveys/{survey_ref}-{short_name}/create-collection-exercise",
+            f"/surveys/{survey_ref}/{short_name}/create-collection-exercise",
             data=new_collection_exercise_details
         )
 
@@ -1005,7 +1005,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         response = self.client.get(
-            f"/surveys/{survey_ref}-{short_name}/create-collection-exercise", follow_redirects=True
+            f"/surveys/{survey_ref}/{short_name}/create-collection-exercise", follow_redirects=True
         )
 
         self.assertEqual(response.status_code, 200)
@@ -1027,7 +1027,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.post(url_create_collection_exercise, status_code=200)
 
         response = self.client.post(
-            f"/surveys/{survey_ref}-{short_name}/create-collection-exercise",
+            f"/surveys/{survey_ref}/{short_name}/create-collection-exercise",
             data=new_collection_exercise_details,
             follow_redirects=True,
         )
@@ -1050,7 +1050,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.post(url_create_collection_exercise, status_code=200)
 
         response = self.client.post(
-            f"/surveys/{survey_ref}-{short_name}/create-collection-exercise",
+            f"/surveys/{survey_ref}/{short_name}/create-collection-exercise",
             data=new_collection_exercise_details,
             follow_redirects=True,
         )


### PR DESCRIPTION
# Motivation and Context
Sand & Gravel's short name in the database is "Sand&Gravel", which is the reference used to look up the survey from the survey service.

We display "Sand&Gravel" as "Sand & Gravel" (with spaces) but later we try to use this as the short name, failing when we can't find the survey "Survey%20&%20Gravel".

We currently can't open the create collection exercise screen from the link on the survey, and we can't create a new collection exercise even if we type in the correct URL.

This bug stops us from creating the 2019 Sand & Gravel collection exercises without manual DB updates or cURL'ing to the Collex REST endpoint.

# What has changed
Changed the format of the URL used in Response Ops to be more RESTful (slashes, not hyphens). Changed the templates to use the non-pretty-printed survey short name (i.e. strip out the spaces). Corrected a misleading comment.

# How to test?
Create a collection exercise for Sand & Gravel using the UI.

# Links
Trello: https://trello.com/c/LGmwUEHY/571-571-bug-unable-to-add-a-collection-exercise-for-surveys-where-the-shortname-contains-a-space-or-dash

# Screenshots (if appropriate):
