### PR TITLE
changed message body character limit to 50000

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.22
+appVersion: 2.1.23

--- a/response_operations_ui/forms.py
+++ b/response_operations_ui/forms.py
@@ -30,7 +30,7 @@ class SecureMessageForm(FlaskForm):
                                       Length(max=96, message="Please enter a subject less than 100 characters")])
     body = TextAreaField('Message',
                          validators=[InputRequired(message="Please enter a message"),
-                                     Length(max=10000, message="Please enter a subject less than 10000 characters")])
+                                     Length(max=50000, message="Please enter a message less than 50000 characters")])
     survey = Label('Survey', text="")
     ru_ref = Label('RU ref', text="")
     business = Label('Business', text="")

--- a/response_operations_ui/templates/conversation-view/cv-reply-form.html
+++ b/response_operations_ui/templates/conversation-view/cv-reply-form.html
@@ -30,7 +30,7 @@
                 "label": {
                     "text": "Reply"
                 },
-                "maxlength": '10000',
+                "maxlength": '50000',
                 "attributes": {
                     "required": true
                 },

--- a/response_operations_ui/templates/create-message.html
+++ b/response_operations_ui/templates/create-message.html
@@ -133,7 +133,7 @@
                         <label class="label" for="secure-message-body">Message</label>
                         {{ form.body(id='secure-message-body',
                         class_='input input--textarea u-mb-m',
-                        rows='10', maxlength='10000', cols=80, required=required) }}
+                        rows='10', maxlength='50000', cols=80, required=required) }}
                     </div>
                 {%- endcall -%}
 


### PR DESCRIPTION
# Motivation and Context
The message body character limit needed to be increased to 50000 from the previous 10000.

# What has changed
* Message body now allow messages of up to 50000.

# How to test?
Send a message of between 10000-50000 characters, and make sure it validates correctly

# Links
[Jira card](https://collaborate2.ons.gov.uk/jira/browse/RAS-16)

[Related frontstage PR](https://github.com/ONSdigital/ras-frontstage/pull/617)
[Related secure-message PR](https://github.com/ONSdigital/ras-secure-message/pull/308)
