### PR TITLE
Upgrade jquery retrieval from http to https

### DIFF
--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -3,7 +3,7 @@
     {% assets "scss_all" %}
      <link rel=stylesheet type=text/css href="{{ url_for('static', filename='css/main.css') }}">
     {% endassets %}
-    <script type="text/javascript" src="http://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     {% assets "js_all" %}
       <script type="text/javascript" src="{{ url_for('static', filename='js/main.min.js') }}"></script>
     {% endassets %}


### PR DESCRIPTION
# Motivation and Context
We're having weird 404s in the logs for the main.min.js.map missing in prod.  It's possibly caused by a mixed-content error happening when the site tries to get jquery as it's over http (and maybe the main.min.js is being served over https?).  Regardless of whether this fixes the problem, this should stop this particiular error occuring and we should always be communicating over https wherever possible.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
