### PR TITLE
strip whitespace at update to party controller

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.8
+appVersion: 2.1.9

--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -184,7 +184,7 @@ def _compare_contact_details(new_contact_details, old_contact_details):
         "firstName": "firstName",
         "lastName": "lastName",
         "telephone": "telephone",
-        "emailAddress": "new_email_address"}
+        "emailAddress": "new_email_address".strip()}
 
     return {old_key for old_key, new_key in contact_details_map.items()
             if old_contact_details[old_key] != new_contact_details[new_key]}

--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -157,7 +157,7 @@ def update_contact_details(respondent_id, form, ru_ref='NOT DEFINED'):
         "firstName": form.get('first_name'),
         "lastName": form.get('last_name'),
         "email_address": form.get('hidden_email'),
-        "new_email_address": form.get('email'),
+        "new_email_address": form.get('email').strip(),
         "telephone": form.get('telephone')
     }
 
@@ -184,7 +184,7 @@ def _compare_contact_details(new_contact_details, old_contact_details):
         "firstName": "firstName",
         "lastName": "lastName",
         "telephone": "telephone",
-        "emailAddress": "new_email_address".strip()}
+        "emailAddress": "new_email_address"}
 
     return {old_key for old_key, new_key in contact_details_map.items()
             if old_contact_details[old_key] != new_contact_details[new_key]}

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -677,11 +677,12 @@ class TestReportingUnits(ViewTestCase):
         changed_details = {
             "first_name": 'Jacky',
             "last_name": 'Turner',
-            "email": r'Jacky.Turner@thisemail.com\ ',
+            "email": r'Jacky.Turner@thisemail.com ',
             "telephone": '7971161859'}
         response = self.mock_for_change_details(changed_details, mock_request)
 
         self.assertEqual(response.status_code, 200)
+        self.assertIsNot(r'Jacky.Turner@thisemail.com '.encode(), response.data)
 
     @requests_mock.mock()
     def test_edit_contact_details_and_email_change(self, mock_request):

--- a/tests/views/test_respondents.py
+++ b/tests/views/test_respondents.py
@@ -94,11 +94,12 @@ class TestRespondents(ViewTestCase):
         changed_details = {
             "first_name": 'Jacky',
             "last_name": 'Turner',
-            "email": r'Jacky.Turner@thisemail.com\ ',
+            "email": r'Jacky.Turner@thisemail.com ',
             "telephone": '7971161867'}
         response = self.mock_for_change_details(changed_details, mock_request)
 
         self.assertEqual(response.status_code, 200)
+        self.assertIsNot(r'Jacky.Turner@thisemail.com '.encode(), response.data)
 
     @requests_mock.mock()
     def test_change_respondent_status(self, mock_request):


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix for https://collaborate2.ons.gov.uk/jira/browse/RAS-40, where in testing whitespace was stripped from the form during contact update (https://github.com/ONSdigital/response-operations-ui/pull/510) but not from the updated email pushed to Party service.

# What has changed
Added strip() of email to update_contact_details in party controller.
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
Same as last pull request https://github.com/ONSdigital/response-operations-ui/pull/510, but this time actually check for spaces in the database with `SELECT * FROM partysvc.respondent;`.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
