### PR TITLE
Remove edit from user period ce

### DIFF
--- a/response_operations_ui/forms.py
+++ b/response_operations_ui/forms.py
@@ -84,7 +84,7 @@ class EditContactDetailsForm(FlaskForm):
 
 
 class EditCollectionExerciseDetailsForm(FlaskForm):
-    user_description = StringField('user_description')
+    user_description = HiddenField('user_description')
     period = IntegerField('period')
     collection_exercise_id = HiddenField('collection_exercise_id')
     hidden_survey_id = HiddenField('hidden_survey_id')

--- a/response_operations_ui/templates/collection_exercise/ce-reference-information.html
+++ b/response_operations_ui/templates/collection_exercise/ce-reference-information.html
@@ -21,13 +21,8 @@
       <td class="table--cell tbl-ce-">
         Shown to respondent as
       </td>
-      <td class="table--cell tbl-ce-" name="user-description">
+      <td class="table--cell tbl-ce-" name="user-description" colspan="2">
         {{ce.userDescription}}
-      </td>
-      <td class="table--cell tbl-ce-">
-        <form action="{{ url_for('collection_exercise_bp.view_collection_exercise_details', short_name=survey.shortName, period=ce.exerciseRef, surveyRef=survey.surveyRef)}}" method="get">
-          <a class="edit-icon" href=# id="edit-collection-exercise-user-description" onclick="this.parentNode.submit()"></a>
-        </form>
       </td>
     </tr>
 

--- a/response_operations_ui/templates/edit-collection-exercise-details.html
+++ b/response_operations_ui/templates/edit-collection-exercise-details.html
@@ -39,14 +39,8 @@
           {{ form.period(class_="input input--text", id='period', required=required, maxlength=6, value=period) }}
         </div>
         {% endif %}
-        <div class="field u-mb-l">
-          <span class="u-vh">Current value: </span>
-          </span>
+          {{ form.user_description(value=user_description, id='user_description') }}
           {{ form.collection_exercise_id(value=collection_exercise_id, id='collection_exercise_id') }}
-        </div>
-        <div class="field u-mb-l">
-          <span class="u-vh">Current value: </span>
-          </span>
           {{ form.hidden_survey_id(value=survey_id, id='survey_id') }}
         </div>
       </div>

--- a/response_operations_ui/templates/edit-collection-exercise-details.html
+++ b/response_operations_ui/templates/edit-collection-exercise-details.html
@@ -40,12 +40,6 @@
         </div>
         {% endif %}
         <div class="field u-mb-l">
-          <label class="label" for="user_description">
-            Period as shown to respondent
-          </label>
-          {{ form.user_description(class_="input input--text", id='user_description', required=required, maxlength=254, value=user_description) }}
-        </div>
-        <div class="field u-mb-l">
           <span class="u-vh">Current value: </span>
           </span>
           {{ form.collection_exercise_id(value=collection_exercise_id, id='collection_exercise_id') }}

--- a/response_operations_ui/templates/edit-collection-exercise-details.html
+++ b/response_operations_ui/templates/edit-collection-exercise-details.html
@@ -39,14 +39,13 @@
           {{ form.period(class_="input input--text", id='period', required=required, maxlength=6, value=period) }}
         </div>
         {% endif %}
-          {{ form.user_description(value=user_description, id='user_description') }}
-          {{ form.collection_exercise_id(value=collection_exercise_id, id='collection_exercise_id') }}
-          {{ form.hidden_survey_id(value=survey_id, id='survey_id') }}
+        {{ form.user_description(value=user_description, id='user_description') }}
+        {{ form.collection_exercise_id(value=collection_exercise_id, id='collection_exercise_id') }}
+        {{ form.hidden_survey_id(value=survey_id, id='survey_id') }}
+        <button class="btn u-mb-s" id="save-btn">Save</button>
+        <div>
+          <a id="cancel-btn" href="{{ url_for('collection_exercise_bp.view_collection_exercise', short_name=short_name, period=period) }}">Cancel</a>
         </div>
-      </div>
-      <button class="btn u-mb-s" id="save-btn">Save</button>
-      <div>
-        <a id="cancel-btn" href="{{ url_for('collection_exercise_bp.view_collection_exercise', short_name=short_name, period=period) }}">Cancel</a>
       </div>
     </form>
   </div>


### PR DESCRIPTION
# Motivation and Context
Remove edit capability from the user description of a collex, because editing it doesn't work

# What has changed
Edit button removed
Edit field removed and replaced with hidden field
Markup changed to only feature one visible field

# How to test?
Spin up resops, ensure you can create a collex, but only edit the period, not the 'period the user sees'.
Make sure tests pass.

# Links
https://trello.com/c/aYtYMH8O
