### PR TITLE
Fix missing csrf token for collection instruments

### DIFF
--- a/response_operations_ui/templates/collection_exercise/ce-instrument-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-instrument-section.html
@@ -58,6 +58,7 @@
       {% set checkboxData = [] %}
 
       <form id="form-select-ci" action="" class="form" method="post" enctype="multipart/form-data">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <div id="ciSelectErrorPanel" class="{{'panel panel--simple panel--error' if error.section == 'ciSelect' else ''}}">
           <div id="ciSelectErrorPanelBody" class="{{'panel__body' if error.section == 'ciSelect' else ''}}">
             <input type="hidden" name="ce_id" value="{{ ce.id }}">
@@ -93,6 +94,7 @@
       </form>
     {% else %}
     <form id="form-load-ci" action="" class="form" method="post" enctype="multipart/form-data">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       <p>
         Add {{'another' if collection_instruments else 'a'}} collection instrument. Must be XLSX
       </p>

--- a/response_operations_ui/templates/collection_exercise/ce-sample-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-sample-section.html
@@ -78,6 +78,7 @@
             action=""
             class="form"
             enctype="multipart/form-data">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <p>
           Choose a sample file to check details before loading
         </p>


### PR DESCRIPTION
# Motivation and Context
More CSRF tokens missing.  Will try and get the sample file upload error in this PR too as it's partially a CSRF tokens issue and partially a javascript issue

Update: Contains the CSRF fix for the sample file but not the javascript part.  That will come in a separate pull request

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
