### PR TITLE
Bug fix for reminder delete checkbox not disabled when a more recent …

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.3.3
+appVersion: 2.3.4

--- a/response_operations_ui/templates/update-event-date.html
+++ b/response_operations_ui/templates/update-event-date.html
@@ -156,9 +156,12 @@
                           "id": "checkbox",
                           "name": "checkbox",
                           "label": {
-                              "text": "Confirm"
+                              "text": "Disabled"
                           },
-                          "value": "y"
+                          "value": "y",
+                          "attributes": {
+                              "disabled": true
+                          }
                       }
                   ]
               })

--- a/tests/views/test_update_event_date.py
+++ b/tests/views/test_update_event_date.py
@@ -256,6 +256,7 @@ class TestUpdateEventDate(ViewTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("To remove this event, delete more recent reminders first.".encode(), response.data)
+        self.assertIn("Disabled".encode(), response.data)
 
     @requests_mock.mock()
     def test_put_update_event_date_update_bad_request(self, mock_request):


### PR DESCRIPTION
Bug fix for reminder delete checkbox not disabled when a more recent one exists

# Motivation and Context
Due to the resent design changes on response operation ui the existing functionality of the delete option for the reminder message to be disabled when more recent one exists was reverted, which created a bug into the system.

# What has changed
The functionality has been reinstated with disabling the previous reminder delete

# How to test?
Business Approval

# Links
[Trello](https://trello.com/c/LHBhIsJy/172-ritm0446724-2nd-reminder-not-showing-after-deleting-1st-reminder)