### PR TITLE
Fix majority of test warnings

### DIFF
--- a/response_operations_ui/common/token_decoder.py
+++ b/response_operations_ui/common/token_decoder.py
@@ -13,6 +13,7 @@ def decode_access_token(access_token):
     uaa_public_key = get_uaa_public_key()
     decoded_jwt = jwt.decode(
         access_token,
+        algorithms=['HS256'],
         key=uaa_public_key,
         audience='response_operations',
         leeway=10

--- a/response_operations_ui/views/errors.py
+++ b/response_operations_ui/views/errors.py
@@ -35,7 +35,7 @@ def update_details_exception(error=None):
 
 @error_bp.app_errorhandler(401)
 def handle_authentication_error(error):
-    logger.warn('Authentication failed')
+    logger.warning('Authentication failed')
     flash('Incorrect username or password', category='failed_authentication')
     return redirect(url_for('sign_in_bp.sign_in'))
 


### PR DESCRIPTION
The unit tests had over 100 warnings when run.  This reduces it down to 5.

## How to test
- Run the unit tests (`make test`) and the python tests should have 5 warnings.