### PR TITLE
113 mark messages as unread

### DIFF
--- a/response_operations_ui/controllers/message_controllers.py
+++ b/response_operations_ui/controllers/message_controllers.py
@@ -107,6 +107,20 @@ def remove_unread_label(message_id):
         logger.exception("Failed to remove unread label", message_id=message_id)
 
 
+def add_unread_label(message_id):
+    url = f"{current_app.config['SECURE_MESSAGE_URL']}/v2/messages/modify/{message_id}"
+    data = {"label": "UNREAD", "action": "add"}
+
+    logger.debug("Adding message unread label", message_id=message_id)
+    response = requests.put(url, headers={"Authorization": _get_jwt(), "Content-Type": "application/json"}, json=data)
+
+    try:
+        response.raise_for_status()
+        logger.debug("Successfully added unread label", message_id=message_id)
+    except HTTPError:
+        logger.exception("Failed to add unread label", message_id=message_id)
+
+
 def update_close_conversation_status(thread_id, status):
     url = f"{current_app.config['SECURE_MESSAGE_URL']}/v2/threads/{thread_id}"
     data = {"is_closed": status}

--- a/response_operations_ui/static/css/components/messaging.css
+++ b/response_operations_ui/static/css/components/messaging.css
@@ -194,6 +194,7 @@ background: #eee;
   border-top-right-radius: 0.2rem;
   padding-top: 0.333rem;
   padding-bottom: 0.333rem;
+  position: relative;
 }
 
 .secure-message-sent-message-meta__label {
@@ -214,3 +215,14 @@ background: #eee;
   display: block;
   color: #fff;
 }
+
+.secure-message-mark-unread {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: block;
+  color: #fff;
+  margin-right: 0.5em;
+  margin-top: 0.2em;
+}
+.secure-message-mark-unread:hover { color: #fff;}

--- a/response_operations_ui/templates/conversation-view/conversation-view.html
+++ b/response_operations_ui/templates/conversation-view/conversation-view.html
@@ -29,9 +29,9 @@
         {% endif %}
 
         {% if thread_data.is_closed %}
-        <a href="{{ url_for('messages_bp.view_selected_survey', selected_survey=selected_survey, page=page, is_closed='true') }}" class="u-mb-s">< Back</a>
+        <a href="{{ url_for('messages_bp.view_selected_survey', selected_survey=selected_survey, page=page, is_closed='true') }}" class="u-mb-s" id="back-link">< Back</a>
         {% else %}
-        <a href="{{ url_for('messages_bp.view_selected_survey', selected_survey=selected_survey, page=page) }}" class="u-mb-s">< Back</a>
+        <a href="{{ url_for('messages_bp.view_selected_survey', selected_survey=selected_survey, page=page) }}" class="u-mb-s" id="back-link">< Back</a>
         {% endif %}
     </div>
 {% endblock %}

--- a/response_operations_ui/templates/conversation-view/conversation-view.html
+++ b/response_operations_ui/templates/conversation-view/conversation-view.html
@@ -28,10 +28,6 @@
             {% include 'conversation-view/cv-reopen-form.html' %}
         {% endif %}
 
-        {% if thread_data.is_closed %}
-        <a href="{{ url_for('messages_bp.view_selected_survey', selected_survey=selected_survey, page=page, is_closed='true') }}" class="u-mb-s" id="back-link">< Back</a>
-        {% else %}
-        <a href="{{ url_for('messages_bp.view_selected_survey', selected_survey=selected_survey, page=page) }}" class="u-mb-s" id="back-link">< Back</a>
-        {% endif %}
+        {% include 'conversation-view/cv-back-link.html' %}
     </div>
 {% endblock %}

--- a/response_operations_ui/templates/conversation-view/cv-back-link.html
+++ b/response_operations_ui/templates/conversation-view/cv-back-link.html
@@ -1,5 +1,5 @@
 {% if thread_data.is_closed %}
-<a href="{{ url_for('messages_bp.view_selected_survey', selected_survey=selected_survey, page=page, is_closed='true') }}" class="u-mb-s">< Back</a>
+<a href="{{ url_for('messages_bp.view_selected_survey', selected_survey=selected_survey, page=page, is_closed='true') }}" class="u-mb-s" id="back-link">< Back</a>
 {% else %}
-<a href="{{ url_for('messages_bp.view_selected_survey', selected_survey=selected_survey, page=page) }}" class="u-mb-s">< Back</a>
+<a href="{{ url_for('messages_bp.view_selected_survey', selected_survey=selected_survey, page=page) }}" class="u-mb-s" id="back-link">< Back</a>
 {% endif %}

--- a/response_operations_ui/templates/conversation-view/cv-message-block.html
+++ b/response_operations_ui/templates/conversation-view/cv-message-block.html
@@ -14,6 +14,13 @@
             Sent:
             <span name="sm-sent-date" id="sm-sent-date-{{ loop.index }}" style="display:inline;">{{ message.get('sent_date') }}</span>
         </span>
+        {% if loop.last %}
+          {% if show_mark_unread == True %}
+            <a class="secure-message-mark-unread" id="sm-mark-as-unread"
+               href={{ url_for('messages_bp.mark_message_unread',
+               message_id=message.message_id, from=message.from, to=message.to) }}>Mark as unread</a>
+          {% endif %}
+        {% endif %}
     </div>
     <div class="secure-message-sent-message-body mars">
         <span style="white-space:pre-line" id="conversation-message-body-{{ loop.index }}" name="conversation-message-body">{{ message.get('body') }}</span>


### PR DESCRIPTION
# Motivation and Context
The requirement was to allow the internal users to be able to mark a message as unread a proxy for further work required . 

# What has changed
The use cases need some explaining. We have a mark as unread link available on the last message in a conversation from a respondent. This only shows if the message was sent to GROUP or to the specific internal user who is looking at the message. IF that link shows then the internal user can select it to mark the message as unread and return to the list of conversations.

There is also a pair of back links on the page. In earlier versions pressing these would return the user to the conversation view and mark the message as read. Now this has slightly different functionality. If the message was sent to group or to the internal user who is logged in then pressing back will mark the message as read. If however the message went to specific internal user and that is NOT the logged in user then pressing back does not mark the message as read.

# How to test?
There are acceptance tests that cover the scenarios but its probably better to manually test these in this repo. 

From frontstage send a message to ONS. This will be sent to group , meaning that any internal user should be able to mark it as unread.  Log into response ops , look at the message and verify that mark as unread label is available . Click it and go the the conversation view . Note message is no longer marked in bold with a dot for unread. Go back into it and select mark unread. Now in the conversation view it is shown as unread. 

When the mark as unread link is selected then on returning to the conversation view you should see a flash message Message from <msg_from> to <msg_to> marked as unread

Log out as this user and log in as another user. ( get the name from public.users table for uaa I think) 
repeat as for the first user and verify this other user can mark as unread etc) . Now using this second user reply to the message . 

On frontstage reply to this message ( simulating a respondent replying to a message from the ONS which now is sent to a specific user ) .

In response ops , still as the second user , verify that you see the mark as unread , press mark as unread to go into the message . Then press BACK and verify that the message now shows read . Go back into the message again and select mark as unread - ready for the next user checks .

Now log in again as the first user . You should see the message in the conversation list . But you should not see the mark as unread link when you open it and pressing back does not mark the message as read.

You should, be able to repeat this switching between users and you should only see mark as unread if a message was sent to GROUP (i.e a new message from respondent) or if a message was sent specifically to the internal user ( i.e respondent replied to a message from that internal user) 

Note: There is a bug here that has been here a while, a ticket has been raised. If an internal user starts a conversation, and they log out and back in again they can no longer see that conversation. 


# Links
https://trello.com/c/Bvakzk6d

# Screenshots (if appropriate):
