### PR TITLE
fixed bug in the case where my conversation and new respondent conver…

### DIFF
--- a/response_operations_ui/controllers/message_controllers.py
+++ b/response_operations_ui/controllers/message_controllers.py
@@ -74,9 +74,9 @@ def get_all_conversation_type_counts(survey_id, conversation_tab, business_id):
         totals = response.json()['totals']
 
         # Secure Message uses different identifiers to the tab names used in the ui, this translates the names
-        if totals['new_respondent_conversations']:
+        if 'new_respondent_conversations' in totals:
             totals['initial'] = totals.pop('new_respondent_conversations')
-        if totals['my_conversations']:
+        if 'my_conversations' in totals:
             totals['my messages'] = totals.pop('my_conversations')
 
         totals['current'] = totals[conversation_tab]

--- a/tests/controllers/test_message_controller.py
+++ b/tests/controllers/test_message_controller.py
@@ -1,0 +1,50 @@
+import responses
+import unittest
+
+from config import TestingConfig
+from response_operations_ui.controllers.message_controllers import get_all_conversation_type_counts
+from response_operations_ui import create_app
+from unittest.mock import patch
+
+url_get_message_counts = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/count'
+
+
+class TestMessageController(unittest.TestCase):
+
+    def setUp(self):
+        self.app = create_app('TestingConfig')
+        self.client = self.app.test_client()
+
+    @patch('response_operations_ui.controllers.message_controllers._get_jwt')
+    def test_get_all_conversation_type_counts_translates_tab_titles_when_all_zero_values(self, mock_get_jwt):
+        mock_counts = {'totals': {'open': 0,
+                                  'closed': 0,
+                                  'new_respondent_conversations': 0,
+                                  'my_conversations': 0,
+                                  'current': 0}}
+        mock_get_jwt.return_value = "blah"
+
+        with responses.RequestsMock() as mock_request:
+            mock_request.add(mock_request.GET, url_get_message_counts, json=mock_counts, status=200)
+            with self.app.app_context():
+                totals = get_all_conversation_type_counts('ASurveyId', 'initial', 'a party id')
+
+            self.assertEqual(totals['initial'], 0)
+            self.assertEqual(totals['my messages'], 0)
+
+    @patch('response_operations_ui.controllers.message_controllers._get_jwt')
+    def test_get_all_conversation_type_counts_translates_tab_titles_when_non_zero_values(self, mock_get_jwt):
+        mock_counts = {'totals': {'open': 0,
+                                  'closed': 1,
+                                  'new_respondent_conversations': 2,
+                                  'my_conversations': 3,
+                                  'current': 2}}
+        mock_get_jwt.return_value = "blah"
+
+        with responses.RequestsMock() as mock_request:
+            mock_request.add(mock_request.GET, url_get_message_counts, json=mock_counts, status=200)
+            with self.app.app_context():
+                totals = get_all_conversation_type_counts('ASurveyId', 'initial', 'a party id')
+
+            self.assertEqual(totals['initial'], 2)
+            self.assertEqual(totals['my messages'], 3)


### PR DESCRIPTION
# Motivation and Context
If an intial or my conversations tab had a count of zero then refining by ru causes a 500

# What has changed
wrote failing tests
Changed the way that the prescence of the counts for initial and my conversations was detected 

# How to test?
For Docker Dev - Pull secure message to make sure you have the master branch
run unit tests
run response ops. Send a message to a respondent. Then refine by the ru of the message sent and then an unknown ru. Validate that no 500 returned and counts are correct

# Links
 https://trello.com/c/WdOeWEQm


