### PR TITLE
Added data attributes to login success/fail panel

### DIFF
--- a/response_operations_ui/templates/sign_in.html
+++ b/response_operations_ui/templates/sign_in.html
@@ -16,7 +16,10 @@
                         onsPanel({
                             "type": "error" if category == "failed_authentication" else "success",
                             "classes": "u-mb-s",
-                            "title":  message if category == "failed_authentication"
+                            "title":  message if category == "failed_authentication",
+                            "attributes": {
+                                "data-ga-category": "Error" if category == "failed_authentication" else "Password Success"
+                            }
                         })
                     %}
                     {% if category == "failed_authentication" %}


### PR DESCRIPTION
# Motivation and Context
We want to track in gtm the number of times the successful logout and failed login message is shown.

# What has changed
Added `data-ga-category="Success/Fail"` to the panel on the sign in template.

# How to test?
Check the data attribute exists and contains the appropriate value on the panel when you sign out or fail to login.
