### PR TITLE
fix route method for respondent search

### DIFF
--- a/response_operations_ui/views/respondents.py
+++ b/response_operations_ui/views/respondents.py
@@ -25,7 +25,7 @@ def respondent_home():
                            breadcrumbs=[{"text": "Respondents"}])
 
 
-@respondent_bp.route('/search', methods=['POST'])
+@respondent_bp.route('/search', methods=['GET', 'POST'])
 @login_required
 def search_redirect():
     form = RespondentSearchForm()


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When the search page loads, the path is:
http://localhost:8080/respondents/
After a search is made, this redirects to the results page:
http://localhost:8080/respondents/search
If the user reloads the page, or navigates back to it from a second page of results, the former 500 error (with no navigation visible) is replaced with the much friendlier and more usable error of:
"At least one input should be filled", in
http://localhost:8080/respondents/

# What has changed
Added a GET method to the Flask route for respondent search, alongside the POST used for actual searches. No refactoring has been done. 
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Local: 
- pipenv run python run_tests.py
- Spin up a local cluster, log into the surveys page on localhost:8085, search for a respondent, and reload the search results page.

Dev: 
- Spin up a cluster, with response ops pod built from image tag "respondents-search"
- run acceptance tests; port-forward to the pod on port 8080
- log into the surveys page on localhost:8080
- search for a respondent, reload the search results page, check for a friendly error

# Links
https://trello.com/c/jg2v393f
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
