### PR TITLE
Return to page when unread

### DIFF
--- a/response_operations_ui/templates/conversation-view/cv-message-block.html
+++ b/response_operations_ui/templates/conversation-view/cv-message-block.html
@@ -18,7 +18,7 @@
           {% if show_mark_unread == True %}
             <a class="secure-message-mark-unread" id="sm-mark-as-unread"
                href="{{ url_for('messages_bp.mark_message_unread',
-               message_id=message.message_id, from=message.from, to=message.to) }}">Mark as unread</a>
+               message_id=message.message_id, from=message.from, to=message.to, page=page) }}">Mark as unread</a>
           {% endif %}
         {% endif %}
     </div>

--- a/response_operations_ui/templates/conversation-view/cv-message-block.html
+++ b/response_operations_ui/templates/conversation-view/cv-message-block.html
@@ -18,7 +18,7 @@
           {% if show_mark_unread == True %}
             <a class="secure-message-mark-unread" id="sm-mark-as-unread"
                href="{{ url_for('messages_bp.mark_message_unread',
-               message_id=message.message_id, from=message.from, to=message.to, page=page) }}">Mark as unread</a>
+               message_id=message.message_id, from=message.from, to=message.to, page=page, my_conversations=my_conversations) }}">Mark as unread</a>
           {% endif %}
         {% endif %}
     </div>

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -6,7 +6,7 @@ from distutils.util import strtobool
 
 from flask import Blueprint, flash, g, Markup, render_template, request, redirect, session, url_for
 from flask_login import login_required, current_user
-from flask_paginate import get_parameter, Pagination
+from flask_paginate import Pagination
 from structlog import wrap_logger
 
 from config import FDI_LIST

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -136,9 +136,9 @@ def view_conversation(thread_id):
 @login_required
 def mark_message_unread(message_id):
 
-    msg_from = request.args.get(get_parameter('from'), default="", type=str)
-    msg_to = request.args.get(get_parameter('to'), default="", type=str)
-    my_conversations = request.args.get(get_parameter('my_conversations', default='false'))
+    msg_from = request.args.get('from', default="", type=str)
+    msg_to = request.args.get('to', default="", type=str)
+    my_conversations = request.args.get('my_conversations', default='false')
 
     message_controllers.add_unread_label(message_id)
 
@@ -201,9 +201,9 @@ def view_selected_survey(selected_survey):
         else:
             survey_id = _get_survey_id(selected_survey)
 
-        page = request.args.get(get_parameter('page'), default=1, type=int)
-        limit = request.args.get(get_parameter('limit'), default=10, type=int)
-        flash_message = request.args.get(get_parameter('flash_message'), default="", type=str)
+        page = request.args.get('page', default=1, type=int)
+        limit = request.args.get('limit', default=10, type=int)
+        flash_message = request.args.get('flash_message', default="", type=str)
 
         is_closed = request.args.get('is_closed', default='false')
         my_conversations = request.args.get('my_conversations', default='false')

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -138,12 +138,13 @@ def mark_message_unread(message_id):
 
     msg_from = request.args.get(get_parameter('from'), default="", type=str)
     msg_to = request.args.get(get_parameter('to'), default="", type=str)
+    my_conversations = request.args.get(get_parameter('my_conversations', default='false'))
 
     message_controllers.add_unread_label(message_id)
 
     marked_unread_message = f"Message from {msg_from} to {msg_to} marked unread"
 
-    return _view_select_survey(marked_unread_message)
+    return _view_select_survey(marked_unread_message, my_conversations)
 
 
 @messages_bp.route('/', methods=['GET'])
@@ -152,7 +153,7 @@ def view_select_survey():
     return _view_select_survey()
 
 
-def _view_select_survey(marked_unread_message=""):
+def _view_select_survey(marked_unread_message="", my_conversations="false"):
     try:
         selected_survey = session["messages_survey_selection"]
     except KeyError:
@@ -160,7 +161,7 @@ def _view_select_survey(marked_unread_message=""):
 
     return redirect(url_for("messages_bp.view_selected_survey",
                             selected_survey=selected_survey, page=request.args.get('page'),
-                            flash_message=marked_unread_message))
+                            flash_message=marked_unread_message, my_conversations=my_conversations))
 
 
 @messages_bp.route('/select-survey', methods=['GET', 'POST'])


### PR DESCRIPTION
# Motivation and Context
When pressing mark unread , the user was returned to the incorrect page 

# What has changed
Added page to url to return to correct page , and my_conversations to go to the correct tab

# How to test?
Have multiple messages ( more than 1 page) .Access messages and press mark unread . Make sure it returns to correct page and tab 
 