### PR TITLE
added flag for allowing past dates

### DIFF
--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -210,8 +210,6 @@ spec:
             value: "{{ .Values.uaa.client_secret }}"
           - name: TEST_MODE
             value: "{{- if .Values.test.enabled -}}True{{- else -}}False{{- end -}}"
-          - name: WTF_CSRF_ENABLED
-            value: "{{- if .Values.test.enabled -}}False{{- else -}}True{{- end -}}"
           - name: ZIPKIN_DSN
             value: "http://$(ZIPKIN_SERVICE_HOST):$(ZIPKIN_SERVICE_PORT)/api/v1/spans"
           - name: ZIPKIN_SAMPLE_RATE

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -210,7 +210,7 @@ spec:
             value: "{{ .Values.uaa.client_secret }}"
           - name: TEST_MODE
             value: "{{- if .Values.test.enabled -}}True{{- else -}}False{{- end -}}"
-          - name: SECURE_COOKIES
+          - name: WTF_CSRF_ENABLED
             value: "{{- if .Values.test.enabled -}}False{{- else -}}True{{- end -}}"
           - name: ZIPKIN_DSN
             value: "http://$(ZIPKIN_SERVICE_HOST):$(ZIPKIN_SERVICE_PORT)/api/v1/spans"

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -202,14 +202,16 @@ spec:
               secretKeyRef:
                 name: jwt-secret
                 key: jwt-secret
-          - name: TEST_MODE
-            value: "{{- if .Values.test.enabled -}}True{{- else -}}False{{- end -}}"
           - name: UAA_SERVICE_URL
             value: "http://$(UAA_SERVICE_HOST):$(UAA_SERVICE_PORT)"
           - name: UAA_CLIENT_ID
             value: "{{ .Values.uaa.client_id }}"
           - name: UAA_CLIENT_SECRET
             value: "{{ .Values.uaa.client_secret }}"
+          - name: TEST_MODE
+            value: "{{- if .Values.test.enabled -}}True{{- else -}}False{{- end -}}"
+          - name: SECURE_COOKIES
+            value: "{{- if .Values.test.enabled -}}False{{- else -}}True{{- end -}}"
           - name: ZIPKIN_DSN
             value: "http://$(ZIPKIN_SERVICE_HOST):$(ZIPKIN_SERVICE_PORT)/api/v1/spans"
           - name: ZIPKIN_SAMPLE_RATE

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -202,6 +202,8 @@ spec:
               secretKeyRef:
                 name: jwt-secret
                 key: jwt-secret
+          - name: TEST_MODE
+            value: "{{- if .Values.test.enabled -}}True{{- else -}}False{{- end -}}"
           - name: UAA_SERVICE_URL
             value: "http://$(UAA_SERVICE_HOST):$(UAA_SERVICE_PORT)"
           - name: UAA_CLIENT_ID

--- a/_infra/helm/response-operations-ui/values.yaml
+++ b/_infra/helm/response-operations-ui/values.yaml
@@ -62,3 +62,6 @@ networkPolicy:
 dns:
   enabled: false
   wellKnownPort: 8080
+
+test:
+  enabled: false

--- a/config.py
+++ b/config.py
@@ -100,6 +100,8 @@ class Config(object):
     # 6 weeks in seconds
     CREATE_ACCOUNT_EMAIL_TOKEN_EXPIRY = int(os.getenv('CREATE_ACCOUNT_EMAIL_TOKEN_EXPIRY', '3628800'))
     CREATE_ACCOUNT_ADMIN_PASSWORD = os.getenv('CREATE_ACCOUNT_ADMIN_PASSWORD')
+    
+    TEST_MODE = strtobool(os.getenv('TEST_MODE', 'False'))
 
 
 class DevelopmentConfig(Config):

--- a/config.py
+++ b/config.py
@@ -102,6 +102,7 @@ class Config(object):
     CREATE_ACCOUNT_ADMIN_PASSWORD = os.getenv('CREATE_ACCOUNT_ADMIN_PASSWORD')
     
     TEST_MODE = strtobool(os.getenv('TEST_MODE', 'False'))
+    WTF_CSRF_ENABLED = strtobool(os.getenv('WTF_CSRF_ENABLED', 'True'))
 
 
 class DevelopmentConfig(Config):

--- a/config.py
+++ b/config.py
@@ -102,7 +102,6 @@ class Config(object):
     CREATE_ACCOUNT_ADMIN_PASSWORD = os.getenv('CREATE_ACCOUNT_ADMIN_PASSWORD')
     
     TEST_MODE = strtobool(os.getenv('TEST_MODE', 'False'))
-    WTF_CSRF_ENABLED = strtobool(os.getenv('WTF_CSRF_ENABLED', 'True'))
 
 
 class DevelopmentConfig(Config):

--- a/response_operations_ui/common/validators.py
+++ b/response_operations_ui/common/validators.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from wtforms import ValidationError
 
+from config import Config
 
 def valid_date_for_event(tag, form):
     form_datetime = datetime(int(form.year.data),
@@ -11,8 +12,7 @@ def valid_date_for_event(tag, form):
                              int(form.minute.data))
     tags_can_be_in_past = ("ref_period_start", "ref_period_end", "employment")
 
-    canCreatePastEvent = False
     
-    if canCreatePastEvent == False:
+    if not Config.TEST_MODE:
         if tag not in tags_can_be_in_past and form_datetime < datetime.now():
             raise ValidationError('Selected date can not be in the past')

--- a/response_operations_ui/common/validators.py
+++ b/response_operations_ui/common/validators.py
@@ -11,5 +11,8 @@ def valid_date_for_event(tag, form):
                              int(form.minute.data))
     tags_can_be_in_past = ("ref_period_start", "ref_period_end", "employment")
 
-    if tag not in tags_can_be_in_past and form_datetime < datetime.now():
-        raise ValidationError('Selected date can not be in the past')
+    canCreatePastEvent = False
+    
+    if canCreatePastEvent == False:
+        if tag not in tags_can_be_in_past and form_datetime < datetime.now():
+            raise ValidationError('Selected date can not be in the past')

--- a/response_operations_ui/common/validators.py
+++ b/response_operations_ui/common/validators.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 
 from wtforms import ValidationError
-
 from config import Config
+
 
 def valid_date_for_event(tag, form):
     form_datetime = datetime(int(form.year.data),
@@ -12,7 +12,6 @@ def valid_date_for_event(tag, form):
                              int(form.minute.data))
     tags_can_be_in_past = ("ref_period_start", "ref_period_end", "employment")
 
-    
     if not Config.TEST_MODE:
         if tag not in tags_can_be_in_past and form_datetime < datetime.now():
             raise ValidationError('Selected date can not be in the past')

--- a/response_operations_ui/views/sign_in.py
+++ b/response_operations_ui/views/sign_in.py
@@ -38,14 +38,14 @@ def sign_in():
         except DecodeError:
             logger.error("Unable to decode token - confirm the UAA public key is correct", access_token=access_token)
             abort(500)
-        else:
-            # store the token in the session (it's server side and stored in redis)
-            session['token'] = access_token
-            user = User(user_id)
-            login_user(user)
-            if 'next' in session:
-                return redirect(session['next'])
-            return redirect(url_for('home_bp.home'))
+    else:
+        # store the token in the session (it's server side and stored in redis)
+        session['token'] = access_token
+        user = User(user_id)
+        login_user(user)
+        if 'next' in session:
+            return redirect(session['next'])
+        return redirect(url_for('home_bp.home'))
 
     for message in get_flashed_messages(with_categories=True):
         if "failed_authentication" in message:

--- a/response_operations_ui/views/sign_in.py
+++ b/response_operations_ui/views/sign_in.py
@@ -38,14 +38,14 @@ def sign_in():
         except DecodeError:
             logger.error("Unable to decode token - confirm the UAA public key is correct", access_token=access_token)
             abort(500)
-    else:
-        # store the token in the session (it's server side and stored in redis)
-        session['token'] = access_token
-        user = User(user_id)
-        login_user(user)
-        if 'next' in session:
-            return redirect(session['next'])
-        return redirect(url_for('home_bp.home'))
+        else:
+            # store the token in the session (it's server side and stored in redis)
+            session['token'] = access_token
+            user = User(user_id)
+            login_user(user)
+            if 'next' in session:
+                return redirect(session['next'])
+            return redirect(url_for('home_bp.home'))
 
     for message in get_flashed_messages(with_categories=True):
         if "failed_authentication" in message:


### PR DESCRIPTION
# Motivation and Context
To help us test creating collection exercises, we needed to have a flag that is set to false by default, but allows testers to set it to true to allow past dates.

# What has changed
Added a `TEST_MODE` flag to `config.py`

# How to test?
Go to `config.py` and set `TEST_MODE` from `false` to `True`.
Create a collection exercise in response-operations-ui, then click on the link for the new collection exercise and then add MPS. There, try to enter a date in the past, and it should allow it. Conversely, if `TEST_MODE` is set to `False`, it won't.

# Links
[Trello card](https://trello.com/c/X7ZRA02H)
