### PR TITLE
Removed reliance on node-sass and swapped to dart sass

### DIFF
--- a/gulp/tasks/scsscompile.js
+++ b/gulp/tasks/scsscompile.js
@@ -4,6 +4,11 @@ const gulpSass = require('gulp-sass');
 const gulpAutoPrefixer = require('gulp-autoprefixer');
 const gulpCleanCss = require('gulp-clean-css');
 const gulpSourcemaps = require('gulp-sourcemaps');
+const dartSass = require('sass');
+const Fiber = require('fibers');
+
+// Forces gulp-sass to use installed node sass instead of dependency
+gulpSass.compiler = dartSass;
 
 function taskFunction() {
     const gulp = this.gulp;
@@ -20,7 +25,11 @@ function taskFunction() {
 
     return gulp.src(`${SCSS_DIR}/main.scss`)
         .pipe(gulpSourcemaps.init())
-        .pipe(gulpSass())
+        .pipe(
+            gulpSass({
+                fiber: Fiber
+            }).on('error', gulpSass.logError)
+        )
         .pipe(gulpAutoPrefixer())
         .pipe(gulpCleanCss())
         .pipe(gulpSourcemaps.write('.'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1932,6 +1932,11 @@
                 }
             }
         },
+        "chownr": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+            "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+        },
         "ci-info": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -2164,9 +2169,9 @@
             }
         },
         "commander": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-            "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
             "dev": true,
             "optional": true
         },
@@ -2353,18 +2358,6 @@
             "requires": {
                 "lru-cache": "^4.0.1",
                 "which": "^1.2.9"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "4.1.5",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-                    "dev": true,
-                    "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
-                    }
-                }
             }
         },
         "crypto-browserify": {
@@ -2695,6 +2688,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
             "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+            "dev": true
+        },
+        "detect-libc": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
             "dev": true
         },
         "detect-newline": {
@@ -3574,6 +3573,15 @@
                 "bser": "^2.0.0"
             }
         },
+        "fibers": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.1.tgz",
+            "integrity": "sha512-H79EJn7DMWXk48ygmC82bMP8KNcFBZF1CPfwBpYF6cO85hGWoIrlu7eyX9ayxfjP9Nsl0JXxdI6fpYU4DWVw2w==",
+            "dev": true,
+            "requires": {
+                "detect-libc": "^1.0.3"
+            }
+        },
         "figures": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -3778,6 +3786,14 @@
                 "map-cache": "^0.2.2"
             }
         },
+        "fs-minipass": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+            "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+            "requires": {
+                "minipass": "^2.2.1"
+            }
+        },
         "fs-mkdirp-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -3814,7 +3830,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -3835,12 +3852,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3855,17 +3874,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -3982,7 +4004,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -3994,6 +4017,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -4008,6 +4032,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -4015,12 +4040,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -4039,6 +4066,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -4119,7 +4147,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -4131,6 +4160,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -4216,7 +4246,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -4252,6 +4283,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -4271,6 +4303,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -4314,12 +4347,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -4333,14 +4368,6 @@
                 "inherits": "~2.0.0",
                 "mkdirp": ">=0.5 0",
                 "rimraf": "2"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.1.15",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-                    "dev": true
-                }
             }
         },
         "function-bind": {
@@ -4377,6 +4404,15 @@
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true
                 }
+            }
+        },
+        "gaze": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+            "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+            "dev": true,
+            "requires": {
+                "globule": "^1.0.0"
             }
         },
         "get-assigned-identifiers": {
@@ -4620,6 +4656,17 @@
             "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
             "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
             "dev": true
+        },
+        "globule": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+            "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+            "dev": true,
+            "requires": {
+                "glob": "~7.1.1",
+                "lodash": "~4.17.10",
+                "minimatch": "~3.0.2"
+            }
         },
         "glogg": {
             "version": "1.0.2",
@@ -5086,9 +5133,9 @@
             }
         },
         "handlebars": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-            "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+            "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
             "dev": true,
             "requires": {
                 "neo-async": "^2.6.0",
@@ -5531,6 +5578,11 @@
                 "xtend": "^4.0.0"
             }
         },
+        "install": {
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/install/-/install-0.12.2.tgz",
+            "integrity": "sha512-+7thTb4Rpvs9mnlhHKGZFJbGOO6kyMgy+gg0sgM5vFzIFK0wrCYXqdlaM71Bi289DTuPHf61puMFsaZBcwDIrg=="
+        },
         "interpret": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
@@ -5931,26 +5983,168 @@
             "dev": true
         },
         "istanbul-api": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
-            "integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.7.tgz",
+            "integrity": "sha512-LYTOa2UrYFyJ/aSczZi/6lBykVMjCCvUmT64gOe+jPZFy4w6FYfPGqFT2IiQ2BxVHHDOvCD7qrIXb0EOh4uGWw==",
             "dev": true,
             "requires": {
-                "async": "^2.6.1",
-                "compare-versions": "^3.2.1",
+                "async": "^2.6.2",
+                "compare-versions": "^3.4.0",
                 "fileset": "^2.0.3",
-                "istanbul-lib-coverage": "^2.0.3",
-                "istanbul-lib-hook": "^2.0.3",
-                "istanbul-lib-instrument": "^3.1.0",
-                "istanbul-lib-report": "^2.0.4",
-                "istanbul-lib-source-maps": "^3.0.2",
-                "istanbul-reports": "^2.1.1",
-                "js-yaml": "^3.12.0",
-                "make-dir": "^1.3.0",
+                "istanbul-lib-coverage": "^2.0.5",
+                "istanbul-lib-hook": "^2.0.7",
+                "istanbul-lib-instrument": "^3.3.0",
+                "istanbul-lib-report": "^2.0.8",
+                "istanbul-lib-source-maps": "^3.0.6",
+                "istanbul-reports": "^2.2.5",
+                "js-yaml": "^3.13.1",
+                "make-dir": "^2.1.0",
                 "minimatch": "^3.0.4",
                 "once": "^1.4.0"
             },
             "dependencies": {
+                "@babel/generator": {
+                    "version": "7.4.4",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+                    "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.4",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.11",
+                        "source-map": "^0.5.0",
+                        "trim-right": "^1.0.1"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.4.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+                    "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.4.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+                    "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.4.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+                    "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.4.4",
+                        "@babel/types": "^7.4.4"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.4.4",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+                    "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/generator": "^7.4.4",
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-split-export-declaration": "^7.4.4",
+                        "@babel/parser": "^7.4.4",
+                        "@babel/types": "^7.4.4",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.11"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.4.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+                    "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.11",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "istanbul-lib-coverage": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+                    "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+                    "dev": true
+                },
+                "istanbul-lib-instrument": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+                    "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/generator": "^7.4.0",
+                        "@babel/parser": "^7.4.3",
+                        "@babel/template": "^7.4.0",
+                        "@babel/traverse": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "istanbul-lib-coverage": "^2.0.5",
+                        "semver": "^6.0.0"
+                    }
+                },
+                "istanbul-lib-source-maps": {
+                    "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+                    "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.1.1",
+                        "istanbul-lib-coverage": "^2.0.5",
+                        "make-dir": "^2.1.0",
+                        "rimraf": "^2.6.3",
+                        "source-map": "^0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                            "dev": true
+                        }
+                    }
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "5.7.0",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+                            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
                 "once": {
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5959,6 +6153,27 @@
                     "requires": {
                         "wrappy": "1"
                     }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "semver": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+                    "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+                    "dev": true
                 }
             }
         },
@@ -5969,9 +6184,9 @@
             "dev": true
         },
         "istanbul-lib-hook": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
-            "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+            "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
             "dev": true,
             "requires": {
                 "append-transform": "^1.0.0"
@@ -6001,16 +6216,44 @@
             }
         },
         "istanbul-lib-report": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
-            "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+            "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "^2.0.3",
-                "make-dir": "^1.3.0",
-                "supports-color": "^6.0.0"
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "supports-color": "^6.1.0"
             },
             "dependencies": {
+                "istanbul-lib-coverage": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+                    "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+                    "dev": true
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+                    "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+                    "dev": true
+                },
                 "supports-color": {
                     "version": "6.1.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -6059,12 +6302,12 @@
             }
         },
         "istanbul-reports": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
-            "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.5.tgz",
+            "integrity": "sha512-ilCSjE6f7elNIRxnSnIhnOpXdf3ryUT7Zkl+TaADItM638SWXjfNW40cujZCIjex4g4DTkzIy9kzwkaLruB50Q==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.1.0"
+                "handlebars": "^4.1.2"
             }
         },
         "jest": {
@@ -6846,9 +7089,9 @@
             }
         },
         "js-base64": {
-            "version": "2.4.9",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
-            "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+            "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
             "dev": true
         },
         "js-tokens": {
@@ -6858,9 +7101,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-            "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -7251,12 +7494,6 @@
             "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
             "dev": true
         },
-        "lodash.assign": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-            "dev": true
-        },
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -7305,12 +7542,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
             "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
-            "dev": true
-        },
-        "lodash.mergewith": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-            "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
             "dev": true
         },
         "lodash.restparam": {
@@ -7384,6 +7615,16 @@
             "requires": {
                 "currently-unhandled": "^0.4.1",
                 "signal-exit": "^3.0.0"
+            }
+        },
+        "lru-cache": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "dev": true,
+            "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "lru-queue": {
@@ -7707,6 +7948,30 @@
                 "is-plain-obj": "^1.1.0"
             }
         },
+        "minipass": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+            "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+            "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+                }
+            }
+        },
+        "minizlib": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+            "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+            "requires": {
+                "minipass": "^2.2.1"
+            }
+        },
         "mixin-deep": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
@@ -7732,7 +7997,6 @@
             "version": "0.5.1",
             "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             },
@@ -7740,8 +8004,7 @@
                 "minimist": {
                     "version": "0.0.8",
                     "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 }
             }
         },
@@ -7840,7 +8103,8 @@
             "version": "2.11.1",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
             "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -7905,40 +8169,22 @@
                 "which": "1"
             },
             "dependencies": {
-                "glob": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "4.1.15",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
                 "semver": {
                     "version": "5.3.0",
                     "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                     "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                     "dev": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                    "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "*",
+                        "fstream": "^1.0.2",
+                        "inherits": "2"
+                    }
                 }
             }
         },
@@ -7993,9 +8239,9 @@
             }
         },
         "node-sass": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.10.0.tgz",
-            "integrity": "sha512-fDQJfXszw6vek63Fe/ldkYXmRYK/QS6NbvM3i5oEo9ntPDy4XX7BcKZyTKv+/kSSxRtXXc7l+MSwEmYc0CSy6Q==",
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
+            "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
             "dev": true,
             "requires": {
                 "async-foreach": "^0.1.3",
@@ -8005,12 +8251,10 @@
                 "get-stdin": "^4.0.1",
                 "glob": "^7.0.3",
                 "in-publish": "^2.0.0",
-                "lodash.assign": "^4.2.0",
-                "lodash.clonedeep": "^4.3.2",
-                "lodash.mergewith": "^4.6.0",
+                "lodash": "^4.17.11",
                 "meow": "^3.7.0",
                 "mkdirp": "^0.5.1",
-                "nan": "^2.10.0",
+                "nan": "^2.13.2",
                 "node-gyp": "^3.8.0",
                 "npmlog": "^4.0.0",
                 "request": "^2.88.0",
@@ -8038,54 +8282,11 @@
                         "supports-color": "^2.0.0"
                     }
                 },
-                "gaze": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-                    "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-                    "dev": true,
-                    "requires": {
-                        "globule": "^1.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "globule": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-                    "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "~7.1.1",
-                        "lodash": "~4.17.10",
-                        "minimatch": "~3.0.2"
-                    }
-                },
-                "lodash": {
-                    "version": "4.17.11",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                "nan": {
+                    "version": "2.13.2",
+                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+                    "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
                     "dev": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
                 },
                 "supports-color": {
                     "version": "2.0.0",
@@ -9657,8 +9858,7 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safe-regex": {
             "version": "1.1.0",
@@ -9692,6 +9892,15 @@
                 "walker": "~1.0.5"
             }
         },
+        "sass": {
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.20.1.tgz",
+            "integrity": "sha512-BnCawee/L5kVG3B/5Jg6BFwASqUwFVE6fj2lnkVuSXDgQ7gMAhY9a2yPeqsKhJMCN+Wgx0r2mAW7XF/aTF5qtA==",
+            "dev": true,
+            "requires": {
+                "chokidar": "^2.0.0"
+            }
+        },
         "sass-graph": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
@@ -9702,37 +9911,6 @@
                 "lodash": "^4.0.0",
                 "scss-tokenizer": "^0.2.3",
                 "yargs": "^7.0.0"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "lodash": {
-                    "version": "4.17.11",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                }
             }
         },
         "sax": {
@@ -10944,14 +11122,24 @@
             }
         },
         "tar": {
-            "version": "2.2.1",
-            "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-            "dev": true,
+            "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+            "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+                }
             }
         },
         "test-exclude": {
@@ -11322,31 +11510,6 @@
             "dev": true,
             "requires": {
                 "glob": "^7.1.2"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                }
             }
         },
         "tslib": {
@@ -11392,13 +11555,13 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.1.tgz",
-            "integrity": "sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==",
+            "version": "3.5.11",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
+            "integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
             "dev": true,
             "optional": true,
             "requires": {
-                "commander": "~2.19.0",
+                "commander": "~2.20.0",
                 "source-map": "~0.6.1"
             },
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "chalk": "^2.4.1",
         "eslint": "^5.10.0",
         "eslint-config-google": "^0.11.0",
+        "fibers": "^4.0.1",
         "gulp": ">=4.0.0",
         "gulp-autoprefixer": "^6.0.0",
         "gulp-clean-css": "^4.0.0",
@@ -56,7 +57,12 @@
         "jest": "^24.5.0",
         "jest-cli": "^24.5.0",
         "lodash": "^4.17.11",
+        "sass": "^1.20.1",
         "stylelint": "^9.9.0",
         "stylelint-config-standard": "^18.2.0"
+    },
+    "dependencies": {
+        "install": "^0.12.2",
+        "tar": "^4.4.8"
     }
 }


### PR DESCRIPTION
# Motivation and Context
Pipeline had broken due to a reliance by an NPM package (`gulp-sass`) on a no-longer-existent binary hosted on Github.

Have moved to a non-compiled version, because there is a current security advisory to do with the `tar` package, which is pinned by `node-gyp`.  To mitigate this, I have taken out compiled steps from the NPM packages, so that `node-gyp` will not be used.

Once `node-gyp` address their reliance on `tar` @2.2.8 (current version is 4.4.8, and is the first that removes the vulnerability), we can consider using compiled bindings.

# What has changed
* `node-sass` module removed
* `sass` module (dart-sass) added
* `sass` specified as `gulp-sass` compiler
* `fibers` module used to speed up compilation loss.

# How to test?
Ensure that you can still run gulp tasks, particularly `scss`, and `build`.
Ensure that you can still run `make build` with success.

# Links
* https://www.npmjs.com/advisories/803
* https://trello.com/c/tLmUCrGE
