### PR TITLE
No enrolements

### DIFF
--- a/response_operations_ui/controllers/case_controller.py
+++ b/response_operations_ui/controllers/case_controller.py
@@ -83,10 +83,10 @@ def get_case_groups_by_business_party_id(business_party_id):
 
     try:
         response.raise_for_status()
-    except requests.exceptions.HTTPError:
         if response.status_code == 204:
             logger.info('No case groups found for business', party_id=business_party_id)
             return []
+    except requests.exceptions.HTTPError:
         logger.exception('Failed to retrieve case groups', business_party_id=business_party_id)
         raise ApiError(response)
 
@@ -103,8 +103,11 @@ def get_cases_by_business_party_id(business_party_id):
 
     try:
         response.raise_for_status()
+        if response.status_code == 204:
+            logger.info('No cases found for business', business_party_id=business_party_id)
+            return []
     except requests.exceptions.HTTPError:
-        if response.status_code == 404 or response.status_code == 204:
+        if response.status_code == 404:
             logger.info('No cases found for business', business_party_id=business_party_id)
             return []
         logger.exception('Error retrieving cases', business_party_id=business_party_id)

--- a/tests/controllers/test_case_controller.py
+++ b/tests/controllers/test_case_controller.py
@@ -76,8 +76,6 @@ class TestCaseControllers(unittest.TestCase):
                 self.assertEqual(len(get_case_events), 2)
 
     def test_empty_response_if_no_enrolements_case_groups(self):
-        category = 'SUCCESSFUL_RESPONSE_UPLOAD'
-
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_case_groups, json=[], status=204,
                      content_type='application/json')
@@ -86,8 +84,6 @@ class TestCaseControllers(unittest.TestCase):
                 self.assertEqual(get_case_events, [])
 
     def test_empty_response_if_no_enrolements_cases(self):
-        category = 'SUCCESSFUL_RESPONSE_UPLOAD'
-
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_cases, json=[], status=204,
                      content_type='application/json')

--- a/tests/controllers/test_case_controller.py
+++ b/tests/controllers/test_case_controller.py
@@ -11,6 +11,8 @@ case_id = '10b04906-f478-47f9-a985-783400dd8482'
 with open('tests/test_data/case/case_events.json') as fp:
     case_events = json.load(fp)
 url_get_case_events = f'{TestingConfig.CASE_URL}/cases/{case_id}/events'
+url_get_case_groups = f'{TestingConfig.CASE_URL}/casegroups/partyid/{case_id}'
+url_get_cases = f'{TestingConfig.CASE_URL}/cases/partyid/{case_id}'
 
 
 class TestCaseControllers(unittest.TestCase):
@@ -72,3 +74,23 @@ class TestCaseControllers(unittest.TestCase):
                 get_case_events = case_controller.get_case_events_by_case_id(case_id, category)
 
                 self.assertEqual(len(get_case_events), 2)
+
+    def test_empty_response_if_no_enrolements_case_groups(self):
+        category = 'SUCCESSFUL_RESPONSE_UPLOAD'
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, url_get_case_groups, json=[], status=204,
+                     content_type='application/json')
+            with self.app.app_context():
+                get_case_events = case_controller.get_case_groups_by_business_party_id(case_id)
+                self.assertEqual(get_case_events, [])
+
+    def test_empty_response_if_no_enrolements_cases(self):
+        category = 'SUCCESSFUL_RESPONSE_UPLOAD'
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, url_get_cases, json=[], status=204,
+                     content_type='application/json')
+            with self.app.app_context():
+                get_case_events = case_controller.get_cases_by_business_party_id(case_id)
+                self.assertEqual(get_case_events, [])


### PR DESCRIPTION
# Motivation and Context
Resolves https://trello.com/c/e5mHbNx8/1484-ritm0307110-re-instate-deleted-account-15-01-20

# What has changed
if they have no enrolments then they should not see any, but instead they are getting a 500 response. This is because the 204 response code lives within a catch block and given that a 204 is a valid response then response.raise_for_status() never throws. The code attempts to json parse nothing which throws the 500 that they are seeing.

# How to test?
try to view enrolments for respondent with no enrolments. you used to get a 500, now you get a screen with no enrolments

# Links
https://trello.com/c/e5mHbNx8/1484-ritm0307110-re-instate-deleted-account-15-01-20

