### PR TITLE
temporarily disabled pipenv check, pending pipenv bug resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ build-kubernetes:
 
 lint:
 	pipenv run flake8 --exclude=./node_modules,./response_operations_ui/logger_config.py ./response_operations_ui ./tests
-	pipenv check ./response_operations_ui ./tests
+# TEMPORARILY disable pipenv check, pending resolution of pipenv bugs 2412 and 4147
+#	pipenv check ./response_operations_ui ./tests
 	npx gulp lint
 
 test: lint

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build-kubernetes:
 lint:
 	pipenv run flake8 --exclude=./node_modules,./response_operations_ui/logger_config.py ./response_operations_ui ./tests
 # TEMPORARILY disable pipenv check, pending resolution of pipenv bugs 2412 and 4147
+# TODO: re-enable as soon as possible.
 #	pipenv check ./response_operations_ui ./tests
 	npx gulp lint
 


### PR DESCRIPTION
# Motivation and Context
Disabled 'pipenv check' in Makefile, pending resolution of blocking pipenv bugs 2412 (plus duplicates) and 4147 

# What has changed
Commented the line 'pipenv check' in the Makefile, with a note to uncomment as soon as possible.

# How to test?
make build
make lint

# Links
https://trello.com/c/botlRPsE

# Screenshots (if appropriate):
