### PR TITLE
Remove hardcoded lists and check surveyMode instead

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.12
+appVersion: 2.2.13

--- a/response_operations_ui/templates/collection_exercise/ce-instrument-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-instrument-section.html
@@ -1,6 +1,6 @@
 <section class="ce-section {{'panel panel--simple panel--error' if missing_ci else ''}}">
   <h2 class="u-fs-r--b u-pt-m">Collection instruments ({{ collection_instruments | length }})</h2>
-  {% if is_seft %}
+  {% if survey.surveyMode == 'SEFT' %}
     {% if collection_instruments %}
       {% set surveyTableData = {
         "table_class": 'table--dense',
@@ -45,7 +45,7 @@
     {% endif %}
   {% endif %}
 
-  {% if not is_seft %}
+  {% if survey.surveyMode != 'SEFT' %}
     {% if collection_instruments %}
       {% set surveyTableData = {
           "table_class": 'table--dense',

--- a/response_operations_ui/templates/survey.html
+++ b/response_operations_ui/templates/survey.html
@@ -92,7 +92,7 @@
   <section class="ce-list">
     <h2>Collection exercises for {{survey.shortName}}</h2>
     <div class="u-mb-l">
-      {% if is_eq_survey %}
+      {% if survey.surveyMode == 'EQ' %}
         <p class="field u-mt-l">
           <a href="{{ url_for('surveys_bp.get_link_collection_instrument', short_name=survey.shortName) }}"
             role="button" class="btn" id="link-collection-instrument" name="link-collection-instrument-link"><span class="btn__inner">Link collection instrument</span></a>

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -100,26 +100,6 @@ def view_collection_exercise(short_name, period):
     info_panel = request.args.get('info_panel')
     sorted_nudge_list = get_existing_sorted_nudge_events(ce_details['events'])
     error_json = _get_error_from_session()
-    # This logic needs to be changed once RAS-117 is done
-    seft_groups = ['ASHE',
-                   'BRES',
-                   'Blocks',
-                   'Bricks',
-                   'AIFDI',
-                   'AOFDI',
-                   'QIFDI',
-                   'QOFDI',
-                   'FSPS',
-                   'GovERD',
-                   'NBS',
-                   'OFATS',
-                   'PCS',
-                   'QITIS',
-                   'Sand & Gravel']
-    if ce_details['survey']['shortName'] in seft_groups:
-        is_seft = True
-    else:
-        is_seft = False
 
     return render_template('collection_exercise/collection-exercise.html',
                            breadcrumbs=breadcrumbs,
@@ -139,8 +119,7 @@ def view_collection_exercise(short_name, period):
                            show_msg=show_msg,
                            ci_classifiers=ce_details['ci_classifiers']['classifierTypes'],
                            info_panel=info_panel,
-                           existing_nudge=sorted_nudge_list if len(sorted_nudge_list) > 0 else [],
-                           is_seft=is_seft)
+                           existing_nudge=sorted_nudge_list if len(sorted_nudge_list) > 0 else [])
 
 
 def _get_error_from_session():

--- a/response_operations_ui/views/surveys.py
+++ b/response_operations_ui/views/surveys.py
@@ -71,20 +71,11 @@ def view_survey(short_name):
 
     _sort_collection_exercise(collection_exercises)
 
-    # This is temporary until the survey data includes whether it's an EQ or SEFT.  Until then we'll define the list
-    # so we can make the 'link collection instrument' button appear only on EQ surveys.
-    eq_surveys = ['MBS', 'QSS', 'QCAS', 'RSI', 'MWSS', 'QBS', 'UKIS', 'QPSESLA', 'QPSESPB', 'QPSESCS',
-                  'VACS2', 'VACS3', 'VACS4', 'VACS5', 'Ecommerce', 'CAT', 'COVID', 'EPE']
-    is_eq_survey = False
-    if short_name in eq_surveys:
-        is_eq_survey = True
-
     return render_template('survey.html',
                            survey=survey,
                            collection_exercises=collection_exercises,
                            breadcrumbs=breadcrumbs, updated_ce_message=updated_ce_message,
-                           created_ce_message=created_ce_message, newly_created_period=newly_created_period,
-                           is_eq_survey=is_eq_survey)
+                           created_ce_message=created_ce_message, newly_created_period=newly_created_period)
 
 
 @surveys_bp.route('/edit-survey-details/<short_name>', methods=['GET'])

--- a/tests/test_data/collection_exercise/formatted_collection_exercise_details.json
+++ b/tests/test_data/collection_exercise/formatted_collection_exercise_details.json
@@ -7,7 +7,8 @@
       "surveyRef": "074",
       "legalBasis": "Voluntary - BEIS",
       "surveyType": "Business",
-      "legalBasisRef": "Vol_BEIS"
+      "legalBasisRef": "Vol_BEIS",
+      "surveyMode": "SEFT"
     },
   "collection_exercise":
     {

--- a/tests/test_data/collection_exercise/formatted_collection_exercise_details_failedvalidation.json
+++ b/tests/test_data/collection_exercise/formatted_collection_exercise_details_failedvalidation.json
@@ -7,7 +7,8 @@
       "surveyRef": "074",
       "legalBasis": "Voluntary - BEIS",
       "surveyType": "Business",
-      "legalBasisRef": "Vol_BEIS"
+      "legalBasisRef": "Vol_BEIS",
+      "surveyMode": "SEFT"
     },
   "collection_exercise":
     {

--- a/tests/test_data/collection_exercise/formatted_collection_exercise_details_no_ci.json
+++ b/tests/test_data/collection_exercise/formatted_collection_exercise_details_no_ci.json
@@ -7,7 +7,8 @@
       "surveyRef": "074",
       "legalBasis": "Voluntary - BEIS",
       "surveyType": "Business",
-      "legalBasisRef": "Vol_BEIS"
+      "legalBasisRef": "Vol_BEIS",
+      "surveyMode": "SEFT"
     },
   "collection_exercise":
     {

--- a/tests/test_data/collection_exercise/formatted_collection_exercise_details_no_events.json
+++ b/tests/test_data/collection_exercise/formatted_collection_exercise_details_no_events.json
@@ -7,7 +7,8 @@
       "surveyRef": "074",
       "legalBasis": "Voluntary - BEIS",
       "surveyType": "Business",
-      "legalBasisRef": "Vol_BEIS"
+      "legalBasisRef": "Vol_BEIS",
+      "surveyMode": "SEFT"
     },
   "collection_exercise":
     {

--- a/tests/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json
+++ b/tests/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json
@@ -7,7 +7,8 @@
       "surveyRef": "074",
       "legalBasis": "Voluntary - BEIS",
       "surveyType": "Business",
-      "legalBasisRef": "Vol_BEIS"
+      "legalBasisRef": "Vol_BEIS",
+      "surveyMode": "SEFT"
     },
   "collection_exercise":
     {

--- a/tests/test_data/collection_exercise/seft_collection_exercise_details.json
+++ b/tests/test_data/collection_exercise/seft_collection_exercise_details.json
@@ -7,7 +7,8 @@
       "surveyRef": "074",
       "legalBasis": "Voluntary - BEIS",
       "surveyType": "Business",
-      "legalBasisRef": "Vol_BEIS"
+      "legalBasisRef": "Vol_BEIS",
+      "surveyMode": "SEFT"
     },
   "collection_exercise":
     {

--- a/tests/test_data/survey/ashe_response.json
+++ b/tests/test_data/survey/ashe_response.json
@@ -28,6 +28,7 @@
     "legalBasis": "Statistics of Trade Act 1947",
     "longName": "Annual Survey of Hours and Earnings",
     "shortName": "ASHE",
-    "surveyRef": "141"
+    "surveyRef": "141",
+    "surveyMode": "SEFT"
   }
 }

--- a/tests/test_data/survey/edited_survey_ce_details.json
+++ b/tests/test_data/survey/edited_survey_ce_details.json
@@ -13,6 +13,7 @@
     "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
     "longName": "Business Register and Employment Survey",
     "shortName": "BRES",
-    "surveyRef": "221"
+    "surveyRef": "221",
+    "surveyMode": "SEFT"
   }
 }

--- a/tests/test_data/survey/survey_by_id.json
+++ b/tests/test_data/survey/survey_by_id.json
@@ -4,5 +4,6 @@
     "longName": "Business Register and Employment Survey",
     "surveyRef": "221",
     "legalBasis": "Statistics of Trade Act 1947",
-    "legalBasisRef": "STA1947"
+    "legalBasisRef": "STA1947",
+    "surveyMode": "SEFT"
 }

--- a/tests/test_data/survey/updated_survey_list.json
+++ b/tests/test_data/survey/updated_survey_list.json
@@ -3,47 +3,54 @@
     "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
     "shortName": "BRES",
     "longName": "Business Register and Employment Survey",
-    "surveyRef": "221"
+    "surveyRef": "221",
+    "surveyMode": "SEFT"
   },
   {
     "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef88",
     "shortName": "QBX",
     "longName": "New Survey Long Name",
-    "surveyRef": "222"
+    "surveyRef": "222",
+    "surveyMode": "EQ"
   },
   {
     "id": "6aa8896f-ced5-4694-800c-6cd661b0c8b2",
     "legalBasis": "Statistics of Trade Act 1947",
     "longName": "Annual Survey of Hours and Earnings",
     "shortName": "ASHE",
-    "surveyRef": "141"
+    "surveyRef": "141",
+    "surveyMode": "SEFT"
   },
   {
     "id": "QOFDI_id",
     "legalBasis": "Statistics of Trade Act 1947",
     "longName": "Quarterly Outward Foreign Direct Investment Survey",
     "shortName": "QOFDI",
-    "surveyRef": "065"
+    "surveyRef": "065",
+    "surveyMode": "SEFT"
   },
   {
     "id": "AIFDI_id",
     "legalBasis": "Statistics of Trade Act 1947",
     "longName": "Annual Inward Foreign Direct Investment Survey",
     "shortName": "AIFDI",
-    "surveyRef": "062"
+    "surveyRef": "062",
+    "surveyMode": "SEFT"
   },
   {
     "id": "AOFDI_id",
     "legalBasis": "Statistics of Trade Act 1947",
     "longName": "Annual Outward Foreign Direct Investment Survey",
     "shortName": "AOFDI",
-    "surveyRef": "063"
+    "surveyRef": "063",
+    "surveyMode": "SEFT"
   },
   {
     "id": "QIFDI_id",
     "legalBasis": "Statistics of Trade Act 1947",
     "longName": "Quarterly Inward Foreign Direct Investment Survey",
     "shortName": "QIFDI",
-    "surveyRef": "064"
+    "surveyRef": "064",
+    "surveyMode": "SEFT"
   }
 ]

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -450,7 +450,8 @@ class TestMessage(ViewTestCase):
         "surveyRef": "062",
         "legalBasis": "Statistics of Trade Act 1947",
         "surveyType": "Business",
-        "legalBasisRef": "STA1947"
+        "legalBasisRef": "STA1947",
+        "surveyMode": "SEFT",
     }
     AOFDI_response = {
         "id": "04dbb407-4438-4f89-acc4-53445d75330c",
@@ -459,7 +460,8 @@ class TestMessage(ViewTestCase):
         "surveyRef": "063",
         "legalBasis": "Statistics of Trade Act 1947",
         "surveyType": "Business",
-        "legalBasisRef": "STA1947"
+        "legalBasisRef": "STA1947",
+        "surveyMode": "SEFT"
     }
     QIFDI_response = {
         "id": "c3eaeff3-d570-475d-9859-32c3bf87800d",
@@ -468,7 +470,8 @@ class TestMessage(ViewTestCase):
         "surveyRef": "064",
         "legalBasis": "Statistics of Trade Act 1947",
         "surveyType": "Business",
-        "legalBasisRef": "STA1947"
+        "legalBasisRef": "STA1947",
+        "surveyMode": "SEFT"
     }
     QOFDI_response = {
         "id": "57a43c94-9f81-4f33-bad8-f94800a66503",
@@ -477,7 +480,8 @@ class TestMessage(ViewTestCase):
         "surveyRef": "065",
         "legalBasis": "Statistics of Trade Act 1947",
         "surveyType": "Business",
-        "legalBasisRef": "STA1947"
+        "legalBasisRef": "STA1947",
+        "surveyMode": "SEFT"
     }
 
     @requests_mock.mock()


### PR DESCRIPTION
# Motivation and Context
Until the surveyMode was added for a survey, we had to add hardcoded lists of known EQ and SEFT surveys as a temporary solution.  Now that the surveyMode has been added, this PR removes the temporary lists and uses the supplied surveyMode data

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
