### PR TITLE
Render template on POST

### DIFF
--- a/response_operations_ui/views/respondents.py
+++ b/response_operations_ui/views/respondents.py
@@ -35,29 +35,14 @@ def search_redirect():
         flash('At least one input should be filled')
         return redirect(url_for('respondent_bp.respondent_home'))
 
-    return redirect(url_for('respondent_bp.respondent_search',
-                            email_address=form.email_address.data or '',
-                            first_name=form.first_name.data or '',
-                            last_name=form.last_name.data or '',
-                            page=request.args.get('page', 1)))
+    email_address = form.email_address.data or ''
+    first_name = form.first_name.data or ''
+    last_name = form.last_name.data or ''
 
-
-@respondent_bp.route('/search', methods=['GET'])
-@login_required
-def respondent_search():
     breadcrumbs = [{"text": "Respondents"}, {"text": "Search"}]
 
-    first_name = request.values.get('first_name', '')
-    last_name = request.values.get('last_name', '')
-    email_address = request.values.get('email_address', '')
     page = request.values.get('page', '1')
     limit = app.config["PARTY_RESPONDENTS_PER_PAGE"]
-
-    form = RespondentSearchForm()
-
-    form.first_name.data = first_name
-    form.last_name.data = last_name
-    form.email_address.data = email_address
 
     party_response = party_controller.search_respondents(first_name, last_name, email_address, page, limit)
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -21,7 +21,7 @@ class TestDates(unittest.TestCase):
 
     def test_get_formatted_date_full_dates(self):
         self.assertEqual(get_formatted_date('2000-01-01 00:00:00'), '01 Jan 2000 00:00')
-        self.assertEqual(get_formatted_date('2020-01-01 00:00:00'), '01 Jan 2020 00:00')
+        self.assertEqual(get_formatted_date('2019-01-01 00:00:00'), '01 Jan 2019 00:00')
         self.assertEqual(get_formatted_date('3000-01-01 00:00:00'), '01 Jan 3000 00:00')
         self.assertEqual(get_formatted_date('1999-12-31 23:59:59'), '31 Dec 1999 23:59')
         self.assertEqual(get_formatted_date('2000-01-01 00:00:00'), '01 Jan 2000 00:00')


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As it currently stands a search for a respondent uses a POST request that redirects to a GET request, in order to pass the parameters from the form data the request appends the first name, last name and email to the get request as url parameters.

Instead let's render the template on POST request as it has all the data it needs at that point anyway.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Modified the respondents.py file and removed the redirection.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Start the respondent operations UI and attempt to search for a user by email. This functionality should continue to work but the inputted data is no longer in the url. 

# Links
<!--- Add any links to issues (trello, github issues) -->
https://trello.com/c/rnMDzAee/1423-stop-email-address-being-passed-as-a-url-parameter-in-rops-3
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
