### PR TITLE
Refactor remaining templates

### DIFF
--- a/response_operations_ui/templates/components/lists/_macro.njk
+++ b/response_operations_ui/templates/components/lists/_macro.njk
@@ -8,13 +8,13 @@
   <{{listEl}} {% if params.id %}id="{{ params.id }}"{% endif %} class="list {{ params.classes }}">
       {% for item in (params.itemsList if params.itemsList is iterable else params.itemsList.items()) %}
           <li class="list__item {{ item.listclass }}" {% if item.current %}aria-current="true"{% endif %}>
-              {% if item.url and item.current != true %}
+              {%- if item.url and item.current != true -%}
                   {% if item.index %}{{ loop.index }}) {% endif %}{% if item.prefix %}<span class="list__prefix" aria-hidden="true">{{ item.prefix }}.</span> {% endif %} <a href="{{ item.url }}" class="list__link {{ item.classes }}" {% if item.target %} target="{{ item.target }}"{% endif %} {% if item.name %} name="{{ item.name }}"{% endif %}>
                     {% if item.prefix %}<span class="u-vh">{{ item.prefix }}.</span>{% endif %} {{ item.text | safe }}
                   </a>
-              {% else %}
+              {%- else -%}
                   {{ item.text | safe }}
-              {% endif %}
+              {%- endif -%}
           </li>
       {% endfor %}
   </{{listEl}}>

--- a/response_operations_ui/templates/errors/500-error.html
+++ b/response_operations_ui/templates/errors/500-error.html
@@ -3,13 +3,15 @@
 {% set page_title = "Server error (Error 500) - ONS Business Surveys" %}
 
 {% block main %}
-        <h1 class="u-fs-l u-mt-m">Error 500 - Server error</h1>
-
-        <div class="panel panel--simple panel--error">
-
-            <p>Something has gone wrong with the website.</p>
-            <p>You may want to visit the <a href="/">homepage</a></p>
-            <p>If you still encounter problems please <a href="/contact-us">contact us</a>. We apologise for any inconvenience this may have caused.</p>
-
-        </div>
+    <h1 class="u-mt-m">Error 500 - Server error</h1>
+    {% call
+        onsPanel({
+            "type": "error",
+            "classes": "u-mb-l"
+        })
+    %}
+        <p>Something has gone wrong with the website.</p>
+        <p>You may want to visit the <a href="/">homepage</a></p>
+        <p>If you still encounter problems please <a href="/contact-us">contact us</a>. We apologise for any inconvenience this may have caused.</p>
+    {% endcall %}
 {% endblock main %}

--- a/response_operations_ui/templates/reporting-unit-search/reporting-units-search.html
+++ b/response_operations_ui/templates/reporting-unit-search/reporting-units-search.html
@@ -1,5 +1,6 @@
 {% extends "layouts/base.html" %}
 {% from "components/button/_macro.njk" import onsButton %}
+{% from "components/input/_macro.njk" import onsInput %}
 
 {% set page_title = "Reporting units" %}
 
@@ -9,11 +10,17 @@
 
         <form action="" method="post">
             {{ form.csrf_token }}
-
-            <div class="field u-mb-s">
-                <label class="label">Type a reference or company name</label>
-                {{ form.query(size=20, class_="ru-search-box input input--text")}}
-            </div>
+            {{
+                onsInput({
+                    "id": "query",
+                    "name": "query",
+                    "type": "text",
+                    "classes": "u-mb-m",
+                    "label": {
+                        "text": "Type a reference or company name"
+                    }
+                })
+            }} 
             {{
                 onsButton({
                     "text": "Search",

--- a/response_operations_ui/templates/reporting-unit-search/reporting-units.html
+++ b/response_operations_ui/templates/reporting-unit-search/reporting-units.html
@@ -9,18 +9,11 @@
     <h1>Reporting units</h1>
     <form action="{{ url_for('reporting_unit_bp.search_redirect') }}" method="post">
         {{ form.csrf_token }}
+        <p class="field u-mb-s">
+            <label for="query" class="label">Type a reference or company name</label>
+            {{ form.query(size=20, class_="ru-search-box input input--text", id="query")}}
+        </p>
 
-        {{
-            onsInput({
-                "id": "query",
-                "name": "query",
-                "type": "text",
-                "classes": "u-mb-m",
-                "label": {
-                    "text": "Type a reference or company name"
-                }
-            })
-        }} 
         {{
             onsButton({
                 "text": "Search",

--- a/response_operations_ui/templates/reporting-unit-search/reporting-units.html
+++ b/response_operations_ui/templates/reporting-unit-search/reporting-units.html
@@ -1,73 +1,85 @@
 {% extends "layouts/base.html" %}
 {% from "components/button/_macro.njk" import onsButton %}
+{% from "components/input/_macro.njk" import onsInput %}
+{% from "components/table/_macro.njk" import onsTable %}
 
 {% set page_title = "Reporting units" %}
 
 {% block main %}
     <h1>Reporting units</h1>
-    
-        <div class="ru-search">
+    <form action="{{ url_for('reporting_unit_bp.search_redirect') }}" method="post">
+        {{ form.csrf_token }}
 
-        <form action="{{ url_for('reporting_unit_bp.search_redirect') }}" method="post">
-            {{ form.csrf_token }}
-
-            <div class="field u-mb-s">
-                <label class="label">Type a reference or company name</label>
-                {{ form.query(size=20, class_="ru-search-box input input--text")}}
-            </div>
-            {{
-                onsButton({
-                    "text": "Search",
-                    "id": "btn-search-ru",
-                    "submitType": "timer"
-                })
-            }}
-        </form>
-
-    </div>
-
+        {{
+            onsInput({
+                "id": "query",
+                "name": "query",
+                "type": "text",
+                "classes": "u-mb-m",
+                "label": {
+                    "text": "Type a reference or company name"
+                }
+            })
+        }} 
+        {{
+            onsButton({
+                "text": "Search",
+                "id": "btn-search-ru",
+                "submitType": "timer"
+            })
+        }}
+    </form>
     {% if not total_business_count %}
-        <div class="u-mt-m">No results found</div>
+        <p class="u-mt-m">No results found</p>
     {% else %}
-        <div class="u-pt-m">
-    
-            <table id="tbl-businesses" class="table table--dense" summary="Businesses in the system">
-                <thead class="table__head">
-                <tr class="table__row">
-                    <th scope="col" class="table__header">
-                        RU reference
-                    </th>
-                    <th scope="col" class="table__header">
-                        Name
-                    </th>
-                    <th scope="col" class="table__header">
-                        Trading as
-                    </th>
-                </tr>
-                </thead>
-    
-                <tbody class="table__body">
-                {% for business in business_list %}
-                <tr class="table__row table__row__selectable">
-                    <td class="table__cell ">
-                        <a href="/reporting-units/{{ business.ruref }}" name="details-link-{{ business.ruref }}">{{ business.ruref }}</a>
-                    </td>
-                    <td class="table__cell">
-                        {{ business.name }}
-                    </td>
-                    <td class="table__cell">
-                        {{ business.trading_as }}
-                    </td>
-                </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        </div>
-            {% if total_business_count == 1  %}
-                <h2 class="u-fs-l">{{ total_business_count }} Result found</h2>
-            {%  else %}    
-                <h2 class="u-fs-l">{{ total_business_count }} Results found</h2>
-            {% endif %}
+        <section class="u-mt-m">
+            {% set surveyTableData = {
+                "table_class": 'table--dense',
+                "id": 'tbl-businesses',
+                "ths": [
+                    { 
+                        "value": "RU reference"
+                    },
+                    { 
+                        "value": "Name"
+                    },
+                    { 
+                        "value": "Trading as"
+                    }
+                ]
+                }
+            %}
+
+            {% set surveyTableDataRows = [] %}
+            {% for business in business_list %}
+                {% do surveyTableDataRows.append(
+                    {
+                        "tds": [
+                        {
+                            "value": '<a href="/reporting-units/' + business.ruref + '" name="details-link-' + business.ruref + '">' + business.ruref + '</a>'
+                        },
+                        {
+                            "value": business.name
+                        },
+                        {
+                            "value": business.trading_as
+                        }
+                        ]
+                    }
+                    ) %}
+
+            {% endfor %}
+
+            {% do surveyTableData | setAttribute("trs", surveyTableDataRows) %}
+            {{
+                onsTable(surveyTableData)
+            }}
+        </section>
+        {% if total_business_count == 1  %}
+            <h2 class="u-fs-l">{{ total_business_count }} Result found</h2>
+        {%  else %}    
+            <h2 class="u-fs-l">{{ total_business_count }} Results found</h2>
+        {% endif %}
         <h3 class="u-mb-m">Displaying <strong>{{ first_index }} - {{ last_index }}</strong> of <strong>{{ total_business_count }}</strong> </h3>
         {% if show_pagination %}{% include 'respondent-search/rs-pagination.html' %}{% endif %}
     {%  endif %}

--- a/response_operations_ui/templates/respondent-search/respondent-search-results.html
+++ b/response_operations_ui/templates/respondent-search/respondent-search-results.html
@@ -1,5 +1,7 @@
 {% extends "layouts/base.html" %}
 {% from "components/button/_macro.njk" import onsButton %}
+{% from "components/fieldset/_macro.njk" import onsFieldset %}
+{% from "components/input/_macro.njk" import onsInput %}
 
 {% set page_title = "Respondents" %}
 

--- a/response_operations_ui/templates/respondent-search/respondent-search-results.html
+++ b/response_operations_ui/templates/respondent-search/respondent-search-results.html
@@ -4,16 +4,12 @@
 {% set page_title = "Respondents" %}
 
 {% block main %}
-    <div class="grid">
-        <div class="grid__col col-12@l">
-            {% include 'respondent-search/rs-inline-form.html' %}
+    {% include 'respondent-search/rs-inline-form.html' %}
 
-            <h2 class="u-fs-l">{{ respondent_count }} respondents found.</h2>
-            <h3 class="u-mb-m">Displaying <strong>{{ first_index }} - {{ last_index }}</strong> of <strong>{{ respondent_count }}</strong> </h3>
+    <h2 class="u-fs-l">{{ respondent_count }} respondents found.</h2>
+    <h3 class="u-mb-m">Displaying <strong>{{ first_index }} - {{ last_index }}</strong> of <strong>{{ respondent_count }}</strong> </h3>
 
-            {% if respondents %}{% include 'respondent-search/rs-table.html' %}{% endif %}
+    {% if respondents %}{% include 'respondent-search/rs-table.html' %}{% endif %}
 
-            {% if show_pagination %}{% include 'respondent-search/rs-pagination.html' %}{% endif %}
-        </div>
-    </div>
+    {% if show_pagination %}{% include 'respondent-search/rs-pagination.html' %}{% endif %}
 {% endblock %}

--- a/response_operations_ui/templates/respondent-search/respondent-search.html
+++ b/response_operations_ui/templates/respondent-search/respondent-search.html
@@ -1,52 +1,84 @@
 {% extends "layouts/base.html" %}
 {% from "components/button/_macro.njk" import onsButton %}
+{% from "components/lists/_macro.njk" import onsList %}
+{% from "components/fieldset/_macro.njk" import onsFieldset %}
+{% from "components/input/_macro.njk" import onsInput %}
 
 {% set page_title = "Respondents" %}
 
 {% block main %}
-    <h1 class="u-fs-xl">Find a respondent</h1>
-    <div class="grid">
-        <div class="grid__col col-12@l">
+    <h1>Find a respondent</h1>
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            {% call
+                onsPanel({
+                    "type":"error",
+                    "classes": "u-mb-s",
+                    "id": "validation-error"
+                })
+            %}
+                {% set errorData = [] %}
+                {% for message in messages %}
+                    {% do errorData.append(
+                        {
+                            "text": message
+                        }
+                    ) %}
+                {% endfor %}
+                {{
+                    onsList({
+                        "classes": "list--bare",
+                        "itemsList": errorData
+                    }) 
+                }}
+            {% endcall %}
+        {% endif %}
+    {% endwith %}
 
-            <div class="ru-search">
-
-                {% with messages = get_flashed_messages() %}
-                    {% if messages %}
-                    {% call panel(id='validation-error', type='error', class='u-mb-s') %}
-                        <ul>
-                        {% for message in messages %}
-                            <li>{{ message }}</li>
-                        {% endfor %}
-                        </ul>
-                    {% endcall %}
-                    {% endif %}
-                {% endwith %}
-
-                <form action="{{ url_for('respondent_bp.search_redirect') }}" method="post">
-                    {{ form.csrf_token }}
-                    <div class="field u-mb-s">
-                        <label class="label">First name</label>
-                        {{ form.first_name(size=20, class_="respondent-search-box input input--text")}}
-                    </div>
-
-                    <div class="field u-mb-s">
-                        <label class="label">Last name</label>
-                        {{ form.last_name(size=20, class_="respondent-search-box input input--text")}}
-                    </div>
-
-                    <div class="field u-mb-s">
-                        <label class="label">Email address</label>
-                        {{ form.email_address(size=20, class_="respondent-search-box input input--text")}}
-                    </div>
-                    {{
-                        onsButton({
-                            "text": "Search",
-                            "id": "btn-search-respondent",
-                            "submitType": "timer"
-                        })
-                    }}   
-                </form>
-            </div>
-        </div>
-    </div>
+    <form action="{{ url_for('respondent_bp.search_redirect') }}" method="post">
+        {{ form.csrf_token }}
+        {%- call onsFieldset({
+            "legend": "Enter respondent information to search",
+            "legendClasses": "u-vh"
+        }) -%}
+            {{
+                onsInput({
+                    "id": "first_name",
+                    "name": "first_name",
+                    "type": "text",
+                    "label": {
+                        "text": "First name"
+                    }
+                })
+            }}
+            {{
+                onsInput({
+                    "id": "last_name",
+                    "name": "last_name",
+                    "type": "text",
+                    "label": {
+                        "text": "Last name"
+                    }
+                })
+            }}        
+            {{
+                onsInput({
+                    "id": "email_address",
+                    "name": "email_address",
+                    "type": "text",
+                    "label": {
+                        "text": "Email address"
+                    }
+                })
+            }}      
+        {%- endcall -%}  
+        {{
+            onsButton({
+                "text": "Search",
+                "id": "btn-search-respondent",
+                "classes": "u-mt-m",
+                "submitType": "timer"
+            })
+        }}   
+    </form>
 {% endblock %}

--- a/response_operations_ui/templates/respondent-search/rs-inline-form.html
+++ b/response_operations_ui/templates/respondent-search/rs-inline-form.html
@@ -1,27 +1,48 @@
-<form action="{{ url_for('respondent_bp.search_redirect') }}" method="post" class="u-mt-l">
-    <fieldset class="fieldgroup fieldgroup--inline u-mb-l">
-        <legend class="fieldgroup__title u-fs-xl u-mb-m">Find a respondent</legend>
-            <div class="fieldgroup__fields">
-                <div class="field field--input">
-                    <label for="first_name" class="label u-fs--b">First name</label>
-                    {{ form.first_name(size=20, class_="input input--text")}}
-                </div>
-                <div class="field field--input">
-                    <label for="last_name" class="label u-fs--b">Last name</label>
-                    {{ form.last_name(size=20, class_="input input--text")}}
-                </div>
-                <div class="field field--input">
-                    <label for="email_address" class="label u-fs--b">Email Address</label>
-                    {{ form.email_address(size=30, class_="input input--text")}}
-                </div>
-                <div class="field field--input">
-                    {{
-                        onsButton({
-                            "text": "Search",
-                            "submitType": "timer"
-                        })
-                    }}   
-                </div>
-            </div>
-    </fieldset>
+    
+<h1 class="u-mt-xl">Find a respondent</h1>
+<form action="{{ url_for('respondent_bp.search_redirect') }}" method="post">
+    {{ form.csrf_token }}
+    {%- call onsFieldset({
+        "legend": "Enter respondent information to search",
+        "legendClasses": "u-vh"
+    }) -%}
+        {{
+            onsInput({
+                "id": "first_name",
+                "name": "first_name",
+                "type": "text",
+                "label": {
+                    "text": "First name"
+                }
+            })
+        }}
+        {{
+            onsInput({
+                "id": "last_name",
+                "name": "last_name",
+                "type": "text",
+                "label": {
+                    "text": "Last name"
+                }
+            })
+        }}        
+        {{
+            onsInput({
+                "id": "email_address",
+                "name": "email_address",
+                "type": "text",
+                "label": {
+                    "text": "Email address"
+                }
+            })
+        }}      
+    {%- endcall -%}  
+    {{
+        onsButton({
+            "text": "Search",
+            "id": "btn-search-respondent",
+            "classes": "u-mt-m u-mb-m",
+            "submitType": "timer"
+        })
+    }}   
 </form>

--- a/response_operations_ui/templates/respondent-search/rs-table.html
+++ b/response_operations_ui/templates/respondent-search/rs-table.html
@@ -1,24 +1,41 @@
-<table class="table">
-    <thead class="table__head">
-        <tr>
-            <th class="table__header">Name</th>
-            <th class="table__header">Email Address</th>
-            <th class="table__header">Status</th>
-        </tr>
-    </thead>
-    <tbody class="table__body">
-        {% for respondent in respondents %}
-        <tr>
-            <td>
-                <a href="{{ respondent.href }}">{{ respondent.name }}</a>
-            </td>
-            <td>
-                {{ respondent.email }}
-            </td>
-            <td>
-                <span class="status status--small {{ respondent.status_class }}">{{ respondent.status | title }}</span>
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
+{% from "components/table/_macro.njk" import onsTable %}
+{% set surveyTableData = {
+    "id": 'tbl-businesses',
+    "ths": [
+        { 
+            "value": "Name"
+        },
+        { 
+            "value": "Email Address"
+        },
+        { 
+            "value": "Status"
+        }
+    ]
+    }
+%}
+
+{% set surveyTableDataRows = [] %}
+{% for respondent in respondents %}
+    {% do surveyTableDataRows.append(
+        {
+            "tds": [
+            {
+                "value": '<a href="' + respondent.href + '">' + respondent.name + '</a>'
+            },
+            {
+                "value": respondent.email
+            },
+            {
+                "value": '<span class="status status--small ' + respondent.status_class + '}">' + respondent.status | title + '</span>'
+            }
+            ]
+        }
+        ) %}
+
+{% endfor %}
+
+{% do surveyTableData | setAttribute("trs", surveyTableDataRows) %}
+{{
+    onsTable(surveyTableData)
+}}

--- a/response_operations_ui/templates/respondent.html
+++ b/response_operations_ui/templates/respondent.html
@@ -1,117 +1,149 @@
 {% extends "layouts/base.html" %}
+{% from "components/metadata/_macro.njk" import onsMetadata %}
 {% set page_title = "Respondents" %}
 
 {% block main %}
 
 {% include 'partials/flashed-messages.html' %}
 
-            <section class="u-mb-xl respondent-account-details">
+<section>
+  <h1 id="respondent-name">{{ respondent.firstName }} {{ respondent.lastName }}</h1>
+  <div class="grid grid--gutterless">
+      <div class="grid__col col-10@m">
+          {% set accountStatus %}
+              {% if respondent.status  == 'Suspended' %} Locked {% else %} {{ respondent.status }} {% endif %}
+              <br>
+              {% if respondent.status == 'Created' %}<a id="resend-verification-email-btn" href="{{ url_for('respondent_bp.view_resend_verification', respondent_id=respondent.id) }}">Re-send verification email</a>
+              {% elif respondent.status == 'Suspended' %}<a id="respondent-unlock-link" href="{{ url_for('respondent_bp.confirm_change_respondent_status', party_id=respondent.id, tab='respondents', change_flag='ACTIVE') }}">Unlock</a>
+              {% endif %}
+          {% endset %}
+          {{ 
+              onsMetadata({
+                  "metadataLabel": "Information about the respondant",
+                  "termCol": "3",
+                  "descriptionCol": "9",
+                  "itemsList": [
+                      {
+                          "term": "Email:",
+                          "descriptions": [ 
+                              {
+                                  "description": respondent.emailAddress,
+                                  "id": "respondent-email",
+                                  "name": "tbl-respondent-email"
+                              }
+                          ]
+                      },
+                      {
+                          "term": "New Email:" if respondent.pendingEmailAddress else "",
+                          "descriptions": [ 
+                              {
+                                  "description": respondent.pendingEmailAddress + '<br>
+                          <a id="resend-verification-email-btn" href="' + url_for('respondent_bp.view_resend_verification', respondent_id=respondent.id) + '">Re-send verification email</a>' if respondent.pendingEmailAddress else "",
+                                  "id": "respondent-email" if respondent.pendingEmailAddress else "",
+                                  "name": "tbl-respondent-pending-email" if respondent.pendingEmailAddress else ""
+                              }                  
+                          ]
+                      },
+                      {
+                          "term": "Tel:",
+                          "descriptions": [ 
+                              {
+                                  "description": respondent.telephone,
+                                  "id": "respondent-phone",
+                                  "name": "tbl-respondent-phone"
+                              },
+                              {
+                                "description": '<a id="edit-contact-details" href="' + url_for('respondent_bp.view_contact_details', respondent_id=respondent.id) + '">Edit Contact Details</a>'
+                              }                                     
+                          ]
+                      },
+                      {
+                          "term": "Account:",
+                          "descriptions": [ 
+                              {
+                                  "description": accountStatus,
+                                  "id": "respondent-account-status"
+                              }                                     
+                          ]
+                      }
+                  ]
+              }) 
+          }}
 
-                    <h1 class="u-fs-xl" id="respondent-name">{{ respondent.firstName }} {{ respondent.lastName }}</h1>
-                    <dl class="description-list">
-                        <dt>
-                            Email
-                        </dt>
-                        <dd id="respondent-email" name="tbl-respondent-email">
-                            {{ respondent.emailAddress }}
-                        </dd>
-                        {% if respondent.pendingEmailAddress %}
-                        <dt>
-                            New Email
-                        </dt>
-                        <dd id="respondent-pending-email" name="tbl-respondent-pending-email">
-                            {{ respondent.pendingEmailAddress }} <br>
-                          <a id="resend-verification-email-btn" href="{{ url_for('respondent_bp.view_resend_verification', respondent_id=respondent.id) }}">Re-send verification email</a>
-                        </dd>
-                        {% endif %}
-                        <dt>
-                            Tel
-                        </dt>
-                        <dd id="respondent-telephone" name="tbl-respondent-phone">
-                            {{ respondent.telephone }}
-                        </dd>
-                        <dd>
-                          <a id="edit-contact-details" href="{{ url_for('respondent_bp.view_contact_details', respondent_id=respondent.id)}}">Edit Contact Details</a>
-                        </dd>
-                        <dt>
-                            Account
-                        </dt>
-                        <dd id="respondent-account-status">
-                            {% if respondent.status  == 'Suspended' %} Locked {% else %} {{ respondent.status }} {% endif %}
-                          <br>
-                          {% if respondent.status == 'Created' %}<a id="resend-verification-email-btn" href="{{ url_for('respondent_bp.view_resend_verification', respondent_id=respondent.id) }}">Re-send verification email</a>
-                          {% elif respondent.status == 'Suspended' %}<a id="respondent-unlock-link" href="{{ url_for('respondent_bp.confirm_change_respondent_status', party_id=respondent.id, tab='respondents', change_flag='ACTIVE') }}">Unlock</a>
-                          {% endif %}
-                        </dd>
-                    </dl>
-            </section>
+      </div>
+  </div>
+</section>
 
 
-            <div class="grid">
-            <section class="grid__col col-12@l respondent-account-enrolments">
+<section>
+  <h2>Enrolments</h2>
 
-                <h2 class="u-fs-l">Enrolments</h2>
+  {% from "components/table/_macro.njk" import onsTable %}
+  {% set surveyTableData = {
+      "table_class": 'table--dense',
+      "ths": [
+          { 
+              "value": "RU Reference"
+          },
+          { 
+              "value": "Reporting unit name"
+          },
+          { 
+              "value": "Trading as"
+          },
+          { 
+              "value": "Survey"
+          },
+          { 
+              "value": "Enrolment status"
+          }
+      ]
+      }
+  %}
 
-                <div class="respondent-account-enrolment data-panelx">
+  {% set surveyTableDataRows = [] %}
+  {% for enrolment in enrolments %}
+      {% set enrolmentData %}
+        {{ enrolment['status'].title() }}
+        {% if enrolment['status'] == 'ENABLED' %}
+        <a href="{{ url_for('reporting_unit_bp.confirm_change_enrolment_status', ru_ref=enrolment['business']['sampleUnitRef'], ru_name=enrolment['business']['name'], survey_id=enrolment['survey']['id'],
+                            survey_name=enrolment['survey']['shortName'], respondent_id=respondent.id, respondent_first_name=respondent.firstName,
+                            respondent_last_name=respondent.lastName, business_id=enrolment['business']['id'], trading_as=enrolment['business']['trading_as'], change_flag='DISABLED', tab='respondents')}}"
+            id="change-enrolment-status">Disable</a>
+        {% elif enrolment['status'] == 'DISABLED' %}
+        <a href="{{ url_for('reporting_unit_bp.confirm_change_enrolment_status', ru_ref=enrolment['business']['sampleUnitRef'], ru_name=enrolment['business']['name'], survey_id=enrolment['survey']['id'],
+                            survey_name=enrolment['survey']['shortName'], respondent_id=respondent.id, respondent_first_name=respondent.firstName,
+                            respondent_last_name=respondent.lastName, business_id=enrolment['business']['id'], trading_as=enrolment['business']['trading_as'], change_flag='ENABLED', tab='respondents')}}"
+          id="change-enrolment-status">Re-enable</a>
+        {% endif %}
+      {% endset %}
+      {% do surveyTableDataRows.append(
+          {
+              "tds": [
+              {
+                  "value": '<a href="' + url_for('reporting_unit_bp.view_reporting_unit', ru_ref=enrolment['business']['sampleUnitRef'], _anchor='survey-'+enrolment['survey']['shortName'] ) + '">' + enrolment['business']['sampleUnitRef'] + '</a>'
+              },
+              {
+                  "value": enrolment['business']['name']
+              },
+              {
+                  "value": enrolment['business']['trading_as'] if enrolment['business']['trading_as'] else ""
+              },
+              {
+                  "value": enrolment['survey']['surveyRef'] + ' ' + enrolment['survey']['shortName'] 
+              },
+              {
+                  "value": enrolmentData 
+              }
+              ]
+          }
+          ) %}
 
+  {% endfor %}
 
-                    <table class="table table--dense" summary="Enrolments">
-                        <thead class="table__head">
-                            <tr class="table__row">
-                                  <th scope="col" class="table__header">
-                                    RU Reference
-                                  </th>
-                                  <th scope="col" class="table__header">
-                                    Reporting unit name
-                                  </th>
-                                  <th scope="col" class="table__header">
-                                    Trading as
-                                  </th>
-                                  <th scope="col" class="table__header">
-                                    Survey
-                                  </th>
-                                  <th scope="col" class="table__header">
-                                    Enrolment status
-                                  </th>
-                                </tr>
-                              </thead>
-                              <tbody class="table__body">
-                                {% for enrolment in enrolments %}
-                                    <tr class="table__row">
-                                      <td class="table__cell">
-                                          <a href=" {{ url_for('reporting_unit_bp.view_reporting_unit', ru_ref=enrolment['business']['sampleUnitRef'], _anchor='survey-'+enrolment['survey']['shortName'] )}}">{{ enrolment['business']['sampleUnitRef'] }}</a>
-                                      </td>
-                                      <td class="table__cell">
-                                        {{ enrolment['business']['name'] }}
-                                      </td>
-                                      <td class="table__cell">
-                                        {% if enrolment['business']['trading_as'] %}
-                                          {{ enrolment['business']['trading_as'] }}
-                                        {% endif %}
-                                      </td>
-                                      <td class="table__cell">
-                                        {{ enrolment['survey']['surveyRef'] }} {{ enrolment['survey']['shortName'] }}
-                                      </td>
-                                      <td class="table__cell">
-                                        {{ enrolment['status'].title() }}
-                                        {% if enrolment['status'] == 'ENABLED' %}
-                                        <a href="{{ url_for('reporting_unit_bp.confirm_change_enrolment_status', ru_ref=enrolment['business']['sampleUnitRef'], ru_name=enrolment['business']['name'], survey_id=enrolment['survey']['id'],
-                                                            survey_name=enrolment['survey']['shortName'], respondent_id=respondent.id, respondent_first_name=respondent.firstName,
-                                                            respondent_last_name=respondent.lastName, business_id=enrolment['business']['id'], trading_as=enrolment['business']['trading_as'], change_flag='DISABLED', tab='respondents')}}"
-                                           id="change-enrolment-status">Disable</a>
-                                        {% elif enrolment['status'] == 'DISABLED' %}
-                                        <a href="{{ url_for('reporting_unit_bp.confirm_change_enrolment_status', ru_ref=enrolment['business']['sampleUnitRef'], ru_name=enrolment['business']['name'], survey_id=enrolment['survey']['id'],
-                                                            survey_name=enrolment['survey']['shortName'], respondent_id=respondent.id, respondent_first_name=respondent.firstName,
-                                                            respondent_last_name=respondent.lastName, business_id=enrolment['business']['id'], trading_as=enrolment['business']['trading_as'], change_flag='ENABLED', tab='respondents')}}"
-                                          id="change-enrolment-status">Re-enable</a>
-                                        {% endif %}
-                                      </td>
-                                    </tr>
-                                {% endfor %}
-                              </tbody>
-                            </table>
-                          </div>
-
-            </section>
-        </div>
+  {% do surveyTableData | setAttribute("trs", surveyTableDataRows) %}
+  {{
+      onsTable(surveyTableData)
+  }}
+</section>
 {% endblock %}


### PR DESCRIPTION
# Motivation and Context
Refactored a set of remaining templates in r'ops to use design system macros correctly.

# What has changed
- 500-error.html
- reporting-units-search.html
- reporting-units.html
- respondent-search.html
- respondent-search-results.html
- rs-inline-form.html
- rs-pagination.html
- rs-table.html
- respondent.html

# How to test?
Ensure pages and workflow is correct.
Ensure acceptance tests pass.