### PR TITLE
Better error handling when new password matches old one

### DIFF
--- a/response_operations_ui/controllers/uaa_controller.py
+++ b/response_operations_ui/controllers/uaa_controller.py
@@ -134,11 +134,5 @@ def change_user_password(email, password):
     if password_reset_code is None:
         return False
 
-    reset_response = change_password(access_token=access_token, user_code=password_reset_code,
+    return change_password(access_token=access_token, user_code=password_reset_code,
                                      new_password=password)
-
-    if reset_response.status_code != 200:
-        logger.error('Error received from UAA on change password', status_code=reset_response.status_code,
-                     message=reset_response.json().get('message'))
-
-    return reset_response.status_code == 200

--- a/response_operations_ui/controllers/uaa_controller.py
+++ b/response_operations_ui/controllers/uaa_controller.py
@@ -135,4 +135,4 @@ def change_user_password(email, password):
         return False
 
     return change_password(access_token=access_token, user_code=password_reset_code,
-                                     new_password=password)
+                           new_password=password)

--- a/response_operations_ui/templates/reset-password.html
+++ b/response_operations_ui/templates/reset-password.html
@@ -17,12 +17,16 @@
     {% set errorStrongerPasswordTitle = "Your password doesn't meet the requirements" %}
     {% set errorStrongerPasswordDescription = "Please choose a different password" %}
 
+    {% set errorPasswordSameAsOldTitle = "Your password matches your old password" %}
+    {% set errorPasswordSameAsOldDescription = "Please choose a different password or login with the old password" %}
+
 <div class="panel panel--error">
     <div class="panel__header">
         <h1 class="panel__title u-fs-r--b">
             {{ errorNotEnteredTitle if errorType.password[0] == errorNotEnteredTitle }}
             {{ errorNoMatchTitle if errorType.password[0] == errorNoMatchTitle }}
             {{ errorStrongerPasswordTitle if errorType.password[0] == errorStrongerPasswordTitle }}
+            {{ errorPasswordSameAsOldTitle if errorType.password[0] == errorPasswordSameAsOldTitle }}
         </h1>
     </div>
     <div class="panel__body" data-qa="error-body">
@@ -31,6 +35,7 @@
             {{ errorNotEnteredDescription if errorType.password[0] == errorNotEnteredTitle }}
             {{ errorNoMatchDescription if errorType.password[0] == errorNoMatchTitle }}
             {{ errorStrongerPasswordDescription if errorType.password[0] == errorStrongerPasswordTitle }}
+            {{ errorPasswordSameAsOldDescription if errorType.password[0] == errorPasswordSameAsOldDescription }}
             </a>
         </p>
     </div>

--- a/response_operations_ui/views/passwords.py
+++ b/response_operations_ui/views/passwords.py
@@ -100,7 +100,6 @@ def post_reset_password(token):
         logger.info('Successfully changed user password', token=token)
         return redirect(url_for('passwords_bp.reset_password_confirmation'))
 
-
     if response.status_code == 422:
         # 422 == New password same as old password
         logger.info('New password same as old password', token=token)


### PR DESCRIPTION
# Motivation and Context
UAA throws a non-200 (422) if you try to set your new password to what it was before. I was handling all non-200s in the same fashion ("Something went wrong" page) but that's obviously overkill here, so it uses the form errors system to display a nice message instead