### PR TITLE
Fixed issue with whitespace on sm reply

### DIFF
--- a/response_operations_ui/templates/conversation-view/cv-message-block.html
+++ b/response_operations_ui/templates/conversation-view/cv-message-block.html
@@ -39,7 +39,7 @@
             "messageName": 'conversation-message-body'
         })
     %}
-        {{ message.get('body') }}
+        <span style="white-space:pre-line">{{ message.get('body') }}</span>
     {% endcall %}
     {% if loop.last %}
         </div>


### PR DESCRIPTION
# Motivation and Context
Issue where any line breaks added to an SM reply were not displayed in the message thread.

# What has changed
Added a `white-space` attribute to maintain the formatting

# How to test?
Send a message that has line breaks and check that this is maintained in the thread.

