### PR TITLE
Add ru_ref metadata to a number of log lines

### DIFF
--- a/response_operations_ui/controllers/case_controller.py
+++ b/response_operations_ui/controllers/case_controller.py
@@ -135,8 +135,7 @@ def generate_iac(case_id):
     url = get_iac_url(case_id)
     logger.info('Generating new IAC', case_id=case_id, url=url)
 
-    response = requests.post(url=url,
-                             auth=app.config['CASE_AUTH'])
+    response = requests.post(url=url, auth=app.config['CASE_AUTH'])
 
     try:
         response.raise_for_status()

--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -85,7 +85,6 @@ def add_enrolment_status_to_respondent(respondent, ru_ref, survey_id):
 
 
 def get_respondent_enrolments(respondent, enrolment_status=None):
-
     enrolments = []
     for association in respondent['associations']:
         business_party = get_business_by_party_id(association['partyId'])
@@ -150,7 +149,7 @@ def search_respondents(first_name, last_name, email_address, page):
 
 
 def update_contact_details(respondent_id, form, ru_ref='NOT DEFINED'):
-    logger.info('Updating respondent details', respondent_id=respondent_id)
+    logger.info('Updating respondent details', respondent_id=respondent_id, ru_ref=ru_ref)
 
     new_contact_details = {
         "firstName": form.get('first_name'),

--- a/response_operations_ui/views/case.py
+++ b/response_operations_ui/views/case.py
@@ -25,6 +25,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 @case_bp.route('/<ru_ref>/response-status', methods=['GET'])
 @login_required
 def get_response_statuses(ru_ref, error=None):
+    logger.info("Retrieving response statuses", ru_ref=ru_ref)
     short_name = request.args.get('survey')
     period = request.args.get('period')
 

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -24,6 +24,7 @@ reporting_unit_bp = Blueprint('reporting_unit_bp', __name__, static_folder='stat
 @reporting_unit_bp.route('/<ru_ref>', methods=['GET'])
 @login_required
 def view_reporting_unit(ru_ref):
+    logger.info("Gathering data to view reporting unit", ru_ref=ru_ref)
     # Make some initial calls to retrieve some data we'll need
     reporting_unit = party_controller.get_party_by_ru_ref(ru_ref)
 
@@ -91,6 +92,7 @@ def view_reporting_unit(ru_ref):
             "title": f"{ru_ref}"
         }
     ]
+    logger.info("Successfully gathered data to view reporting unit", ru_ref=ru_ref)
     return render_template('reporting-unit.html', ru_ref=ru_ref, ru=reporting_unit,
                            surveys=surveys_with_latest_case, breadcrumbs=breadcrumbs)
 


### PR DESCRIPTION
# Motivation and Context
There are a few places we use the ru_ref and don't log it.  This is useful because the business generally give us an ru_ref as the only piece of information when something goes wrong.

# What has changed
A few log lines have been added, and a few log lines have had ru_ref added to the metadata

# How to test?
Unit tests pass

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
