### PR TITLE
Add google analytics

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ class Config(object):
     DEBUG = os.getenv('DEBUG', False)
     TESTING = False
     PORT = os.getenv('PORT', 8085)
+    GOOGLE_ANALYTICS = os.getenv('GOOGLE_ANALYTICS', None)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     RESPONSE_OPERATIONS_UI_SECRET = os.getenv('RESPONSE_OPERATIONS_UI_SECRET', "secret")
     SESSION_TYPE = "redis"

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ class Config(object):
     DEBUG = os.getenv('DEBUG', False)
     TESTING = False
     PORT = os.getenv('PORT', 8085)
-    GOOGLE_ANALYTICS = os.getenv('GOOGLE_ANALYTICS', None)
+    GOOGLE_ANALYTICS_ID = os.getenv('GOOGLE_ANALYTICS_ID', None)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     RESPONSE_OPERATIONS_UI_SECRET = os.getenv('RESPONSE_OPERATIONS_UI_SECRET', "secret")
     SESSION_TYPE = "redis"

--- a/response_operations_ui/templates/layouts/base-head.html
+++ b/response_operations_ui/templates/layouts/base-head.html
@@ -24,8 +24,6 @@
     <script type="text/javascript" src="{{ url_for('static', filename='js/main.min.js') }}"></script>
     <link href="/static/images/favicon.ico" rel="Shortcut Icon" />
 
-    {{ analytics }}
-
     {% if config.GOOGLE_ANALYTICS %}
       <!-- Global site tag (gtag.js) - Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.GOOGLE_ANALYTICS }}"></script>

--- a/response_operations_ui/templates/layouts/base-head.html
+++ b/response_operations_ui/templates/layouts/base-head.html
@@ -23,7 +23,21 @@
     {% endassets %}
     <script type="text/javascript" src="{{ url_for('static', filename='js/main.min.js') }}"></script>
     <link href="/static/images/favicon.ico" rel="Shortcut Icon" />
+
+    {{ analytics }}
+
+    {% if config.GOOGLE_ANALYTICS %}
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.GOOGLE_ANALYTICS }}"></script>
+      <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '{{ config.GOOGLE_ANALYTICS }}');
+      </script>
+    {% endif %}
   </head>
 
 {% block base %}{% endblock %}
+
 </html>

--- a/response_operations_ui/templates/layouts/base-head.html
+++ b/response_operations_ui/templates/layouts/base-head.html
@@ -24,14 +24,14 @@
     <script type="text/javascript" src="{{ url_for('static', filename='js/main.min.js') }}"></script>
     <link href="/static/images/favicon.ico" rel="Shortcut Icon" />
 
-    {% if config.GOOGLE_ANALYTICS %}
+    {% if config.GOOGLE_ANALYTICS_ID %}
       <!-- Global site tag (gtag.js) - Google Analytics -->
-      <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.GOOGLE_ANALYTICS }}"></script>
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.GOOGLE_ANALYTICS_ID }}"></script>
       <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '{{ config.GOOGLE_ANALYTICS }}');
+      gtag('config', '{{ config.GOOGLE_ANALYTICS_ID }}');
       </script>
     {% endif %}
   </head>


### PR DESCRIPTION
# Motivation and Context
ras-frontstage has google analytics but response-operations doesn't.  We're adding it so that we can start seeing the journeys that internal users take though our systems so we can have more data to figure out what's important.

# What has changed
Added google analytics code snippet

# How to test?
Can't be tested until it hits preprod.  We've added the container value (the GOOGLE_ANALYTICS value) into the preprod build.  Once we've deployed it and verified the analytics are working, we'll need to do the same to prod

# Links
https://trello.com/c/A9wl7wX5/794-add-analytics-to-rops-iv5

# Screenshots (if appropriate):
