### PR TITLE
Fix styling on date fields

### DIFF
--- a/response_operations_ui/templates/create-ce-event.html
+++ b/response_operations_ui/templates/create-ce-event.html
@@ -34,7 +34,6 @@
             <h2 id='error-saving-message' class="u-fs-r--b">Error creating {{event_name}} date</h2>
     {% endif %}
 
-
     {% if date_restriction_text %}
       {% for text in date_restriction_text %}
       <div>
@@ -46,23 +45,20 @@
     <form method="POST" action="{{ url_for('collection_exercise_bp.create_collection_exercise_event', short_name=short_name, period=period, ce_id=ce_id, tag=tag)}}" class="">
       <div class="date-time-editor u-mb-l">
         {{ form.csrf_token }}
-
-        <fieldset class="fieldgroup fieldgroup--date u-mt-l" data-qa="widget-date">
-          <legend class="fieldgroup__title u-fs-r--b">Date</legend>
+        <fieldset class="fieldgroup fieldgroup--inline fieldgroup--date" data-qa="widget-date" role="group">
+          <legend class="fieldgroup__title u-fs-r--b">Please enter a date</legend>
           <div class="fieldgroup__fields">
-            <div class="field field--input field--day">
-              <label class="label u-fs-s--b" id="label-date-range-from-day">Day</label>
-              {{ form.day(size=2, class_="input input--StringField") }}
+            <div class="field field--input">
+              <label class="label u-fs-r" for="date-en-gb-day" data-qa="label-day">Day</label>
+              {{ form.day(id="date-en-gb-day", size=2, class_="input input--text input--StringField input--w-2", type="number") }}
             </div>
-
-            <div class="field field--select field--month">
-              <label class="label u-fs-s--b" id="label-date-range-from-month">Month</label>
-              {{ form.month(class_="input input--select") }}
+            <div class="field field--select">
+              <label class="label u-fs-r" for="date-en-gb-month" data-qa="label-month">Month</label>
+              {{ form.month(id="date-en-gb-month", class_="input input--select input--w-auto") }}
             </div>
-
-            <div class="field field--input field--year">
-              <label class="label u-fs-s--b" id="label-date-range-from-year">Year</label>
-              {{ form.year(class="input input--StringField") }}
+            <div class="field field--input">
+              <label class="label u-fs-r" for="date-en-gb-year" data-qa="label-year">Year</label>
+              {{ form.year(id="date-en-gb-year", class="input input--text input--StringField input--w-4", type="number") }}
             </div>
           </div>
         </fieldset>
@@ -71,13 +67,12 @@
           <legend class="fieldgroup__title u-fs-r--b">Time (Newport)</legend>
           <div class="fieldgroup__fields">
             <div class="field field--select field--hrs">
-              <label class="label u-fs-s--b" id="time-hrs">Hrs</label>
-              {{ form.hour(class_="input input--select input--select__time-hrs") }}
+              <label class="label u-fs-s--b" for="time-select-hrs" id="time-hrs">Hrs</label>
+              {{ form.hour(id="time-select-hrs", class_="input input--select input--select__time-hrs") }}
             </div>
-
             <div class="field field--select field--mins">
-              <label class="label u-fs-s--b" id="time-mins">Mins</label>
-              {{ form.minute(class_="input input--select input--select__time-mins") }}
+              <label class="label u-fs-s--b" for="time-select-mins" id="time-mins">Mins</label>
+              {{ form.minute(id="time-select-mins", class_="input input--select input--select__time-mins") }}
             </div>
           </div>
         </fieldset>

--- a/response_operations_ui/templates/update-event-date.html
+++ b/response_operations_ui/templates/update-event-date.html
@@ -45,23 +45,20 @@
     <form method="POST" class="">
       <div class="date-time-editor u-mb-l">
         {{ form.csrf_token }}
-
-        <fieldset class="fieldgroup fieldgroup--date u-mt-l" data-qa="widget-date">
+        <fieldset class="fieldgroup fieldgroup--inline fieldgroup--date" data-qa="widget-date" role="group">
           <legend class="fieldgroup__title u-fs-r--b">Date</legend>
           <div class="fieldgroup__fields">
-            <div class="field field--input field--day">
-              <label class="label u-fs-s--b" id="label-date-range-from-day">Day</label>
-              {{ form.day(size=2, class_="input input--StringField") }}
+            <div class="field field--input">
+              <label class="label u-fs-r" for="date-en-gb-day" id="label-date-range-from-day" data-qa="label-day">Day</label>
+              {{ form.day(id="date-en-gb-day", size=2, class_="input input--text input--StringField input--w-2", type="number") }}
             </div>
-
-            <div class="field field--select field--month">
-              <label class="label u-fs-s--b" id="label-date-range-from-month">Month</label>
-              {{ form.month(class_="input input--select") }}
+            <div class="field field--select">
+              <label class="label u-fs-r" for="date-en-gb-month" id="label-date-range-from-month" data-qa="label-month">Month</label>
+              {{ form.month(id="date-en-gb-month", class_="input input--select input--w-auto") }}
             </div>
-
-            <div class="field field--input field--year">
-              <label class="label u-fs-s--b" id="label-date-range-from-year">Year</label>
-              {{ form.year(class="input input--StringField") }}
+            <div class="field field--input">
+              <label class="label u-fs-r" for="date-en-gb-year" id="label-date-range-from-year" data-qa="label-year">Year</label>
+              {{ form.year(id="date-en-gb-year", class="input input--text input--StringField input--w-4", type="number") }}
             </div>
           </div>
         </fieldset>
@@ -70,13 +67,13 @@
           <legend class="fieldgroup__title u-fs-r--b">Time (Newport)</legend>
           <div class="fieldgroup__fields">
             <div class="field field--select field--hrs">
-              <label class="label u-fs-s--b" id="time-hrs">Hrs</label>
-              {{ form.hour(class_="input input--select input--select__time-hrs") }}
+              <label class="label u-fs-s--b" for="time-select-hrs" id="time-hrs">Hrs</label>
+              {{ form.hour(id="time-select-hrs", class_="input input--select input--select__time-hrs") }}
             </div>
 
             <div class="field field--select field--mins">
-              <label class="label u-fs-s--b" id="time-mins">Mins</label>
-              {{ form.minute(class_="input input--select input--select__time-mins") }}
+              <label class="label u-fs-s--b" for="time-select-mins" id="time-mins">Mins</label>
+              {{ form.minute(id="time-select-mins", class_="input input--select input--select__time-mins") }}
             </div>
           </div>
         </fieldset>


### PR DESCRIPTION
# Motivation and Context
A previous PR updated the version of the pattern library.  One of the unnoticed things that broke was the formatting of the dates on the create/change business events page.

# What has changed
Just the HTML to deal with the layout of the date box.
Additionally, the labels on the affected have their `for` attribute configured correctly now, so clicking on the label will select the input box.

# How to test?
Look at the create and change business events pages 
 - Surveys -> Pick a survey -> Create collection exercise (Create page)
 - Surveys -> Pick a survey -> Pick a collection exercise -> edit one of the top left fields (Update page)

# Links
https://trello.com/c/Bdu8EYTp
