### PR TITLE
add dashboard config if it has an ingress

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.36
+appVersion: 2.1.0

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -84,7 +84,9 @@ spec:
           - name: CREATE_ACCOUNT_EMAIL_TOKEN_EXPIRY
             value: "{{ .Values.admin.createccountEmailExpiry }}"
           - name: DASHBOARD_URL
-            {{- if .Values.dns.enabled }}
+            {{- if .Values.dashboard.hasIngress }}
+            value: {{ .Values.dashboard.address }}
+            {{- else if .Values.dns.enabled }}
             value: "http://responses-dashboard.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
             {{- else }}
             value: "http://$(RESPONSES_DASHBOARD_SERVICE_HOST):$(RESPONSES_DASHBOARD_SERVICE_PORT)"

--- a/_infra/helm/response-operations-ui/values.yaml
+++ b/_infra/helm/response-operations-ui/values.yaml
@@ -48,6 +48,10 @@ notify:
   requestCreateAccountTemplate: request_create_account_id
   requestPasswordChangeTemplate: request_password_change_id
 
+dashboard:
+  hasIngress: false
+  address: https://dashboard.example.com
+
 database:
    managedRedis: false
 


### PR DESCRIPTION
The overview screen uses the dashboard but in preprod/prod the dashboard is behind an ingress so the the usual way of getting the address must be modified slightly.
