### PR TITLE
Rename @ru_id to @business_details

### DIFF
--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -468,14 +468,14 @@ def _get_to_name(message):
 
 def _get_ru_ref_from_message(message):
     try:
-        return message['@ru_id']['sampleUnitRef']
+        return message['@business_details']['sampleUnitRef']
     except (KeyError, TypeError):
         logger.error("Failed to retrieve RU ref from message", message_id=message.get('msg_id'), exc_info=True)
 
 
 def _get_business_name_from_message(message):
     try:
-        return message['@ru_id']['name']
+        return message['@business_details']['name']
     except (KeyError, TypeError):
         logger.exception("Failed to retrieve business name from message", message_id=message.get('msg_id'))
 

--- a/tests/test_data/message/thread.json
+++ b/tests/test_data/message/thread.json
@@ -31,7 +31,7 @@
                             "sampleUnitType": "BI",
                             "status": "CREATED",
                             "telephone": "0987654321"}],
-               "@ru_id": {"associations": [{"enrolments": [{"enrolmentStatus": "ENABLED",
+               "@business_details": {"associations": [{"enrolments": [{"enrolmentStatus": "ENABLED",
                                                             "name": "Monthly Survey of Building MaterialsBricks",
                                                             "surveyId": "6aa8896f-ced5-4694-800c-6cd661b0c8b2"}],
                                             "partyId": "633330a6-aa84-4d1e-8e5d-2bafa9e3dac5"}],

--- a/tests/test_data/message/thread_missing_respondent.json
+++ b/tests/test_data/message/thread_missing_respondent.json
@@ -8,7 +8,7 @@
                 "id": "688da990-8e33-471f-ae26-e253df4bb759",
                 "lastName": "User"
             },
-            "@ru_id": null,
+            "@business_details": null,
             "_links": "",
             "body": "fifth message",
             "collection_case": "",
@@ -35,7 +35,7 @@
                 "id": "688da990-8e33-471f-ae26-e253df4bb759",
                 "lastName": "User"
             },
-            "@ru_id": null,
+            "@business_details": null,
             "_links": "",
             "body": "fourth message!!!",
             "collection_case": "",
@@ -62,7 +62,7 @@
                 "id": "688da990-8e33-471f-ae26-e253df4bb759",
                 "lastName": "User"
             },
-            "@ru_id": null,
+            "@business_details": null,
             "_links": "",
             "body": "another one",
             "collection_case": "",
@@ -89,7 +89,7 @@
                 "id": "688da990-8e33-471f-ae26-e253df4bb759",
                 "lastName": "User"
             },
-            "@ru_id": null,
+            "@business_details": null,
             "_links": "",
             "body": "another message",
             "collection_case": "",
@@ -116,7 +116,7 @@
                 "id": "688da990-8e33-471f-ae26-e253df4bb759",
                 "lastName": "User"
             },
-            "@ru_id": null,
+            "@business_details": null,
             "_links": "",
             "body": "more messages",
             "collection_case": "",
@@ -145,7 +145,7 @@
                     "lastName": "User"
                 }
             ],
-            "@ru_id": null,
+            "@business_details": null,
             "_links": "",
             "body": "another message",
             "collection_case": "",
@@ -173,7 +173,7 @@
                 "id": "688da990-8e33-471f-ae26-e253df4bb759",
                 "lastName": "User"
             },
-            "@ru_id": null,
+            "@business_details": null,
             "_links": "",
             "body": "this is another message",
             "collection_case": "",

--- a/tests/test_data/message/thread_missing_subject.json
+++ b/tests/test_data/message/thread_missing_subject.json
@@ -31,7 +31,7 @@
                             "sampleUnitType": "BI",
                             "status": "CREATED",
                             "telephone": "0987654321"}],
-               "@ru_id": {"associations": [{"enrolments": [{"enrolmentStatus": "ENABLED",
+               "@business_details": {"associations": [{"enrolments": [{"enrolmentStatus": "ENABLED",
                                                             "name": "Monthly Survey of Building MaterialsBricks",
                                                             "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54"}],
                                             "partyId": "633330a6-aa84-4d1e-8e5d-2bafa9e3dac5"}],

--- a/tests/test_data/message/thread_unread.json
+++ b/tests/test_data/message/thread_unread.json
@@ -18,7 +18,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"

--- a/tests/test_data/message/threads.json
+++ b/tests/test_data/message/threads.json
@@ -18,7 +18,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -72,7 +72,7 @@
           "telephone": "07832323234"
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -107,7 +107,7 @@
       "telephone": ""
      }
     ],
-    "@ru_id": {
+    "@business_details": {
      "associations": [
       {
        "enrolments": [

--- a/tests/test_data/message/threads_missing_atmsg_from.json
+++ b/tests/test_data/message/threads_missing_atmsg_from.json
@@ -17,7 +17,7 @@
           "lastName": "LastName"
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"

--- a/tests/test_data/message/threads_missing_atmsg_to.json
+++ b/tests/test_data/message/threads_missing_atmsg_to.json
@@ -16,7 +16,7 @@
         "id": "ff4537df-2097-4a73-a530-e98dba7bf28f",
         "lastName": "Employee"
       },
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"

--- a/tests/test_data/message/threads_missing_business_name.json
+++ b/tests/test_data/message/threads_missing_business_name.json
@@ -23,7 +23,7 @@
         "id": "ff4537df-2097-4a73-a530-e98dba7bf28f",
         "lastName": "Employee"
       },
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "sampleUnitRef": "50012345678"
       },

--- a/tests/test_data/message/threads_missing_msg_to.json
+++ b/tests/test_data/message/threads_missing_msg_to.json
@@ -14,7 +14,7 @@
         "id": "ff4537df-2097-4a73-a530-e98dba7bf28f",
         "lastName": "Employee"
       },
-      "@ru_id": {},
+      "@business_details": {},
       "sent_date": "2017-10-03 15:51:32.961321"
     },
     {

--- a/tests/test_data/message/threads_missing_ru_ref.json
+++ b/tests/test_data/message/threads_missing_ru_ref.json
@@ -23,7 +23,7 @@
         "id": "ff4537df-2097-4a73-a530-e98dba7bf28f",
         "lastName": "Employee"
       },
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple"
       },

--- a/tests/test_data/message/threads_missing_sent_date.json
+++ b/tests/test_data/message/threads_missing_sent_date.json
@@ -23,7 +23,7 @@
         "id": "ff4537df-2097-4a73-a530-e98dba7bf28f",
         "lastName": "Employee"
       },
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"

--- a/tests/test_data/message/threads_multipage.json
+++ b/tests/test_data/message/threads_multipage.json
@@ -18,7 +18,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -59,7 +59,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -100,7 +100,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -141,7 +141,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -182,7 +182,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -223,7 +223,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -264,7 +264,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -305,7 +305,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -346,7 +346,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -387,7 +387,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"

--- a/tests/test_data/message/threads_no_unread.json
+++ b/tests/test_data/message/threads_no_unread.json
@@ -18,7 +18,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -72,7 +72,7 @@
           "telephone": "07832323234"
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"

--- a/tests/test_data/message/threads_unread.json
+++ b/tests/test_data/message/threads_unread.json
@@ -31,7 +31,7 @@
           "telephone": "07832323234"
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"
@@ -72,7 +72,7 @@
           "lastName": ""
         }
       ],
-      "@ru_id": {
+      "@business_details": {
         "id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
         "name": "Apple",
         "sampleUnitRef": "50012345678"


### PR DESCRIPTION
# Motivation and Context
In secure-message, we're changing ru_id to business_id to more accurately reflect what it is.  This required us changing the @ru_id part of the payload to a more sensible name.  Instead of @business_id, it's been changed to @business_details as it doesn't only include the id so it's more accurate.

# What has changed
- All instances of @ru_id have been changed to @business_details

# How to test?
- Everything works as it did before.  Unit and acceptance tests still pass

# Links
https://trello.com/c/nct0vF5E

# Screenshots (if appropriate):
