### PR TITLE
Handle rare empty eq or non-eq or seft issue better

### DIFF
--- a/response_operations_ui/templates/collection_exercise/ce-instrument-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-instrument-section.html
@@ -1,7 +1,7 @@
 <section class="ce-section {{'panel panel--simple panel--error' if missing_ci else ''}}">
   <h2 class="u-fs-r--b u-pt-m">Collection instruments ({{ collection_instruments | length }})</h2>
   {% if is_seft %}
-      {% if collection_instruments %}
+    {% if collection_instruments %}
       {% set surveyTableData = {
         "table_class": 'table--dense',
         "id": "collection-instruments-table",
@@ -15,8 +15,8 @@
         ]
       }
     %}
-      {% set surveyTableDataRows = [] %}
-      {% for collection_instrument in collection_instruments %}
+    {% set surveyTableDataRows = [] %}
+    {% for collection_instrument in collection_instruments %}
       {% do surveyTableDataRows.append(
         {
           "tds": [
@@ -26,82 +26,78 @@
           ]
         }
       ) %}
-      {% endfor %}
-      {% do surveyTableData | setAttribute("trs", surveyTableDataRows) %}
-      {{
-      onsTable(surveyTableData)
-    }}
-        {% if not ce.state|upper == "LIVE" %}  
-          <p class="field u-mt-l">
-            <a href="{{ url_for('collection_exercise_bp.get_seft_collection_instrument', period=ce.exerciseRef, short_name=survey.shortName.replace(' ', '')) }}"
-              role="button" class="btn btn--secondary" id="btn-mng-seft-ci"><span class="btn__inner">Manage collection instruments</span></a>
-          </p>
-        {% endif %}
-      {% elif not collection_instruments %}
-        {% if not ce.state|upper == "LIVE" %}  
-          <p class="field u-mt-l">
-            <a href="{{ url_for('collection_exercise_bp.get_seft_collection_instrument', period=ce.exerciseRef, short_name=survey.shortName.replace(' ', '')) }}"
-              role="button" class="btn btn--secondary" id="btn-load-seft-ci"><span class="btn__inner">Load collection instruments</span></a>
-          </p>
-        {% endif %}
+    {% endfor %}
+    {% do surveyTableData | setAttribute("trs", surveyTableDataRows) %}
+    {{ onsTable(surveyTableData) }}
+    {% if not ce.state|upper == "LIVE" %}
+      <p class="field u-mt-l">
+        <a href="{{ url_for('collection_exercise_bp.get_seft_collection_instrument', period=ce.exerciseRef, short_name=survey.shortName.replace(' ', '')) }}"
+          role="button" class="btn btn--secondary" id="btn-mng-seft-ci"><span class="btn__inner">Manage collection instruments</span></a>
+      </p>
+    {% endif %}
+    {% elif not collection_instruments %}
+      {% if not ce.state|upper == "LIVE" %}
+        <p class="field u-mt-l">
+          <a href="{{ url_for('collection_exercise_bp.get_seft_collection_instrument', period=ce.exerciseRef, short_name=survey.shortName.replace(' ', '')) }}"
+            role="button" class="btn btn--secondary" id="btn-load-seft-ci"><span class="btn__inner">Load collection instruments</span></a>
+        </p>
       {% endif %}
+    {% endif %}
   {% endif %}
 
   {% if not is_seft %}
-  {% if collection_instruments %}
-  {% set surveyTableData = {
-        "table_class": 'table--dense',
-        "id": "collection-instruments-table",
-        "caption": 'Sample details for this collection exercise',
-        "hideCaption": true,
-        "ths": [
-          { 
-              "value": "Collection instrument",
-              "class": "u-vh"
-          }
-        ]
-      }
-    %}
-  {% set surveyTableDataRows = [] %}
-  {% for collection_instrument in collection_instruments %}
-  {% if not locked %}
-  {% set formData = 
-          '<form id="form-unselect-ci-' + loop.index|string + '" action="" method="post">' +
-          '<a class="remove-icon" href=# id="unlink-ci-' + loop.index|string + '"></a>' +
-          '<input type="hidden" name="ce_id" value="' + ce.id + '">' +
-          '<input type="hidden" name="ci_id" value="' + collection_instrument.id + '">' +
-          '<input type="hidden" name="unselect-ci">' +
-          '<input type="hidden" name="csrf_token" value="' + csrf_token() + '"/>' +
-          '</form>'
-       %}
-  {% endif %}
-  {% do surveyTableDataRows.append(
-        {
-          "tds": [
+    {% if collection_instruments %}
+      {% set surveyTableData = {
+          "table_class": 'table--dense',
+          "id": "collection-instruments-table",
+          "caption": 'Sample details for this collection exercise',
+          "hideCaption": true,
+          "ths": [
             {
-              "value": collection_instrument.file_name
-            },
-            {
-              "value": formData,
-              "class": "u-ta-right"
+                "value": "Collection instrument",
+                "class": "u-vh"
             }
           ]
         }
-      ) %}
-  {% endfor %}
-  {% do surveyTableData | setAttribute("trs", surveyTableDataRows) %}
-  {{
-      onsTable(surveyTableData)
-    }}
-  {% for i in range(surveyTableDataRows | length) %}
-  {% set j = i + 1 %}
-  {% if not locked %}
-    <script{% if csp_nonce %} nonce="{{ csp_nonce() }}" {% endif %}>
-    document.getElementById("unlink-ci-{{ j }}").addEventListener('click', function () {
-      this.parentNode.submit()
-    });</script>
-  {% endif %}
-    {% endfor %}
+      %}
+      {% set surveyTableDataRows = [] %}
+      {% for collection_instrument in collection_instruments %}
+        {% if not locked %}
+          {% set formData =
+            '<form id="form-unselect-ci-' + loop.index|string + '" action="" method="post">' +
+            '<a class="remove-icon" href=# id="unlink-ci-' + loop.index|string + '"></a>' +
+            '<input type="hidden" name="ce_id" value="' + ce.id + '">' +
+            '<input type="hidden" name="ci_id" value="' + collection_instrument.id + '">' +
+            '<input type="hidden" name="unselect-ci">' +
+            '<input type="hidden" name="csrf_token" value="' + csrf_token() + '"/>' +
+            '</form>'
+          %}
+        {% endif %}
+        {% do surveyTableDataRows.append(
+          {
+            "tds": [
+              {
+                "value": collection_instrument.file_name
+              },
+              {
+                "value": formData,
+                "class": "u-ta-right"
+              }
+            ]
+          }
+        ) %}
+      {% endfor %}
+      {% do surveyTableData | setAttribute("trs", surveyTableDataRows) %}
+      {{ onsTable(surveyTableData) }}
+      {% for i in range(surveyTableDataRows | length) %}
+        {% set j = i + 1 %}
+        {% if not locked %}
+          <script{% if csp_nonce %} nonce="{{ csp_nonce() }}" {% endif %}>
+          document.getElementById("unlink-ci-{{ j }}").addEventListener('click', function () {
+            this.parentNode.submit()
+          });</script>
+        {% endif %}
+      {% endfor %}
     {% endif %}
 
     {% if not locked %}
@@ -121,23 +117,19 @@
           <div id="ciSelectErrorPanelBody" class="{{'panel__body' if error.section == 'ciSelect' else ''}}">
             <input type="hidden" name="ce_id" value="{{ ce.id }}">
             {% for ci in eq_ci_selectors %}
-            {% do checkboxData.append(
-                {
-                  "id": ci.id,
-                  "name": "checkbox-answer",
-                  "label": {
-                      "text": survey.surveyRef + ' ' + ci.file_name|string + ' eQ'
-                  },
-                  "value": ci.id
-                }
-              ) %}
+              {% do checkboxData.append(
+                  {
+                    "id": ci.id,
+                    "name": "checkbox-answer",
+                    "label": {
+                        "text": survey.surveyRef + ' ' + ci.file_name|string + ' eQ'
+                    },
+                    "value": ci.id
+                  }
+                ) %}
             {% endfor %}
-
             {% do checkboxesData | setAttribute("checkboxes", checkboxData) %}
-            {{ 
-              onsCheckboxes(checkboxesData) 
-            }}
-
+            {{ onsCheckboxes(checkboxesData) }}
             {{
               onsButton({
                 "text": "Add",
@@ -151,42 +143,12 @@
 
       </form>
       {% else %}
-      <form id="form-load-ci" action="" class="form" method="post" enctype="multipart/form-data">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <p>
-          Add {{'another' if collection_instruments else 'a'}} collection instrument. Must be XLSX
-        </p>
-        <div id="ciFileErrorPanel" class="{{'panel panel--simple panel--error' if error.section == 'ciFile' else ''}}">
-          <div id="ciFileErrorPanelBody" class="{{'panel__body' if error.section == 'ciFile' else ''}}">
-            <p id="ciFileErrorText" class="hidden">
-              Incorrect file type. Please choose a file type XLSX
-            </p>
-            {{-
-            onsUpload({
-                "id": "ciFile",
-                "name": "ciFile",
-                "listeners": {
-                  "change": "validateCI.checkSelectedCI(this.files)"
-                },
-                "accept": ".xlsx",
-                "label": {
-                    "classes": "u-vh",
-                    "text": "Choose CI file"
-                }
-            })
-        -}}
-          </div>
+        <div>
+            <ul>
+              <li>This survey type is an EQ but no collection instruments set up for it.</li>
+              <li>or, this survey hasn't had its survey mode set to either EQ or SEFT.</li>
+            </ul>
         </div>
-        {{
-        onsButton({
-          "text": "Add CI",
-          "id": "btn-load-ci",
-          "classes": "btn--small btn--disabled",
-          "name": "load-ci",
-          "submitType": "timer"
-        })
-      }}
-      </form>
       {% endif %}
     </div>
     {% endif %}


### PR DESCRIPTION
# Motivation and Context
We currently have EQ and SEFT as a hardcoded list until another bit of work is done for us to define which one it is on survey creation.
If a survey is recognised as EQ but has no collection instruments OR a new survey is added, the old SEFT collection instrument upload field is displayed.  This PR puts a more sensible message for the user to know what might be wrong.

Also sorted out the indentation in the template as it was difficult to understand.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
