### PR TITLE
Increase number of CE's shown on RU page to 12.

### DIFF
--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -61,7 +61,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for ce in survey.collection_exercises[:4] %}
+              {% for ce in survey.collection_exercises[:12] %}
               <tr class="table--row">
                 <td name="tbl-ce-period" class="table--cell">
                   {{ ce.exerciseRef }}


### PR DESCRIPTION

# Motivation and Context
Business previously had to make service desk requests to changes to CE's from more than 4 months ago

# What has changed
System was already pulling all the surveys and limiting the display in the template to the most recent 4, increased it to 12. (no performance difference)

# How to test?
After running the AT's you can add this line on a local running resops on line 55 in reporting_units.py to get 12 surveys loaded:
sorted_linked_surveys[0]['collection_exercises'] = sorted_linked_surveys[0]['collection_exercises'] * 6

# Links
https://trello.com/c/ocsILSfS/1068-12-months-on-response-ops-for-ces-5

