### PR TITLE
GDPR Account Deletion

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.14
+appVersion: 2.3.0

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -132,6 +132,12 @@ spec:
             {{- else }}
             value: "http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)"
             {{- end }}
+          - name: AUTH_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://auth.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: "http://$(AUTH_SERVICE_HOST):$(AUTH_SERVICE_PORT)"
+            {{- end }}
           - name: REDIS_HOST
             {{- if .Values.database.managedRedis }}
             valueFrom:

--- a/config.py
+++ b/config.py
@@ -47,6 +47,8 @@ class Config(object):
     PARTY_URL = os.getenv('PARTY_URL')
     PARTY_RESPONDENTS_PER_PAGE = os.getenv('PARTY_RESPONDENTS_PER_PAGE', 25)
     PARTY_BUSINESS_RESULTS_PER_PAGE = os.getenv('PARTY_BUSINESS_RESULTS_PER_PAGE', 25)
+    
+    AUTH_URL = os.getenv('AUTH_URL')
 
     GOOGLE_CLOUD_PROJECT = os.getenv('GOOGLE_CLOUD_PROJECT', 'test-project-id')
     PUBSUB_TOPIC = os.getenv('PUBSUB_TOPIC', 'ras-rm-notify-test')
@@ -108,6 +110,7 @@ class DevelopmentConfig(Config):
     SAMPLE_URL = os.getenv('SAMPLE_URL', 'http://localhost:8125')
     SAMPLE_FILE_UPLOADER_URL = os.getenv('SAMPLE_FILE_UPLOADER_URL', 'http://localhost:8125')
     SURVEY_URL = os.getenv('SURVEY_URL', 'http://localhost:8080')
+    AUTH_URL = os.getenv('AUTH_URL', 'http://localhost:8041')
 
     UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL', 'http://localhost:9080')
     UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID', 'response_operations')

--- a/response_operations_ui/controllers/respondent_controllers.py
+++ b/response_operations_ui/controllers/respondent_controllers.py
@@ -36,8 +36,8 @@ def find_respondent_account_by_username(username):
     headers = {
         'Authorization': 'Basic %s' % base64.b64encode(bytes(auth)).decode("ascii")
     }
-    url = f'{app.config["AUTH_URL"]}/api/account/users/username'
-    response = requests.get(url, json={"username": username}, headers=headers)
+    url = f'{app.config["AUTH_URL"]}/api/account/user/{username}'
+    response = requests.get(url, headers=headers)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
@@ -70,8 +70,8 @@ def undo_delete_respondent_account_by_username(username):
     headers = {
         'Authorization': 'Basic %s' % base64.b64encode(bytes(auth)).decode("ascii")
     }
-    url = f'{app.config["AUTH_URL"]}/api/account/user'
-    form_data = {"username": username}
+    url = f'{app.config["AUTH_URL"]}/api/account/user/{username}'
+    form_data = {"mark_for_deletion": False}
     response = requests.patch(url, data=form_data, headers=headers)
     try:
         response.raise_for_status()

--- a/response_operations_ui/controllers/respondent_controllers.py
+++ b/response_operations_ui/controllers/respondent_controllers.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import logging
 
 import requests
@@ -5,7 +7,6 @@ from flask import current_app as app
 from structlog import wrap_logger
 
 from response_operations_ui.exceptions.exceptions import ApiError
-
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -28,3 +29,64 @@ def search_respondent_by_email(email):
     logger.info("Respondent retrieved by email successfully")
 
     return response.json()
+
+
+def find_respondent_account_by_username(username):
+    logger.info('Finding respondent account')
+    auth = "{}:{}".format(app.config["SECURITY_USER_NAME"], app.config["SECURITY_USER_PASSWORD"]).encode('utf-8')
+    headers = {
+        'Authorization': 'Basic %s' % base64.b64encode(bytes(auth)).decode("ascii")
+    }
+    url = f'{app.config["AUTH_URL"]}/api/account/users/username'
+    response = requests.get(url, json={"username": username}, headers=headers)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.error('Failed to retrieve user', email=obfuscate_email(username))
+        raise ApiError(response)
+    logger.info('Successfully retrieve user', email=obfuscate_email(username))
+    return response.json()
+
+
+def delete_respondent_account_by_username(username):
+    logger.info('Marking respondent for deletion')
+    auth = "{}:{}".format(app.config["SECURITY_USER_NAME"], app.config["SECURITY_USER_PASSWORD"]).encode('utf-8')
+    headers = {
+        'Authorization': 'Basic %s' % base64.b64encode(bytes(auth)).decode("ascii")
+    }
+    url = f'{app.config["AUTH_URL"]}/api/account/user'
+    form_data = {"username": username}
+    response = requests.delete(url, data=form_data, headers=headers)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.error('Failed to mark respondent for deletion', username=obfuscate_email(username))
+        raise ApiError(response)
+    logger.info('Successfully marked respondent for deletion', username=obfuscate_email(username))
+
+
+def undo_delete_respondent_account_by_username(username):
+    logger.info('Restating respondent marked for deletion')
+    auth = "{}:{}".format(app.config["SECURITY_USER_NAME"], app.config["SECURITY_USER_PASSWORD"]).encode('utf-8')
+    headers = {
+        'Authorization': 'Basic %s' % base64.b64encode(bytes(auth)).decode("ascii")
+    }
+    url = f'{app.config["AUTH_URL"]}/api/account/user'
+    form_data = {"username": username}
+    response = requests.patch(url, data=form_data, headers=headers)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.error('Failed to undo respondent mark for deletion', username=obfuscate_email(username))
+        raise ApiError(response)
+    logger.info('Successfully restated respondent', username=obfuscate_email(username))
+
+
+def obfuscate_email(email):
+    """Takes an email address and returns an obfuscated version of it.
+    For example: test@example.com would turn into t**t@e*********m
+    """
+    m = email.split('@')
+    prefix = f'{m[0][0]}{"*" * (len(m[0]) - 2)}{m[0][-1]}'
+    domain = f'{m[1][0]}{"*" * (len(m[1]) - 2)}{m[1][-1]}'
+    return f'{prefix}@{domain}'

--- a/response_operations_ui/controllers/respondent_controllers.py
+++ b/response_operations_ui/controllers/respondent_controllers.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import logging
 
 import requests

--- a/response_operations_ui/templates/delete-respondent.html
+++ b/response_operations_ui/templates/delete-respondent.html
@@ -1,0 +1,68 @@
+{% from "components/panel/_macro.njk" import onsPanel %}
+{% from "components/button/_macro.njk" import onsButton %}
+{% extends "layouts/base.html" %}
+{% set page_title = "Delete Respondent" %}
+{% block main %}
+{% include 'partials/flashed-messages.html' %}
+<section>
+  {% if delete %}
+    <h1 id="respondent-data">Delete {{ respondent_details.firstName[0]|upper }}{{ respondent_details.firstName[1:] }} {{ respondent_details.lastName[0]|upper }}{{ respondent_details.lastName[1:] }}'s data</h1>
+    {% call
+      onsPanel({
+        "type":"warn",
+        "id": "warn-delete",
+        "classes": "u-mb-m",
+      })
+    %}
+    <p>All of the information about this person will be deleted</p>
+    <p>Once their data has been removed, it is unrecoverable</p>
+    <p>Allow 24 hours for this to be completed.</p>
+    {% endcall %}
+    <div class="u-mb-l">
+      <form id="del-respondent-data" action="{{ url_for('respondent_bp.delete_respondent', respondent_id=respondent_details.id, mark_for_deletion=mark_for_deletion) }}" class="form u-mb-l" method="post">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <p>
+          {{
+              onsButton({
+                  "text": "Delete respondent",
+                  "id": "btn-del-res",
+                  "name": "delete-respondent"
+              })
+          }}
+         
+          <a href="{{ url_for('respondent_bp.respondent_details', respondent_id=respondent_details.id) }}"
+              role="button" type="cancel" class="btn btn--secondary" id="btn-cancel-del-respondent"><span class="btn__inner">Cancel</span></a>
+        </p>
+      </form>
+    </div>
+  {% elif not delete %}
+    <h1 id="undo-respondent-data">Cancel deletion of {{ respondent_details.firstName[0]|upper }}{{ respondent_details.firstName[1:] }} {{ respondent_details.lastName[0]|upper }}{{ respondent_details.lastName[1:] }}'s data</h1>
+    {% call
+      onsPanel({
+        "type":"warn",
+        "id": "warn-delete",
+        "classes": "u-mb-m",
+        })
+    %}
+    <p>The account is pending deletion and will be deleted by the end of day processing</p>
+    <p>Once their data has been removed, it is unrecoverable</p>
+    {% endcall %}
+    <div class="u-mb-l">
+      <form id="undo-respondent-deletion" action="{{ url_for('respondent_bp.undo_delete_respondent', respondent_id=respondent_details.id) }}" class="form u-mb-l" method="post">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <p>
+          {{
+            onsButton({
+                "text": "Remove respondent for deletion",
+                "id": "btn-undo-res-del",
+                "name": "undo-respondent-delete"
+            })
+          }}
+          <a href="{{ url_for('respondent_bp.respondent_details', respondent_id=respondent_details.id) }}"
+              role="button" type="cancel" class="btn btn--secondary" id="btn-cancel-undo-del-respondent"><span class="btn__inner">Cancel</span></a>
+        </p>
+      </form>
+    </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/response_operations_ui/templates/respondent-search/respondent-search.html
+++ b/response_operations_ui/templates/respondent-search/respondent-search.html
@@ -3,10 +3,21 @@
 {% from "components/lists/_macro.njk" import onsList %}
 {% from "components/fieldset/_macro.njk" import onsFieldset %}
 {% from "components/input/_macro.njk" import onsInput %}
+{% from "components/panel/_macro.njk" import onsPanel %}
 
 {% set page_title = "Respondents" %}
-
 {% block main %}
+    {% if success_panel %}
+    {% call
+        onsPanel({
+            "type": "success",
+            "classes": "u-mb-s",
+            "id": "success-panel"
+        })
+    %}
+        {{ success_panel }}
+    {% endcall %}
+{% endif %}
     <h1>Find a respondent</h1>
     {% with messages = get_flashed_messages() %}
         {%- if messages -%}

--- a/response_operations_ui/templates/respondent.html
+++ b/response_operations_ui/templates/respondent.html
@@ -63,7 +63,14 @@
                               {
                                   "description": accountStatus,
                                   "id": "respondent-account-status"
-                              }                                     
+                              },
+                                {
+                                  "description": '<a id="delete-respondent" href="' + url_for('respondent_bp.delete_respondent', respondent_id=respondent.id) + '">Delete respondent</a>' if not mark_for_deletion else ""
+                              }  
+                              ,
+                                {
+                                  "description": '<a id="undo-delete-respondent" href="' + url_for('respondent_bp.undo_delete_respondent', respondent_id=respondent.id) + '">Remove respondent for deletion</a>' if mark_for_deletion else ""
+                              }                                
                           ]
                       }
                   ]

--- a/response_operations_ui/views/respondents.py
+++ b/response_operations_ui/views/respondents.py
@@ -7,9 +7,8 @@ from flask_paginate import Pagination
 from structlog import wrap_logger
 
 from response_operations_ui.common.respondent_utils import filter_respondents
-from response_operations_ui.controllers import party_controller, reporting_units_controllers
+from response_operations_ui.controllers import party_controller, reporting_units_controllers, respondent_controllers
 from response_operations_ui.forms import RespondentSearchForm, EditContactDetailsForm
-
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -22,7 +21,7 @@ respondent_bp = Blueprint('respondent_bp', __name__,
 def respondent_home():
     return render_template('respondent-search/respondent-search.html',
                            form=RespondentSearchForm(),
-                           breadcrumbs=[{"text": "Respondents"}])
+                           breadcrumbs=[{"text": "Respondents"}, {}])
 
 
 @respondent_bp.route('/search', methods=['GET', 'POST'])
@@ -82,10 +81,9 @@ def search_redirect():
 @respondent_bp.route('/respondent-details/<respondent_id>', methods=['GET'])
 @login_required
 def respondent_details(respondent_id):
-
     respondent = party_controller.get_respondent_by_party_id(respondent_id)
     enrolments = party_controller.get_respondent_enrolments(respondent)
-
+    account = respondent_controllers.find_respondent_account_by_username(respondent['emailAddress'])
     breadcrumbs = [
         {
             "text": "Respondents",
@@ -93,7 +91,7 @@ def respondent_details(respondent_id):
         },
         {
             "text": f"{respondent['emailAddress']}"
-        }
+        },{}
     ]
 
     respondent['status'] = respondent['status'].title()
@@ -106,7 +104,11 @@ def respondent_details(respondent_id):
     elif info:
         flash(info, 'information')
 
-    return render_template('respondent.html', respondent=respondent, enrolments=enrolments, breadcrumbs=breadcrumbs)
+    return render_template('respondent.html',
+                           respondent=respondent,
+                           enrolments=enrolments,
+                           breadcrumbs=breadcrumbs,
+                           mark_for_deletion=account['mark_for_deletion'])
 
 
 @respondent_bp.route('/edit-contact-details/<respondent_id>', methods=['GET'])
@@ -163,7 +165,7 @@ def resend_verification(party_id):
     reporting_units_controllers.resend_verification_email(party_id)
     logger.info("Re-sent verification email.", party_id=party_id)
     flash('Verification email re-sent')
-    return redirect(url_for('respondent_bp.respondent_details', respondent_id=party_id,))
+    return redirect(url_for('respondent_bp.respondent_details', respondent_id=party_id, ))
 
 
 @respondent_bp.route('<respondent_id>/change-enrolment-status', methods=['POST'])
@@ -196,3 +198,52 @@ def confirm_change_respondent_status(party_id):
                            email_address=respondent['emailAddress'],
                            change_flag=request.args['change_flag'],
                            tab='respondents')
+
+
+@respondent_bp.route('/delete-respondent/<respondent_id>', methods=['GET', 'POST'])
+@login_required
+def delete_respondent(respondent_id):
+    respondent = party_controller.get_respondent_by_party_id(respondent_id)
+
+    if request.method == 'POST':
+        respondent_controllers.delete_respondent_account_by_username(respondent['emailAddress'])
+        flash('The account is pending deletion and will be deleted by the end of day processing.', 'success')
+        return redirect(url_for('respondent_bp.respondent_details', respondent_id=respondent_id, ))
+    breadcrumbs = [
+        {
+            "url": '/respondents',
+            "text": 'Respondents'
+        },
+        {
+            "text": f"{respondent['emailAddress']}",
+            "url": f"/respondents/respondent-details/{respondent_id}"
+        },
+        {"text": 'Delete'}, {}
+    ]
+
+    return render_template('delete-respondent.html', respondent_details=respondent,
+                           delete=True, breadcrumbs=breadcrumbs)
+
+
+@respondent_bp.route('/undo-delete-respondent/<respondent_id>', methods=['GET', 'POST'])
+@login_required
+def undo_delete_respondent(respondent_id):
+    respondent = party_controller.get_respondent_by_party_id(respondent_id)
+
+    if request.method == 'POST':
+        respondent_controllers.undo_delete_respondent_account_by_username(respondent['emailAddress'])
+        flash('Respondent for deletion removed', 'success')
+        return redirect(url_for('respondent_bp.respondent_details', respondent_id=respondent_id, ))
+    breadcrumbs = [
+        {
+            "url": '/respondents',
+            "text": 'Respondents'
+        },
+        {
+            "text": f"{respondent['emailAddress']}",
+            "url": f"/respondents/respondent-details/{respondent_id}"
+        },
+        {"text": 'Cancel Delete'}, {}
+    ]
+    return render_template('delete-respondent.html', respondent_details=respondent,
+                           delete=False, breadcrumbs=breadcrumbs)

--- a/response_operations_ui/views/respondents.py
+++ b/response_operations_ui/views/respondents.py
@@ -91,7 +91,7 @@ def respondent_details(respondent_id):
         },
         {
             "text": f"{respondent['emailAddress']}"
-        },{}
+        }, {}
     ]
 
     respondent['status'] = respondent['status'].title()

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -39,8 +39,7 @@ url_get_survey_by_id = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}'
 url_get_respondent_party_by_party_id = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents/id/{respondent_party_id}'
 url_get_iac = f'{TestingConfig.IAC_URL}/iacs'
 url_get_case = f'{TestingConfig.CASE_URL}/cases/{case_id}?iac=true'
-url_delete_respondent_account_by_username = f'{TestingConfig.AUTH_URL}/api/account/user'
-url_get_respondent_account_by_username = f'{TestingConfig.AUTH_URL}/api/account/users/username'
+url_auth_respondent_account = f'{TestingConfig.AUTH_URL}/api/account/user'
 
 
 with open('tests/test_data/reporting_units/respondent.json') as fp:

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -39,6 +39,9 @@ url_get_survey_by_id = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}'
 url_get_respondent_party_by_party_id = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents/id/{respondent_party_id}'
 url_get_iac = f'{TestingConfig.IAC_URL}/iacs'
 url_get_case = f'{TestingConfig.CASE_URL}/cases/{case_id}?iac=true'
+url_delete_respondent_account_by_username = f'{TestingConfig.AUTH_URL}/api/account/user'
+url_get_respondent_account_by_username = f'{TestingConfig.AUTH_URL}/api/account/users/username'
+
 
 with open('tests/test_data/reporting_units/respondent.json') as fp:
     respondent = json.load(fp)

--- a/tests/views/test_respondents.py
+++ b/tests/views/test_respondents.py
@@ -81,6 +81,7 @@ class TestRespondents(ViewTestCase):
 
     @requests_mock.mock()
     def test_edit_contact_details_and_email_change(self, mock_request):
+        mock_request.get(url_get_respondent_account_by_username, json={"mark_for_deletion": False})
         changed_details = {
             "first_name": 'Jacky',
             "last_name": 'Turner',
@@ -92,6 +93,7 @@ class TestRespondents(ViewTestCase):
 
     @requests_mock.mock()
     def test_edit_contact_details_email_change_with_trailing_space(self, mock_request):
+        mock_request.get(url_get_respondent_account_by_username, json={"mark_for_deletion": False})
         changed_details = {
             "first_name": 'Jacky',
             "last_name": 'Turner',
@@ -105,6 +107,7 @@ class TestRespondents(ViewTestCase):
     @requests_mock.mock()
     def test_change_respondent_status(self, mock_request):
         mock_request.put(url_change_respondent_status)
+        mock_request.get(url_get_respondent_account_by_username, json={"mark_for_deletion": False})
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)

--- a/tests/views/test_respondents.py
+++ b/tests/views/test_respondents.py
@@ -10,8 +10,7 @@ from tests.views.test_reporting_units import url_edit_contact_details, url_get_p
     url_get_casegroups_by_business_party_id, url_get_cases_by_business_party_id, url_get_business_party_by_party_id, \
     url_get_available_case_group_statuses_direct, url_get_survey_by_id, url_get_respondent_party_by_party_id, \
     url_get_collection_exercise_by_id, url_get_iac, url_change_respondent_status, \
-    url_delete_respondent_account_by_username, url_get_respondent_account_by_username
-
+    url_auth_respondent_account
 respondent_party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
 business_party_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
 party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
@@ -81,7 +80,7 @@ class TestRespondents(ViewTestCase):
 
     @requests_mock.mock()
     def test_edit_contact_details_and_email_change(self, mock_request):
-        mock_request.get(url_get_respondent_account_by_username, json={"mark_for_deletion": False})
+        mock_request.get(f'{url_auth_respondent_account}/Jacky.Turner@email.com', json={"mark_for_deletion": False})
         changed_details = {
             "first_name": 'Jacky',
             "last_name": 'Turner',
@@ -93,7 +92,7 @@ class TestRespondents(ViewTestCase):
 
     @requests_mock.mock()
     def test_edit_contact_details_email_change_with_trailing_space(self, mock_request):
-        mock_request.get(url_get_respondent_account_by_username, json={"mark_for_deletion": False})
+        mock_request.get(f'{url_auth_respondent_account}/Jacky.Turner@email.com', json={"mark_for_deletion": False})
         changed_details = {
             "first_name": 'Jacky',
             "last_name": 'Turner',
@@ -107,7 +106,7 @@ class TestRespondents(ViewTestCase):
     @requests_mock.mock()
     def test_change_respondent_status(self, mock_request):
         mock_request.put(url_change_respondent_status)
-        mock_request.get(url_get_respondent_account_by_username, json={"mark_for_deletion": False})
+        mock_request.get(f'{url_auth_respondent_account}/Jacky.Turner@email.com', json={"mark_for_deletion": False})
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
@@ -218,8 +217,8 @@ class TestRespondents(ViewTestCase):
     @requests_mock.mock()
     def test_delete_respondent_template_for_delete(self, mock_request):
         mock_request.put(url_change_respondent_status)
-        mock_request.delete(url_delete_respondent_account_by_username)
-        mock_request.get(url_get_respondent_account_by_username, json={"mark_for_deletion": True})
+        mock_request.delete(url_auth_respondent_account)
+        mock_request.get(f'{url_auth_respondent_account}/Jacky.Turner@email.com', json={"mark_for_deletion": True})
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
@@ -247,8 +246,8 @@ class TestRespondents(ViewTestCase):
     @requests_mock.mock()
     def test_delete_respondent_template_for_undo_delete(self, mock_request):
         mock_request.put(url_change_respondent_status)
-        mock_request.patch(url_delete_respondent_account_by_username)
-        mock_request.get(url_get_respondent_account_by_username, json={"mark_for_deletion": False})
+        mock_request.patch(f'{url_auth_respondent_account}/Jacky.Turner@email.com')
+        mock_request.get(f'{url_auth_respondent_account}/Jacky.Turner@email.com', json={"mark_for_deletion": False})
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)


### PR DESCRIPTION
# Motivation and Context
This PR provides a new feature to mark respondent user account ready for deletion with the next processing and to undo the deletion.

# What has changed
> * New html included as per the prototype
> * New endpoints to `respondent.py`
> * Changes to `respondent_controller.py`
> * Changes to existing view

# How to test?
Smoke Test
# Links
[Trello](https://trello.com/c/eg9lY2nj/12-s20-gdpr-retention-manual-account-deletion-process-following-respondent-request-8)