### PR TITLE
Fix for no messages in my conversations

### DIFF
--- a/response_operations_ui/templates/messages.html
+++ b/response_operations_ui/templates/messages.html
@@ -64,7 +64,7 @@
         {% if not messages %}
           {% if is_closed %}
           <p>No closed conversations</p>
-          {% elif my_conversations == true %}
+          {% elif my_conversations == 'true' %}
           <p>There are currently no messages</p>
           {% else %}
           <p>No new conversations</p>


### PR DESCRIPTION
# Motivation and Context
my conversations was showing wrong message when no conversations and in my_messages

# What has changed
Changed the conditional operator in messages.html to select teh correct message 

# How to test?
Run acceptance tests , or fire up response ops ui with no messages and navigate to my_messages
check that     'There are currently no messages' is displayed
 
 