### PR TITLE
Suppress testfixtures warning

### DIFF
--- a/tests/test_logger_config.py
+++ b/tests/test_logger_config.py
@@ -2,14 +2,21 @@ import logging
 import os
 import unittest
 
+import pytest
 from structlog import wrap_logger
 from testfixtures import log_capture
 
 from response_operations_ui.logger_config import logger_initial_config
 
+# Supresses the warnings that won't be fixed by the project maintainer until Python 2 is deprecated.
+# More information about this can be found https://github.com/Simplistix/testfixtures/pull/54
+# Remove this and the filterwarnings if this problem ever gets fixed.
+testfixtures_warning = "inspect.getargspec()"
+
 
 class TestLoggerConfig(unittest.TestCase):
 
+    @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
     @log_capture()
     def test_success(self, l):
         os.environ['JSON_INDENT_LOGGING'] = '1'
@@ -21,6 +28,7 @@ class TestLoggerConfig(unittest.TestCase):
                            '\n "level": "error",\n "service": "response-operations-ui"'
         self.assertIn(message_contents, message)
 
+    @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
     @log_capture()
     def test_indent_type_error(self, l):
         os.environ['JSON_INDENT_LOGGING'] = 'abc'
@@ -31,6 +39,7 @@ class TestLoggerConfig(unittest.TestCase):
         self.assertIn('"event": "Test", "trace": "", "span": "", "parent": "",'
                       ' "level": "error", "service": "response-operations-ui"', message)
 
+    @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
     @log_capture()
     def test_indent_value_error(self, l):
         logger_initial_config(service_name='response-operations-ui')


### PR DESCRIPTION
# Motivation and Context
There was a warning in the logger config unit tests that wasn't fixable by us (as the problem is in the library).  Suppressing the warning is reasonable here (where it rarely is okay) because it's being left there intentionally to be backwards compatible with Python 2.

# What has changed
The warning is suppressed in the logger config tests.  This suppression doesn't affect any other warnings.

# How to test?
Unit tests should still pass

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
