### PR TITLE
html changes to correct banner postion

### DIFF
--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -7,6 +7,9 @@
         {% include 'partials/header.html' %}
 
         <div class="container page__container">
+          {% if availability_message %}
+            <div class="panel panel--simple panel--warn u-mb-l container">{{ availability_message }}</div>
+          {% endif %}
           {% if breadcrumbs %}
             {% include 'partials/breadcrumbs.html' %}
           {% endif %}

--- a/response_operations_ui/templates/partials/header.html
+++ b/response_operations_ui/templates/partials/header.html
@@ -58,6 +58,4 @@
         </div>
     </div>
 </header>
-{% if availability_message %}
-<div class="panel panel--simple panel--warn u-mb-l container">{{ availability_message }}</div>
-{% endif %}
+


### PR DESCRIPTION
# Motivation and Context
Currently when we do a deploy we don't put maintenance banner when we work on response ops.Mostly this is handled by pre-communication with the business but this limits times we can do deployments and potentially causes issues if someone is in the middle of a session.
We need a better strategy for managing response ops downtime

# What has changed
Modified Partials/header.html  and templates/layouts/base.html  to correct banner postion  a


# How to test?
tested manually  and passed the test 
# Links
https://trello.com/c/WGSjK35Y
# Screenshots (if appropriate):
