### PR TITLE
Use error text from api if provided

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.11
+appVersion: 2.1.12

--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -58,7 +58,9 @@ def upload_ru_specific_collection_instrument(collection_exercise_id, file, ru_re
     :param file: The collection instrument (spreadsheet) to be uploaded
     :param ru_ref: The ru_ref to link the collection instrument to.
     :type ru_ref: str
-    :return: True on success, False on failure.
+    :return: True, None on success. False, error text on failure (if the response is in json format) and False, None
+             otherwise.
+    :rtype: tuple
     """
     bound_logger = logger.bind(collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
     bound_logger.info('Uploading BRES collection instrument')
@@ -71,10 +73,12 @@ def upload_ru_specific_collection_instrument(collection_exercise_id, file, ru_re
         response.raise_for_status()
     except requests.exceptions.HTTPError:
         bound_logger.error('Failed to upload BRES collection instrument', status=response.status_code, exc_info=True)
-        return False
+        if response.headers['Content-Type'] == 'application/json':
+            return False, response.json().get('errors')[0]
+        return False, None
 
     bound_logger.info('Successfully uploaded BRES collection instrument')
-    return True
+    return True, None
 
 
 def link_collection_instrument_to_survey(survey_uuid, eq_id, form_type):

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -280,10 +280,11 @@ def _upload_collection_instrument(short_name, period):
         if not exercise:
             return make_response(jsonify({'message': 'Collection exercise not found'}), 404)
 
+        error_text = None
         if is_ru_specific_instrument:
             ru_ref = file.filename.split(".")[0]
-            upload_success = collection_instrument_controllers.upload_ru_specific_collection_instrument(exercise['id'],
-                                                                                                        file, ru_ref)
+            upload_success, error_text = collection_instrument_controllers.\
+                upload_ru_specific_collection_instrument(exercise['id'], file, ru_ref)
         else:
             form_type = _get_form_type(file.filename)
             upload_success = collection_instrument_controllers.upload_collection_instrument(exercise['id'],
@@ -292,10 +293,11 @@ def _upload_collection_instrument(short_name, period):
         if upload_success:
             success_panel = "Collection instrument loaded"
         else:
+            message = error_text if error_text else "Please try again"
             session['error'] = json.dumps({
                 "section": "ciFile",
                 "header": "Error: Failed to upload collection instrument",
-                "message": "Please try again"
+                "message": message
             })
     else:
         session['error'] = json.dumps(error)

--- a/tests/controllers/test_collection_instrument_controller.py
+++ b/tests/controllers/test_collection_instrument_controller.py
@@ -65,7 +65,20 @@ class TestCollectionInstrumentController(unittest.TestCase):
             rsps.add(rsps.POST, ci_bres_upload_url, status=200)
             with self.app.app_context():
                 file = self.create_test_file()
-                self.assertTrue(upload_ru_specific_collection_instrument(collection_exercise_id, file, ru_ref))
+                success, error_text = upload_ru_specific_collection_instrument(collection_exercise_id, file, ru_ref)
+                self.assertTrue(success)
+                self.assertIsNone(error_text)
+
+    def test_upload_ru_specific_collection_instrument_validation_failure(self):
+        """Tests on validation failure (400) False is returned"""
+        with responses.RequestsMock() as rsps:
+            error = 'Reporting unit 12345678901 already has an instrument uploaded for this collection exercise'
+            rsps.add(rsps.POST, ci_bres_upload_url, status=500, json={'errors': [error]})
+            with self.app.app_context():
+                file = self.create_test_file()
+                success, error_text = upload_ru_specific_collection_instrument(collection_exercise_id, file, ru_ref)
+                self.assertFalse(success)
+                self.assertEqual(error_text, error)
 
     def test_upload_ru_specific_collection_instrument_unauthorised(self):
         """Tests on unauthorised (401) False is returned"""
@@ -73,7 +86,9 @@ class TestCollectionInstrumentController(unittest.TestCase):
             rsps.add(rsps.POST, ci_bres_upload_url, status=401)
             with self.app.app_context():
                 file = self.create_test_file()
-                self.assertFalse(upload_ru_specific_collection_instrument(collection_exercise_id, file, ru_ref))
+                success, error_text = upload_ru_specific_collection_instrument(collection_exercise_id, file, ru_ref)
+                self.assertFalse(success)
+                self.assertIsNone(error_text)
 
     def test_upload_ru_specific_collection_instrument_failure(self):
         """Tests on failure (500) False is returned"""
@@ -81,7 +96,9 @@ class TestCollectionInstrumentController(unittest.TestCase):
             rsps.add(rsps.POST, ci_bres_upload_url, status=500, json={'errors': ['Failed to publish upload message']})
             with self.app.app_context():
                 file = self.create_test_file()
-                self.assertFalse(upload_ru_specific_collection_instrument(collection_exercise_id, file, ru_ref))
+                success, error_text = upload_ru_specific_collection_instrument(collection_exercise_id, file, ru_ref)
+                self.assertFalse(success)
+                self.assertEqual(error_text, 'Failed to publish upload message')
 
     def test_upload_collection_instrument(self):
         """Tests on success (200) True is returned"""


### PR DESCRIPTION
# Motivation and Context
For ru specific SEFT uploads, there is now a bit of validation with specific error text.  This PR allows that specific text to be rendered on screen if present, whilst falling back to default error text if there's nothing to put up.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
