### PR TITLE
remove redundant code and modify error messages

### DIFF
--- a/response_operations_ui/forms.py
+++ b/response_operations_ui/forms.py
@@ -74,11 +74,11 @@ class EditContactDetailsForm(FlaskForm):
     first_name = StringField('first_name', validators=[InputRequired(message="Enter a first name"),
                                                        Length(max=254,
                                                               message="First name must be fewer than 254 characters")])
-    email = StringField('emailAddress', validators=[InputRequired("The email address must be in the correct format"),
+    email = StringField('emailAddress', validators=[InputRequired("Enter an email address"),
                                                     Email(message='The email address must be in the correct format'),
                                                     Length(max=254,
                                                            message='Your email must be less than 254 characters')])
-    telephone = StringField('telephone')
+    telephone = StringField('telephone', validators=[InputRequired(message="Enter a phone number")])
     hidden_email = HiddenField('hidden_email')
 
     def __init__(self, form, default_values=None):
@@ -88,31 +88,6 @@ class EditContactDetailsForm(FlaskForm):
             self.last_name.data = default_values.get('lastName')
             self.email.data = default_values.get('emailAddress')
             self.telephone.data = default_values.get('telephone')
-
-    @staticmethod
-    def validate_first_name(form, field):
-        first_name = field.data
-        if first_name is None:
-            raise ValidationError('Enter a fist name')
-
-    @staticmethod
-    def validate_last_name(form, field):
-        last_name = field.data
-        if last_name is None:
-            raise ValidationError('Enter a last name')
-        if len(last_name) >= 254:
-            raise ValidationError("Last name must be fewer than 254 characters")
-
-    @staticmethod
-    def validate_email(form, field):
-        email = field.data
-        return _validate_email_address(email)
-
-    @staticmethod
-    def validate_telephone(form, field):
-        telephone = field.data
-        if telephone is None:
-            raise ValidationError('Enter a telephone number')
 
 
 class EditCollectionExerciseDetailsForm(FlaskForm):

--- a/response_operations_ui/templates/edit-contact-details.html
+++ b/response_operations_ui/templates/edit-contact-details.html
@@ -58,7 +58,10 @@
                 <li class="list__item"><a href='#firstName'>{{ error }}</a></li>
               {% endfor %}
               {% for error in form.email.errors %}
-                <li class="list__item"><a href='#email'> c</a></li>
+                <li class="list__item"><a href='#email'>{{ error }}</a></li>
+              {% endfor %}
+              {% for error in form.telephone.errors %}
+                <li class="list__item"><a href='#telephone'>{{ error }}</a></li>
               {% endfor %}
             </ol>
            </div>


### PR DESCRIPTION
# Motivation and Context
Bug found where the error messages were not displaying for email and telephone.

# What has changed
Added in the error message for no telephone and fixed the type of email address. Removed redundant code.

# How to test?
Spin up response ops manually, go to edit details page, inspect and remove the required tags, submit a form with blank text boxes.

# Links
https://trello.com/c/T4mEeKr3

# Screenshots (if appropriate):
