### PR TITLE
Fix for employment date change event view

### DIFF
--- a/response_operations_ui/common/date_restriction_generator.py
+++ b/response_operations_ui/common/date_restriction_generator.py
@@ -17,7 +17,9 @@ def get_date_restriction_text(tag, events):
         "reminder3": [f"Must be after Second Reminder {_get_event_date_string('reminder2', events)}",
                       f"Must be before Exercise end {_get_event_date_string('exercise_end', events)}"],
         "ref_period_start": [f"Must be before Reference Period end {_get_event_date_string('ref_period_end', events)}"],
-        "ref_period_end": [f"Must be after Reference Period start {_get_event_date_string('ref_period_start', events)}"]
+        "ref_period_end": [f"Must be after Reference Period start "
+                           f"{_get_event_date_string('ref_period_start', events)}"],
+        "employment": None
     }
 
     if _get_event_date_string('reminder2', events):


### PR DESCRIPTION
# Motivation and Context
A recent [PR](https://github.com/ONSdigital/response-operations-ui/pull/301) that went in to fix the collection exercise events had broken the employment date view. When clicking to change the employment date, it would result in a 500 page appearing. This PR adds it to the date restriction with it returning None
# What has changed
- Added `employment` to the date restriction generator

# How to test?
- Run unit tests
- Create and update the employment date on a collection exercise
- Run the acceptance tests

