### PR TITLE
Upload component had attributes param removed

### DIFF
--- a/response_operations_ui/templates/components/upload/_macro.njk
+++ b/response_operations_ui/templates/components/upload/_macro.njk
@@ -12,7 +12,8 @@
             "label": params.label,
             "classes": "input--upload",
             "accept": params.accept,
-            "name": "file"
+            "name": params.name,
+            "attributes": params.attributes
         }) }}
     {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
# Motivation and Context
The upload component in the design system had the `attributes` param removed.
This PR puts it back so load sample works again.

# How to test?
Check you can load a sample ok.