### PR TITLE
Get respondents in a single call, rather then many

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.5
+appVersion: 2.4.6

--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlencode
 
 import requests
 from flask import current_app as app
@@ -67,6 +68,22 @@ def get_respondent_by_party_id(respondent_party_id):
         raise ApiError(response)
 
     logger.info('Successfully retrieved respondent party', respondent_party_id=respondent_party_id)
+    return response.json()
+
+
+def get_respondent_by_party_ids(uuids):
+    logger.info('Retrieving respondent data for multiple respondents', respondent_party_ids=uuids)
+    params = urlencode([("id", uuid) for uuid in uuids])
+    url = f'{app.config["PARTY_URL"]}/party-api/v1/respondents'
+    response = requests.get(url, auth=app.config['BASIC_AUTH'], params=params)
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.error('Error retrieving respondent data for multiple respondents', respondent_party_ids=uuids)
+        raise ApiError(response)
+
+    logger.info('Successfully retrieved respondent data for multiple respondents', respondent_party_ids=uuids)
     return response.json()
 
 

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -49,8 +49,8 @@ def view_reporting_unit(ru_ref):
     surveys = [get_survey_by_id(survey_id) for survey_id in survey_ids]
 
     # Get all respondents for the given ru
-    respondents = [party_controller.get_respondent_by_party_id(respondent['partyId'])
-                   for respondent in reporting_unit.get('associations')]
+    respondent_party_ids = [respondent['partyId'] for respondent in reporting_unit.get('associations')]
+    respondents = party_controller.get_respondent_by_party_ids(respondent_party_ids)
 
     # Link collection exercises and respondents to appropriate surveys
     linked_surveys = [survey_with_respondents_and_exercises(survey, respondents, live_collection_exercises, ru_ref)

--- a/tests/test_data/party/respondent_party_list.json
+++ b/tests/test_data/party/respondent_party_list.json
@@ -1,0 +1,24 @@
+[
+  {
+      "associations": [
+          {
+              "enrolments": [
+                  {
+                      "enrolmentStatus": "ENABLED",
+                      "name": "Business Register and Employment Survey",
+                      "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+                  }
+              ],
+              "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+              "sampleUnitRef": "50012345678"
+          }
+      ],
+      "emailAddress": "Jacky.Turner@email.com",
+      "firstName": "Jacky",
+      "lastName": "Turner",
+      "telephone": "7971161859",
+      "id": "cd592e0f-8d07-407b-b75d-e01fbdae8233",
+      "sampleUnitType": "BI",
+      "status": "ACTIVE"
+  }
+]

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -37,6 +37,7 @@ url_get_available_case_group_statuses_direct = f'{TestingConfig.CASE_URL}/casegr
                                                f'/{collection_exercise_id_1}/{ru_ref}'
 url_get_survey_by_id = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}'
 url_get_respondent_party_by_party_id = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents/id/{respondent_party_id}'
+url_get_respondent_party_by_list = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents?id={respondent_party_id}'
 url_get_iac = f'{TestingConfig.IAC_URL}/iacs'
 url_get_case = f'{TestingConfig.CASE_URL}/cases/{case_id}?iac=true'
 url_auth_respondent_account = f'{TestingConfig.AUTH_URL}/api/account/user'
@@ -67,6 +68,8 @@ with open('tests/test_data/survey/single_survey.json') as fp:
     survey = json.load(fp)
 with open('tests/test_data/party/respondent_party.json') as fp:
     respondent_party = json.load(fp)
+with open('tests/test_data/party/respondent_party_list.json') as fp:
+    respondent_party_list = json.load(fp)
 with open('tests/test_data/iac/iac.json') as fp:
     iac = json.load(fp)
 
@@ -97,7 +100,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
@@ -138,7 +141,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, status_code=404)
         mock_request.get(url_get_casegroups_by_business_party_id, json=[])
-        mock_request.get(url_get_respondent_party_by_party_id, json=[])
+        mock_request.get(url_get_respondent_party_by_list, json=[])
 
         response = self.client.get("/reporting-units/50012345678")
 
@@ -223,7 +226,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, status_code=404)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
@@ -280,7 +283,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', status_code=500)
 
         response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
@@ -301,7 +304,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', status_code=404)
 
         response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
@@ -320,7 +323,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
@@ -339,7 +342,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
@@ -358,7 +361,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, json={})
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
@@ -460,7 +463,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
@@ -490,7 +493,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
@@ -522,6 +525,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
@@ -645,7 +649,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
         response = self.client.post(f"/reporting-units/50012345678/edit-contact-details/{respondent_party_id}",
@@ -762,7 +766,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
         mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 


### PR DESCRIPTION
# Motivation and Context
Previously, for the reporting unit page it would get each respondent from party one by one.  This PR makes it get them all in one go.  There is a slight performance increase for doing this (on a sufficiently large reporting unit I saw up to a 25% improvement, going from 4sec to 3 seconds) and the logging becomes less noisy (2 log lines instead of 2 x number of respondent log lines).

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
Go to a reporting unit and make sure the respondent data looks like it always does.  This PR shouldn't have any noticeable changes for the user.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
