### PR TITLE
Use correct algorithm for uaa jwt

### DIFF
--- a/response_operations_ui/common/token_decoder.py
+++ b/response_operations_ui/common/token_decoder.py
@@ -13,7 +13,6 @@ def decode_access_token(access_token):
     uaa_public_key = get_uaa_public_key()
     decoded_jwt = jwt.decode(
         access_token,
-        algorithms=['RS256'],
         key=uaa_public_key,
         audience='response_operations',
         leeway=10

--- a/response_operations_ui/common/token_decoder.py
+++ b/response_operations_ui/common/token_decoder.py
@@ -13,7 +13,7 @@ def decode_access_token(access_token):
     uaa_public_key = get_uaa_public_key()
     decoded_jwt = jwt.decode(
         access_token,
-        algorithms=['HS256'],
+        algorithms=['RS256'],
         key=uaa_public_key,
         audience='response_operations',
         leeway=10


### PR DESCRIPTION
Fixes the warning fix from earlier.   For now we can live with the deprecation warning during the unit tests as changing it to be correct causes the unit tests to fail in a 'non-trivial to fix' way.

## How to test
- Fire up this service and attempt to sign in.  You should no longer see an error ending in `raise InvalidAlgorithmError('The specified alg value is not allowed')\njwt.exceptions.InvalidAlgorithmError: The specified alg value is not allowed"`