### PR TITLE
added image.tag to helm templates

### DIFF
--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -21,7 +21,11 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
+          {{- if eq .Values.image.tag "latest"}}
           image: "{{ .Values.image.name }}/{{ .Chart.Name }}:{{ .Chart.AppVersion }}"
+          {{- else}}
+          image: "{{ .Values.image.name }}/{{ .Chart.Name }}:{{ .Values.image.tag }}"
+          {{- end}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http-server

--- a/_infra/helm/response-operations-ui/values.yaml
+++ b/_infra/helm/response-operations-ui/values.yaml
@@ -18,6 +18,7 @@ analytics:
 
 image:
   name: eu.gcr.io/ons-rasrmbs-management
+  tag: latest
   pullPolicy: Always
 
 container:


### PR DESCRIPTION
# Motivation and Context
To allow the docker image to be specified in spinnaker

# What has changed
Docker image tag defaults to AppVersion but can now be overwritten.