### PR TITLE
New structlog processor for Google Cloud Logging

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.16
+appVersion: 2.0.17

--- a/response_operations_ui/logger_config.py
+++ b/response_operations_ui/logger_config.py
@@ -34,6 +34,17 @@ def logger_initial_config(service_name=None,
         event_dict['service'] = service_name
         return event_dict
 
+    def add_severity_level(logger, method_name, event_dict):
+        """
+        Add the log level to the event dict.
+        """
+        if method_name == "warn":
+            # The stdlib has an alias
+            method_name = "warning"
+
+        event_dict["severity"] = method_name
+        return event_dict
+
     def zipkin_ids(logger, method_name, event_dict):
         event_dict['trace'] = ''
         event_dict['span'] = ''
@@ -48,6 +59,6 @@ def logger_initial_config(service_name=None,
         return event_dict
 
     logging.basicConfig(stream=sys.stdout, level=log_level, format=logger_format)
-    configure(processors=[zipkin_ids, add_log_level, filter_by_level, add_service, format_exc_info,
+    configure(processors=[add_severity_level, add_log_level, filter_by_level, add_service, format_exc_info,
                           TimeStamper(fmt=logger_date_format, utc=True, key="created_at"),
                           JSONRenderer(indent=indent)])

--- a/tests/test_logger_config.py
+++ b/tests/test_logger_config.py
@@ -24,7 +24,8 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        message_contents = '\n "event": "Test",\n "severity": "error",\n "level": "error",\n "service": "response-operations-ui"'
+        message_contents = '\n "event": "Test",\n "severity": "error",'\
+                           '\n "level": "error",\n "service": "response-operations-ui"'
         self.assertIn(message_contents, message)
 
     @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
@@ -35,7 +36,8 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        self.assertIn('"event": "Test", "severity": "error", "level": "error", "service": "response-operations-ui"', message)
+        self.assertIn('"event": "Test", "severity": "error", "level": "error",'\
+                      ' "service": "response-operations-ui"', message)
 
     @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
     @log_capture()
@@ -44,4 +46,5 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        self.assertIn('"event": "Test", "severity": "error", "level": "error", "service": "response-operations-ui"', message)
+        self.assertIn('"event": "Test", "severity": "error", "level": "error",'\
+                      ' "service": "response-operations-ui"', message)

--- a/tests/test_logger_config.py
+++ b/tests/test_logger_config.py
@@ -24,8 +24,7 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        message_contents = '\n "event": "Test",\n "trace": "",\n "span": "",\n "parent": "",' \
-                           '\n "level": "error",\n "service": "response-operations-ui"'
+        message_contents = '\n "event": "Test",\n "severity": "error",\n "level": "error",\n "service": "response-operations-ui"'
         self.assertIn(message_contents, message)
 
     @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
@@ -36,8 +35,7 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        self.assertIn('"event": "Test", "trace": "", "span": "", "parent": "",'
-                      ' "level": "error", "service": "response-operations-ui"', message)
+        self.assertIn('"event": "Test", "severity": "error", "level": "error", "service": "response-operations-ui"', message)
 
     @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
     @log_capture()
@@ -46,5 +44,4 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        self.assertIn('"event": "Test", "trace": "", "span": "", "parent": "",'
-                      ' "level": "error", "service": "response-operations-ui"', message)
+        self.assertIn('"event": "Test", "severity": "error", "level": "error", "service": "response-operations-ui"', message)

--- a/tests/test_logger_config.py
+++ b/tests/test_logger_config.py
@@ -36,7 +36,7 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        self.assertIn('"event": "Test", "severity": "error", "level": "error",'\
+        self.assertIn('"event": "Test", "severity": "error", "level": "error",'
                       ' "service": "response-operations-ui"', message)
 
     @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
@@ -46,5 +46,5 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        self.assertIn('"event": "Test", "severity": "error", "level": "error",'\
+        self.assertIn('"event": "Test", "severity": "error", "level": "error",'
                       ' "service": "response-operations-ui"', message)


### PR DESCRIPTION
# Motivation and Context
Added "severity level" processor to structlog, so Google Cloud Logging can parse the severity

# What has changed
New structlog processor defined in logger config, replacing obsolete zipkin processor
Unit tests updated for the change
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
make test, or
pipenv run python run_tests.py
Spin up cluster in Dev, with response ops pod built from image tag "cloud-logging-new"; generate an error by reqesting non-existent survey ID MBX; check Stackdriver logs for correct parsing and severity levels.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
https://trello.com/c/wDSxYgCQ
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
