### PR TITLE
put client-id and secret in rops external secret

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -217,7 +217,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: rops
-                key: client-password
+                key: client-secret
           - name: TEST_MODE
             value: "{{- if .Values.test.enabled -}}True{{- else -}}False{{- end -}}"
           - name: WTF_CSRF_ENABLED

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -211,12 +211,12 @@ spec:
           - name: UAA_CLIENT_ID
             valueFrom:
               secretKeyRef:
-                name: uaa-secret
+                name: rops
                 key: client-id
           - name: UAA_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: uaa-secret
+                name: rops
                 key: client-password
           - name: TEST_MODE
             value: "{{- if .Values.test.enabled -}}True{{- else -}}False{{- end -}}"

--- a/_infra/helm/response-operations-ui/templates/external-secrets.yaml
+++ b/_infra/helm/response-operations-ui/templates/external-secrets.yaml
@@ -11,3 +11,11 @@ spec:
       name: create-account-password
       version: latest
       property: create-account-password
+    - key: rops
+      name: client-id
+      version: latest
+      property: client-id
+    - key: rops
+      name: client-secret
+      version: latest
+      property: client-secret


### PR DESCRIPTION
We cannot use the uaa-secret to get the client-id and secert as that contains a giant yaml file.
