### PR TITLE
fixed error to make sure button turns green

### DIFF
--- a/response_operations_ui/assets/tests/validate-ci.test.js
+++ b/response_operations_ui/assets/tests/validate-ci.test.js
@@ -124,8 +124,8 @@ describe('Collection Instrument File Validation', () => {
                 type: 'invalid file type'
             });
 
-            expect(validateCI.__private__.nodeClassesChange.mock.calls.length).toEqual(6);
-            expect(validateCI.__private__.nodeClassesChange.mock.calls.map(i => i[2])).toEqual(['add', 'add', 'remove', 'remove', 'remove', 'remove']);  
+            expect(validateCI.__private__.nodeClassesChange.mock.calls.length).toEqual(9);
+            expect(validateCI.__private__.nodeClassesChange.mock.calls.map(i => i[2])).toEqual(['add', 'add', 'remove', 'remove', 'add', 'remove', 'add', 'remove', 'add']);
         });
 
         test('it should hide panel if file type is correct', () => {
@@ -133,8 +133,8 @@ describe('Collection Instrument File Validation', () => {
                 type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
             });
 
-            expect(validateCI.__private__.nodeClassesChange.mock.calls.length).toEqual(6);
-            expect(validateCI.__private__.nodeClassesChange.mock.calls.map(i => i[2])).toEqual(['remove', 'remove', 'add', 'add', 'add', 'add']);
+            expect(validateCI.__private__.nodeClassesChange.mock.calls.length).toEqual(9);
+            expect(validateCI.__private__.nodeClassesChange.mock.calls.map(i => i[2])).toEqual(['remove', 'remove', 'add', 'add', 'remove', 'add', 'remove', 'add', 'remove']);
         });
     });
 

--- a/response_operations_ui/static/js/validate-ci.js
+++ b/response_operations_ui/static/js/validate-ci.js
@@ -35,6 +35,7 @@ window.validateCI = {
 
         this.__private__.arrayLikeToArray(errorPanelBody.querySelectorAll('p')).forEach(el => {
             this.__private__.nodeClassesChange(el, ['hidden'], contraAction);
+            this.__private__.nodeClassesChange(button, ['unready'], mainAction);
         });
     },
 


### PR DESCRIPTION
# Motivation and Context
Previously, when a user selects an eq collection instrument file on a survey in response operations ui, the button to add the collection instrument would stay grey, and the mouse cursor would tell the user that the button cannot be pressed, even though the user actually can press the button. This PR adds a line of code to make the button turn green and to tell the user that it can be pressed.

# What has changed
* Added a line of code in validate-ci.js to change the button's displayed colour when a valid collection instrument is selected.
* Adjusted the code in the validate-ci.test.js file so that the tests for showing/hiding the panel based on whether or not the file type is correct expect the right values.

# How to test?
* On response operations ui (localhost:8085), log in, then go "surveys", then click on a survey, then a collection exercise.
* Scroll down to collection instruments and add a valid file. The button should turn green.
* If you try to add an invalid file, the button should turn grey.
* In the terminal, the tests should pass when the `make test` command is run.

# Links
[Trello card](https://trello.com/c/7L5xF3ny)