### PR TITLE
Modify how attributes come from party

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.13
+appVersion: 2.4.14

--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -48,8 +48,11 @@ def get_business_attributes_by_party_id(business_party_id, collection_exercise_i
     bound_logger = logger.bind(business_id=business_party_id, collection_exercise_ids=collection_exercise_ids)
     bound_logger.info('Retrieving business attributes')
     url = f'{app.config["PARTY_URL"]}/party-api/v1/businesses/id/{business_party_id}/attributes'
-    params = urlencode([("collection_exercise_id", uuid) for uuid in collection_exercise_ids])
-    response = requests.get(url, params=params, auth=app.config['BASIC_AUTH'])
+    if collection_exercise_ids:
+        params = urlencode([("collection_exercise_id", uuid) for uuid in collection_exercise_ids])
+        response = requests.get(url, params=params, auth=app.config['BASIC_AUTH'])
+    else:
+        response = requests.get(url, auth=app.config['BASIC_AUTH'])
 
     try:
         response.raise_for_status()

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -41,8 +41,10 @@ def view_reporting_unit(ru_ref):
     live_collection_exercises_ids = [ce['id'] for ce in live_collection_exercises]
 
     # Attributes represent the data for a reporting unit at the time they were enrolled onto each collection exercise.
-    attributes = party_controller.get_business_attributes_by_party_id(reporting_unit['id'],
-                                                                      live_collection_exercises_ids)
+    all_attributes = party_controller.get_business_attributes_by_party_id(reporting_unit['id'])
+
+    # Copies and uses only the collection exercises that haven't gone live yet
+    attributes = {k: v for k, v in all_attributes.items() if k in live_collection_exercises_ids}
 
     refined_live_collection_exercises = [add_collection_exercise_details(ce, attributes[ce['id']], case_groups)
                                          for ce in live_collection_exercises]

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -43,7 +43,7 @@ def view_reporting_unit(ru_ref):
     # Attributes represent the data for a reporting unit at the time they were enrolled onto each collection exercise.
     all_attributes = party_controller.get_business_attributes_by_party_id(reporting_unit['id'])
 
-    # Copies and uses only the collection exercises that haven't gone live yet
+    # Copies and uses only the collection exercises that have gone live
     attributes = {k: v for k, v in all_attributes.items() if k in live_collection_exercises_ids}
 
     refined_live_collection_exercises = [add_collection_exercise_details(ce, attributes[ce['id']], case_groups)

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -34,10 +34,7 @@ url_get_party_by_ru_ref = f'{TestingConfig.PARTY_URL}/party-api/v1/parties/type/
 url_get_cases_by_business_party_id = f'{TestingConfig.CASE_URL}/cases/partyid/{business_party_id}'
 
 url_get_collection_exercise_by_id = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'
-url_get_empty_attributes = f'{TestingConfig.PARTY_URL}/party-api/v1/businesses/id/{business_party_id}/attributes'
-url_get_business_attributes = f'{TestingConfig.PARTY_URL}/party-api/v1/businesses/id/{business_party_id}/' \
-                              f'attributes?collection_exercise_id={collection_exercise_id_1}' \
-                              f'&collection_exercise_id={collection_exercise_id_2}'
+url_get_business_attributes = f'{TestingConfig.PARTY_URL}/party-api/v1/businesses/id/{business_party_id}/attributes'
 
 url_get_survey_by_id = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}'
 url_get_respondent_party_by_party_id = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents/id/{respondent_party_id}'
@@ -135,7 +132,7 @@ class TestReportingUnits(TestCase):
     def test_get_reporting_unit_cases_404(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_cases_by_business_party_id, status_code=404)
-        mock_request.get(url_get_empty_attributes, json={})
+        mock_request.get(url_get_business_attributes, json={})
         mock_request.get(url_get_respondent_party_by_list, json=[])
 
         response = self.client.get("/reporting-units/50012345678")


### PR DESCRIPTION
# Motivation and Context
There was a bug where if a reporting unit was part of more than 50~ collection exercises, the url for the search would be too long and get rejected by gunicorn.  This PR makes it so that it gets ALL the attributes and then filters out all the non-live collection exercises (of which there should only be a handful).

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
