### PR TITLE
added route to respondent links

### DIFF
--- a/response_operations_ui/common/respondent_utils.py
+++ b/response_operations_ui/common/respondent_utils.py
@@ -29,7 +29,7 @@ def filter_respondents(respondents):
     for respondent in respondents:
         try:
             filtered_respondents.append({
-                'href': '/respondents'+'/respondent-details/' + str(respondent['id']),
+                'href': '/respondents' + '/respondent-details/' + str(respondent['id']),
                 'name': respondent['firstName'] + ' ' + respondent['lastName'],
                 'email': respondent['emailAddress'],
                 'status': status_enum_to_string(respondent['status']),

--- a/response_operations_ui/common/respondent_utils.py
+++ b/response_operations_ui/common/respondent_utils.py
@@ -28,8 +28,9 @@ def filter_respondents(respondents):
     filtered_respondents = []
     for respondent in respondents:
         try:
+            respondent_id = str(respondent['id'])
             filtered_respondents.append({
-                'href': '/respondents' + '/respondent-details/' + str(respondent['id']),
+                'href': f'/respondents/respondent-details/{respondent_id}',
                 'name': respondent['firstName'] + ' ' + respondent['lastName'],
                 'email': respondent['emailAddress'],
                 'status': status_enum_to_string(respondent['status']),

--- a/response_operations_ui/common/respondent_utils.py
+++ b/response_operations_ui/common/respondent_utils.py
@@ -29,7 +29,7 @@ def filter_respondents(respondents):
     for respondent in respondents:
         try:
             filtered_respondents.append({
-                'href': '/respondent-details/' + str(respondent['id']),
+                'href': '/respondents'+'/respondent-details/' + str(respondent['id']),
                 'name': respondent['firstName'] + ' ' + respondent['lastName'],
                 'email': respondent['emailAddress'],
                 'status': status_enum_to_string(respondent['status']),

--- a/tests/common/test_respondent_utils.py
+++ b/tests/common/test_respondent_utils.py
@@ -90,7 +90,7 @@ class TestRespondentUtils(unittest.TestCase):
             'status_class': 'ACTIVE'
         }]
         output = filter_respondents(correct_item)
-        self.assertEqual(output[0]['href'], '/respondent-details/515')
+        self.assertEqual(output[0]['href'], '/respondents/respondent-details/515')
 
     def test_filter_respondents_assembles_name(self):
         correct_item = [{


### PR DESCRIPTION
# Motivation and Context
Was causing 500 errors when clicking on a respondent

# What has changed
Added the /respondents/ route to links

# How to test?
search for a respondent and click on a result, shouldn't error

# Links
https://trello.com/c/M8esqZzO/855-bug-when-finding-a-respondent-by-search-in-resops-clicking-on-the-link-to-their-profile-causes-a-500-error

# Screenshots (if appropriate):
