### PR TITLE
Maintainance banner res ops ui

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ node: '10'
 cache:
   - pip
 
+services:
+    - redis-server
+
 env:
    global:
      - APP_SETTINGS=TestingConfig

--- a/config.py
+++ b/config.py
@@ -78,7 +78,7 @@ class DevelopmentConfig(Config):
     DEBUG = os.getenv('DEBUG', True)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'DEBUG')
     REDIS_HOST = os.getenv('REDIS_HOST', "localhost")
-    REDIS_PORT = os.getenv('REDIS_PORT', 7379)
+    REDIS_PORT = os.getenv('REDIS_PORT', 6379)
     REDIS_DB = os.getenv('REDIS_DB', 0)
     SECURE_COOKIES = strtobool(os.getenv('SECURE_COOKIES', 'False'))
 

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -50,6 +50,17 @@ def create_app(config_name=None):
     login_manager.init_app(app)
     login_manager.login_view = "sign_in_bp.sign_in"
 
+    @app.context_processor
+    def inject_availability_message():
+
+        redis_avail_msg = app.config['SESSION_REDIS']
+
+        if len(redis_avail_msg.keys('AVAILABILITY_MESSAGE_RES_OPS')) == 1:
+            return {
+                "availability_message": redis_avail_msg.get('AVAILABILITY_MESSAGE_RES_OPS').decode('utf-8')
+            }
+        return {}
+
     @login_manager.user_loader
     def user_loader(user_id):
         return User(user_id)

--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -6,7 +6,7 @@
       <div class="page__content">
         {% include 'partials/header.html' %}
 
-        <div class="container container--wide page__container">
+        <div class="container page__container">
           {% if breadcrumbs %}
             {% include 'partials/breadcrumbs.html' %}
           {% endif %}

--- a/response_operations_ui/templates/partials/header.html
+++ b/response_operations_ui/templates/partials/header.html
@@ -1,9 +1,9 @@
 <div class="skip">
   <a class="skip__link" href="#main">Skip to content</a>
 </div>
-<header class="header header--internal header--thin u-mb-no">
+<header class="header header--internal header--thin u-mb-l">
   <div class="header__top" role="banner">
-    <div class="container container--wide">
+    <div class="container">
       <div class="grid grid--gutterless">
         <div class="grid__col col-6@s">
           <div class="logo">
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="header__main">
-    <div class="container container--wide">
+    <div class="container">
       <div class="grid grid--gutterless grid--align-mid u-cf">
         <div class="grid__col col-10@xs col-6@s col-8@m">
           <h1 class="header__title">Survey Data Collection</h1>
@@ -40,7 +40,7 @@
     </div>
   </div>
   <div class="header__nav">
-        <div class="container container--wide">
+        <div class="container">
             <nav class="nav nav--horizontal nav--light nav--main js-main-nav nav--h-m" aria-label="Main menu" id="main-nav" aria-hidden="true">
                 <ul class="nav__list" aria-label="Navigation menu" role="menubar">
                     <li class="nav__item {% if request.path == '/' %} nav__item--active{% endif %}" role="menuitem"><a href="/" class="nav__link">Home</a></li>

--- a/response_operations_ui/templates/partials/header.html
+++ b/response_operations_ui/templates/partials/header.html
@@ -58,3 +58,6 @@
         </div>
     </div>
 </header>
+{% if availability_message %}
+<div class="panel panel--simple panel--warn u-mb-l container">{{ availability_message }}</div>
+{% endif %}

--- a/response_operations_ui/views/info.py
+++ b/response_operations_ui/views/info.py
@@ -24,7 +24,7 @@ def get_info():
 
     info = {
         "name": 'response-operations-ui',
-        "version": '0.20.0',
+        "version": '1.0.0',
     }
     info = {**_health_check, **info}
 

--- a/tests/views/test_availability_message.py
+++ b/tests/views/test_availability_message.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+from unittest.mock import patch
+from response_operations_ui import create_app
+
+
+TESTMSG = b'RESPONSE UI TEST MESSAGE'
+
+
+class TestAvailabilityMessage(TestCase):
+
+    def setUp(self):
+        self.app = create_app('TestingConfig')
+        self.client = self.app.test_client()
+
+    @patch('redis.StrictRedis')
+    def test_message_does_not_show_if_redis_flag_not_set(self, mock_redis):
+        mock_redis.get.return_value = b''
+        mock_redis.keys.return_value = []
+        response = self.client.get('/', follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(TESTMSG in response.data)
+
+    @patch('redis.StrictRedis')
+    def test_message_shows_correct_message_if_redis_flag_set(self, mock_redis):
+        mock_redis.get.return_value = TESTMSG
+        mock_redis.keys.return_value = ['AVAILABILITY_MESSAGE_RES_OPS']
+        response = self.client.get('/', follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(TESTMSG in response.data)


### PR DESCRIPTION
# Motivation and Context

Currently when we do a deploy  we don't  put maintenance banner when we work on response ops.Mostly this is handled by pre-communication with the business but this limits times we can do deployments and potentially causes issues if someone is in the middle of a session.
We need a better strategy for managing response ops downtime.

# What has changed
Few lines of code added  :
To access  redis  new decorator variable session .
Modified Partials/header.html as well to add availability msg variable
Added new test file which include Unit test cases to test the fix .


# How to test?
Manual and unit test passed

# Links
https://trello.com/c/WGSjK35Y
# Screenshots (if appropriate):
