### PR TITLE
Changes to fix the issue with X-Forward-Proto not supported

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.3.0
+appVersion: 2.3.1

--- a/_infra/helm/response-operations-ui/templates/backendconfig.yaml
+++ b/_infra/helm/response-operations-ui/templates/backendconfig.yaml
@@ -1,13 +1,11 @@
 {{- if .Values.publicIP }}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: rops-backend-config
 spec:
   securityPolicy:
     name: "ras-cloud-armor-policy"
-  customRequestHeaders:
-    X-Forwarded-Proto: https
   sessionAffinity: 
     affinityType: CLIENT_IP
   timeoutSec: {{ .Values.ingress.timeoutSec }}

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -182,6 +182,8 @@ spec:
             {{- else }}
             value: "http://$(SAMPLE_SERVICE_HOST):$(SAMPLE_SERVICE_PORT)"
             {{- end }}
+          - name: SCHEME
+            value: {{ .Values.scheme }}
           - name: SEND_EMAIL_TO_GOV_NOTIFY
             value: "{{ .Values.sendEmailToGovNotify }}"
           - name: SURVEY_URL

--- a/_infra/helm/response-operations-ui/values.yaml
+++ b/_infra/helm/response-operations-ui/values.yaml
@@ -20,6 +20,8 @@ gcp:
   project: ras-rm-sandbox
   topic: ras-rm-notify-test
 
+scheme: http
+
 image:
   devRepo: eu.gcr.io/ons-rasrmbs-management
   name: eu.gcr.io/ons-rasrmbs-management

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -39,7 +39,7 @@ class GCPLoadBalancer:
         self.app = app
 
     def __call__(self, environ, start_response):
-        scheme = environ.get("HTTP_X_FORWARDED_PROTO", "http")
+        scheme = environ.get("SCHEME", "http")
         if scheme:
             environ["wsgi.url_scheme"] = scheme
         return self.app(environ, start_response)


### PR DESCRIPTION
# Motivation and Context
With the kubernetes upgrade response ops ui is failing for x forward proto not supported. This PR contains the fix for the same.

# What has changed
X-Forward-Proto has been removed and a schema has been introduced for referance.

# How to test?
Smoke Test
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
