### PR TITLE
Add fix for load balancer ssl termination in GCP

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.0
+appVersion: 2.0.1

--- a/_infra/helm/response-operations-ui/templates/backendconfig.yaml
+++ b/_infra/helm/response-operations-ui/templates/backendconfig.yaml
@@ -6,4 +6,6 @@ metadata:
 spec:
   securityPolicy:
     name: "ras-cloud-armor-policy"
+  customRequestHeaders:
+    X-Forwarded-Proto: https
 {{- end }}

--- a/config.py
+++ b/config.py
@@ -6,12 +6,12 @@ VACANCIES_LIST = {'VACS2', 'VACS3', 'VACS4', 'VACS5'}
 
 
 class Config(object):
-
     DEBUG = os.getenv('DEBUG', False)
     TESTING = False
     PORT = os.getenv('PORT', 8085)
     GOOGLE_TAG_MANAGER = os.getenv('GOOGLE_TAG_MANAGER', None)
     GOOGLE_TAG_MANAGER_PROP = os.getenv('GOOGLE_TAG_MANAGER_PROP', None)
+    PREFERRED_URL_SCHEME = 'https'
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     RESPONSE_OPERATIONS_UI_SECRET = os.getenv('RESPONSE_OPERATIONS_UI_SECRET', "secret")
     SESSION_TYPE = "redis"
@@ -102,10 +102,10 @@ class Config(object):
     CREATE_ACCOUNT_ADMIN_PASSWORD = os.getenv('CREATE_ACCOUNT_ADMIN_PASSWORD')
 
 
-
 class DevelopmentConfig(Config):
     DEBUG = os.getenv('DEBUG', True)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'DEBUG')
+    PREFERRED_URL_SCHEME = 'http'
     REDIS_HOST = os.getenv('REDIS_HOST', "localhost")
     REDIS_PORT = os.getenv('REDIS_PORT', 6379)
     REDIS_DB = os.getenv('REDIS_DB', 0)

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -3,7 +3,7 @@ import os
 import requestsdefaulter
 
 import redis
-from flask import Flask
+from flask import Flask, request
 from flask_assets import Environment
 from flask_login import LoginManager
 from flask_session import Session
@@ -20,11 +20,12 @@ cf = ONSCloudFoundry()
 
 
 class GCPLoadBalancer:
+
     def __init__(self, app):
         self.app = app
 
     def __call__(self, environ, start_response):
-        scheme = environ.get("HTTP_X_FORWARDED_PROTO", "https")
+        scheme = environ.get("HTTP_X_FORWARDED_PROTO", "http")
         if scheme:
             environ["wsgi.url_scheme"] = scheme
         return self.app(environ, start_response)
@@ -44,7 +45,7 @@ def create_app(config_name=None):
         assets.cache = False
         assets.manifest = None
 
-    if not app.config['DEBUG']:
+    if not app.config['DEBUG'] and not cf.detected:
         app.wsgi_app = GCPLoadBalancer(app.wsgi_app)
 
     assets.url = app.static_url_path

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -16,8 +16,18 @@ from response_operations_ui.user import User
 from response_operations_ui.views import setup_blueprints
 from response_operations_ui.common.jinja_filters import filter_blueprint
 
-
 cf = ONSCloudFoundry()
+
+
+class GCPLoadBalancer:
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        scheme = environ.get("HTTP_X_FORWARDED_PROTO", "https")
+        if scheme:
+            environ["wsgi.url_scheme"] = scheme
+        return self.app(environ, start_response)
 
 
 def create_app(config_name=None):
@@ -33,6 +43,9 @@ def create_app(config_name=None):
     if app.config['DEBUG'] or app.config['TESTING']:
         assets.cache = False
         assets.manifest = None
+
+    if not app.config['DEBUG']:
+        app.wsgi_app = GCPLoadBalancer(app.wsgi_app)
 
     assets.url = app.static_url_path
 

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -3,7 +3,7 @@ import os
 import requestsdefaulter
 
 import redis
-from flask import Flask, request
+from flask import Flask
 from flask_assets import Environment
 from flask_login import LoginManager
 from flask_session import Session


### PR DESCRIPTION
When running behind a GCP load balancer with SSL termination use the HTTP_X_FORWARDED_PROTO header to set the protocol scheme on the WSGI middleware.

If this is not set then flask will redirect all requests back to http.