### PR TITLE
Remove casegroups call

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.6
+appVersion: 2.4.7

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.5
+appVersion: 2.4.6

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -30,7 +30,7 @@ def view_reporting_unit(ru_ref):
     reporting_unit = party_controller.get_party_by_ru_ref(ru_ref)
 
     cases = case_controller.get_cases_by_business_party_id(reporting_unit['id'])
-    case_groups = case_controller.get_case_groups_by_business_party_id(reporting_unit['id'])
+    case_groups = [case['caseGroup'] for case in cases]
 
     # Get all collection exercises for retrieved case groups
     collection_exercise_ids = {case_group['collectionExerciseId'] for case_group in case_groups}

--- a/tests/test_data/case/cases_list_completed.json
+++ b/tests/test_data/case/cases_list_completed.json
@@ -16,7 +16,7 @@
       "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
       "sampleUnitRef": "50012345678",
       "sampleUnitType": "B",
-      "caseGroupStatus": "NOTSTARTED"
+      "caseGroupStatus": "COMPLETE"
     },
     "responses": [],
     "caseEvents": null
@@ -38,7 +38,7 @@
       "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
       "sampleUnitRef": "50012345678",
       "sampleUnitType": "B",
-      "caseGroupStatus": "NOTSTARTED"
+      "caseGroupStatus": "COMPLETE"
     },
     "responses": [],
     "caseEvents": null

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -30,11 +30,9 @@ url_resend_verification_email = f'{TestingConfig.PARTY_URL}/party-api/v1/resend-
 
 url_get_party_by_ru_ref = f'{TestingConfig.PARTY_URL}/party-api/v1/parties/type/B/ref/{ru_ref}'
 url_get_cases_by_business_party_id = f'{TestingConfig.CASE_URL}/cases/partyid/{business_party_id}'
-url_get_casegroups_by_business_party_id = f'{TestingConfig.CASE_URL}/casegroups/partyid/{business_party_id}'
+
 url_get_collection_exercise_by_id = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'
 url_get_business_party_by_party_id = f'{TestingConfig.PARTY_URL}/party-api/v1/businesses/id/{business_party_id}'
-url_get_available_case_group_statuses_direct = f'{TestingConfig.CASE_URL}/casegroups/transitions' \
-                                               f'/{collection_exercise_id_1}/{ru_ref}'
 url_get_survey_by_id = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}'
 url_get_respondent_party_by_party_id = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents/id/{respondent_party_id}'
 url_get_iac = f'{TestingConfig.IAC_URL}/iacs'
@@ -142,30 +140,6 @@ class TestReportingUnits(ViewTestCase):
         self.assertEqual(response.status_code, 200)
 
     @requests_mock.mock()
-    def test_get_reporting_unit_casegroups_fail(self, mock_request):
-        mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
-        mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, status_code=500)
-
-        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
-
-        request_history = mock_request.request_history
-        self.assertEqual(len(request_history), 3)
-        self.assertEqual(response.status_code, 500)
-
-    @requests_mock.mock()
-    def test_get_reporting_unit_casegroups_404(self, mock_request):
-        mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
-        mock_request.get(url_get_cases_by_business_party_id, json=[])
-        mock_request.get(url_get_casegroups_by_business_party_id, status_code=404)
-
-        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
-
-        request_history = mock_request.request_history
-        self.assertEqual(len(request_history), 3)
-        self.assertEqual(response.status_code, 500)
-
-    @requests_mock.mock()
     def test_get_reporting_unit_collection_exercise_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
@@ -222,8 +196,6 @@ class TestReportingUnits(ViewTestCase):
         response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
         request_history = mock_request.request_history
-        # TODO: url_get_business_party_by_party_id and url_get_available_case_group_statuses_direct are called twice
-        # duplicated calls should probably be refactored out
         self.assertEqual(len(request_history), 8)
         self.assertEqual(response.status_code, 500)
 
@@ -404,7 +376,6 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
-        mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
@@ -430,11 +401,9 @@ class TestReportingUnits(ViewTestCase):
         mock_request.put(url_change_respondent_status)
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
-        mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
@@ -461,11 +430,9 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(get_respondent_by_id_url)
         mock_request.put(url_change_respondent_status)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
-        mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
@@ -585,11 +552,9 @@ class TestReportingUnits(ViewTestCase):
         mock_request.put(url_edit_contact_details)
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
-        mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
@@ -702,11 +667,9 @@ class TestReportingUnits(ViewTestCase):
         mock_request.put(url_change_enrolment_status)
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
-        mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
         mock_request.get(url_get_survey_by_id, json=survey)
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -53,10 +53,10 @@ with open('tests/test_data/party/business_reporting_unit.json') as fp:
     business_reporting_unit = json.load(fp)
 with open('tests/test_data/case/cases_list.json') as fp:
     cases_list = json.load(fp)
+with open('tests/test_data/case/cases_list_completed.json') as fp:
+    cases_list_completed = json.load(fp)
 with open('tests/test_data/case/case_groups_list.json') as fp:
     case_groups = json.load(fp)
-with open('tests/test_data/case/case_groups_list_completed.json') as fp:
-    case_groups_completed = json.load(fp)
 with open('tests/test_data/collection_exercise/collection_exercise.json') as fp:
     collection_exercise = json.load(fp)
 with open('tests/test_data/party/business_party.json') as fp:
@@ -91,7 +91,6 @@ class TestReportingUnits(ViewTestCase):
     def test_get_reporting_unit(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
@@ -136,7 +135,6 @@ class TestReportingUnits(ViewTestCase):
     def test_get_reporting_unit_cases_404(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, status_code=404)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=[])
         mock_request.get(url_get_respondent_party_by_party_id, json=[])
 
         response = self.client.get("/reporting-units/50012345678")
@@ -171,21 +169,19 @@ class TestReportingUnits(ViewTestCase):
     def test_get_reporting_unit_collection_exercise_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', status_code=500)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', status_code=500)
 
         response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
         request_history = mock_request.request_history
-        self.assertEqual(len(request_history), 4)
+        self.assertEqual(len(request_history), 3)
         self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_party_id_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, status_code=500)
@@ -193,14 +189,13 @@ class TestReportingUnits(ViewTestCase):
         response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
         request_history = mock_request.request_history
-        self.assertEqual(len(request_history), 6)
+        self.assertEqual(len(request_history), 5)
         self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_survey_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
@@ -211,14 +206,13 @@ class TestReportingUnits(ViewTestCase):
         request_history = mock_request.request_history
         # TODO: url_get_business_party_by_party_id and url_get_available_case_group_statuses_direct are called twice
         # duplicated calls should probably be refactored out
-        self.assertEqual(len(request_history), 8)
+        self.assertEqual(len(request_history), 7)
         self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_respondent_party_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
@@ -230,14 +224,13 @@ class TestReportingUnits(ViewTestCase):
         request_history = mock_request.request_history
         # TODO: url_get_business_party_by_party_id and url_get_available_case_group_statuses_direct are called twice
         # duplicated calls should probably be refactored out
-        self.assertEqual(len(request_history), 9)
+        self.assertEqual(len(request_history), 8)
         self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_iac_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
@@ -250,14 +243,13 @@ class TestReportingUnits(ViewTestCase):
         request_history = mock_request.request_history
         # TODO: url_get_business_party_by_party_id and url_get_available_case_group_statuses_direct are called twice
         # duplicated calls should probably be refactored out
-        self.assertEqual(len(request_history), 10)
+        self.assertEqual(len(request_history), 9)
         self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_iac_404(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
@@ -274,8 +266,7 @@ class TestReportingUnits(ViewTestCase):
     @requests_mock.mock()
     def test_get_reporting_unit_when_changed_status_shows_new_status(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
-        mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups_completed)
+        mock_request.get(url_get_cases_by_business_party_id, json=cases_list_completed)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
@@ -293,7 +284,6 @@ class TestReportingUnits(ViewTestCase):
     def test_get_reporting_unit_shows_change_link(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
@@ -310,8 +300,7 @@ class TestReportingUnits(ViewTestCase):
     @requests_mock.mock()
     def test_get_reporting_unit_hides_change_link_when_no_available_statuses(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
-        mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups_completed)
+        mock_request.get(url_get_cases_by_business_party_id, json=cases_list_completed)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)
@@ -323,7 +312,7 @@ class TestReportingUnits(ViewTestCase):
         response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn("Change</a>".encode(), response.data)
+        self.assertNotIn("ChaFnge</a>".encode(), response.data)
 
     @requests_mock.mock()
     def test_search_reporting_units_for_1_business_redirects_and_holds_correct_data(self, mock_request):
@@ -412,7 +401,6 @@ class TestReportingUnits(ViewTestCase):
         mock_request.post(url_resend_verification_email)
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(url_get_casegroups_by_business_party_id, json=case_groups)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise)
         mock_request.get(url_get_business_party_by_party_id, json=business_party)

--- a/tests/views/test_respondents.py
+++ b/tests/views/test_respondents.py
@@ -7,8 +7,8 @@ import requests_mock
 from config import TestingConfig
 from tests.views import ViewTestCase
 from tests.views.test_reporting_units import url_edit_contact_details, url_get_party_by_ru_ref, \
-    url_get_casegroups_by_business_party_id, url_get_cases_by_business_party_id, url_get_business_party_by_party_id, \
-    url_get_available_case_group_statuses_direct, url_get_survey_by_id, url_get_respondent_party_by_party_id, \
+    url_get_cases_by_business_party_id, url_get_business_party_by_party_id, \
+    url_get_survey_by_id, url_get_respondent_party_by_party_id, \
     url_get_collection_exercise_by_id, url_get_iac, url_change_respondent_status, \
     url_auth_respondent_account
 respondent_party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
@@ -17,10 +17,15 @@ party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
 survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
 collection_exercise_id_1 = '14fb3e68-4dca-46db-bf49-04b84e07e77c'
 collection_exercise_id_2 = '9af403f8-5fc5-43b1-9fca-afbd9c65da5c'
+ru_ref = '50012345678'
+
 get_business_by_id_url = f'{TestingConfig.PARTY_URL}/party-api/v1/businesses/id/{business_party_id}'
 get_respondent_by_email_url = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents/email'
 get_respondent_by_id_url = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents/id/{party_id}'
 get_survey_by_id_url = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}'
+url_get_casegroups_by_business_party_id = f'{TestingConfig.CASE_URL}/casegroups/partyid/{business_party_id}'
+url_get_available_case_group_statuses_direct = f'{TestingConfig.CASE_URL}/casegroups/transitions' \
+                                               f'/{collection_exercise_id_1}/{ru_ref}'
 iac_1 = 'jkbvyklkwj88'
 iac_2 = 'ljbgg3kgstr4'
 


### PR DESCRIPTION
# Motivation and Context
The reporting unit page was making 2 calls, one to get case data and the other to get casegroup data.  The former contains the latter, so this PR makes it so theres only 1 call needed.  This should result in less communications between the systems, and a very minor performance boost (in the tens/hundreds of ms).

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
Open a reporting unit page and see that all the expected data is there.  This PR shouldn't be noticable to a user of the system.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
