### PR TITLE
Fix error when party list is empty

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.7
+appVersion: 2.4.8

--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -72,7 +72,22 @@ def get_respondent_by_party_id(respondent_party_id):
 
 
 def get_respondent_by_party_ids(uuids):
+    """
+    Gets data for multiple respondents from party.  If the list is empty, returns an empty
+    list without going to party.
+
+    This call will return as many parties as it can find.  If some are missing, no error will
+    be thrown.
+
+    :param uuids: A list of uuid strings of respondent party ids
+    :type uuids: list
+    :return: A list of dicts containing party data
+    """
     logger.info('Retrieving respondent data for multiple respondents', respondent_party_ids=uuids)
+    if not uuids:
+        logger.info('List is empty.  Returning empty list', respondent_party_ids=uuids)
+        return []
+
     params = urlencode([("id", uuid) for uuid in uuids])
     url = f'{app.config["PARTY_URL"]}/party-api/v1/respondents'
     response = requests.get(url, auth=app.config['BASIC_AUTH'], params=params)

--- a/tests/controllers/test_party_controller.py
+++ b/tests/controllers/test_party_controller.py
@@ -3,7 +3,7 @@ import mock
 from collections import namedtuple
 
 from response_operations_ui import create_app
-from response_operations_ui.controllers.party_controller import search_respondents
+from response_operations_ui.controllers.party_controller import search_respondents, get_respondent_by_party_ids
 from response_operations_ui.exceptions.exceptions import SearchRespondentsException
 
 fake_response = namedtuple('Response', 'status_code json')
@@ -27,3 +27,9 @@ class TestPartyController(unittest.TestCase):
             # Test and assert
             with self.assertRaises(SearchRespondentsException):
                 search_respondents('firstname', 'lastname', 'name@email.com', page=1, limit=limit)
+
+    def test_get_respondent_by_party_ids_with_empty_list(self):
+        input_data = []
+        expected_output = []
+        output = get_respondent_by_party_ids(input_data)
+        self.assertEqual(output, expected_output)


### PR DESCRIPTION
# Motivation and Context
If a reporting unit had no respondents associated with it, it would cause an error due to it calling party with an empty list.
This PR fixes that

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
