### PR TITLE
changed redirect after message

### DIFF
--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -48,8 +48,8 @@ def create_message():
             message_controllers.send_message(_get_message_json(form))
             ru_ref = request.form.get("ru_ref")
             flash("Message sent.")
-            logger.debug("This is the value of ru_ref: " + ruRef)
-            print("This is the value of ru_ref: " + ruRef)
+            logger.debug("This is the value of ru_ref: " + ru_ref)
+            print("This is the value of ru_ref: " + ru_ref)
             return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ru_ref))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -48,8 +48,6 @@ def create_message():
             message_controllers.send_message(_get_message_json(form))
             ru_ref = request.form.get("ru_ref")
             flash("Message sent.")
-            logger.debug("This is the value of ru_ref: " + ru_ref)
-            print("This is the value of ru_ref: " + ru_ref)
             return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ru_ref))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -32,7 +32,7 @@ CACHE_HEADERS = {
 
 @messages_bp.route('/create-message', methods=['POST'])
 @login_required
-def create_message(ru_ref):
+def create_message():
     form = SecureMessageForm(request.form)
     breadcrumbs = _build_create_message_breadcrumbs()
 
@@ -52,7 +52,7 @@ def create_message(ru_ref):
             if survey in VACANCIES_LIST:
                 survey = 'Vacancies'
             flash("Message sent.")
-            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ru_ref))
+            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=form.ru_ref))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)
             form.errors['sending'] = ["Message failed to send, something has gone wrong with the website."]

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -52,6 +52,7 @@ def create_message():
             if survey in VACANCIES_LIST:
                 survey = 'Vacancies'
             flash("Message sent.")
+            logger.info("This is the ru_ref" + form.ru_ref.text)
             return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=form.ru_ref.text))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -47,13 +47,12 @@ def create_message():
         try:
             message_controllers.send_message(_get_message_json(form))
             survey = request.form.get("hidden_survey")
-            ruRef = request.form.get("ru_ref")
             if survey in FDI_LIST:
                 survey = 'FDI'
             if survey in VACANCIES_LIST:
                 survey = 'Vacancies'
             flash("Message sent.")
-            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ruRef))
+            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=form.ru_ref.text))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)
             form.errors['sending'] = ["Message failed to send, something has gone wrong with the website."]

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -46,18 +46,11 @@ def create_message():
 
         try:
             message_controllers.send_message(_get_message_json(form))
-            survey = request.form.get("hidden_survey")
-            ruRef = request.form.get("ru_ref")
-            if survey in FDI_LIST:
-                survey = 'FDI'
-            if survey in VACANCIES_LIST:
-                survey = 'Vacancies'
+            ru_ref = request.form.get("ru_ref")
             flash("Message sent.")
             logger.debug("This is the value of ru_ref: " + ruRef)
             print("This is the value of ru_ref: " + ruRef)
-            logger.debug("This is the value of hidden_survey: " + survey)
-            print("This is the value of hidden_survey: " + survey)
-            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ruRef))
+            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ru_ref))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)
             form.errors['sending'] = ["Message failed to send, something has gone wrong with the website."]

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -47,14 +47,18 @@ def create_message():
         try:
             message_controllers.send_message(_get_message_json(form))
             survey = request.form.get("hidden_survey")
+            ruRef = request.form.get("ru_ref")
             if survey in FDI_LIST:
                 survey = 'FDI'
             if survey in VACANCIES_LIST:
                 survey = 'Vacancies'
             flash("Message sent.")
-            logger.debug("This is the value of ru_ref: " + form.ru_ref.text)
-            print("This is the value of ru_ref: " + form.ru_ref.text)
-            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=form.ru_ref.text))
+            logger.debug("This is the value of ru_ref: " + ruRef)
+            print("This is the value of ru_ref: " + ruRef)
+            logger.debug("This is the value of hidden_survey: " + survey)
+            print("This is the value of hidden_survey: " + survey)
+            
+            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ruRef))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)
             form.errors['sending'] = ["Message failed to send, something has gone wrong with the website."]

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -32,7 +32,7 @@ CACHE_HEADERS = {
 
 @messages_bp.route('/create-message', methods=['POST'])
 @login_required
-def create_message():
+def create_message(ru_ref):
     form = SecureMessageForm(request.form)
     breadcrumbs = _build_create_message_breadcrumbs()
 

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -47,7 +47,7 @@ def create_message():
         try:
             message_controllers.send_message(_get_message_json(form))
             survey = request.form.get("hidden_survey")
-            ruRef = request.form.get("hidden_ru_ref")
+            ruRef = request.form.get("ru_ref")
             if survey in FDI_LIST:
                 survey = 'FDI'
             if survey in VACANCIES_LIST:

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -52,7 +52,6 @@ def create_message():
             if survey in VACANCIES_LIST:
                 survey = 'Vacancies'
             flash("Message sent.")
-            logger.info("This is the ru_ref" + form.ru_ref.text)
             return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=form.ru_ref.text))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -52,7 +52,7 @@ def create_message():
             if survey in VACANCIES_LIST:
                 survey = 'Vacancies'
             flash("Message sent.")
-            return redirect(url_for('messages_bp.view_selected_survey', selected_survey=survey))
+            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ru_ref))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)
             form.errors['sending'] = ["Message failed to send, something has gone wrong with the website."]

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -47,12 +47,13 @@ def create_message():
         try:
             message_controllers.send_message(_get_message_json(form))
             survey = request.form.get("hidden_survey")
+            ruRef = request.form.get("hidden_ru_ref")
             if survey in FDI_LIST:
                 survey = 'FDI'
             if survey in VACANCIES_LIST:
                 survey = 'Vacancies'
             flash("Message sent.")
-            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=form.ru_ref))
+            return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ruRef))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)
             form.errors['sending'] = ["Message failed to send, something has gone wrong with the website."]

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -53,6 +53,7 @@ def create_message():
                 survey = 'Vacancies'
             flash("Message sent.")
             logger.debug("This is the value of ru_ref: " + form.ru_ref.text)
+            print("This is the value of ru_ref: " + form.ru_ref.text)
             return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=form.ru_ref.text))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -52,6 +52,7 @@ def create_message():
             if survey in VACANCIES_LIST:
                 survey = 'Vacancies'
             flash("Message sent.")
+            logger.debug("This is the value of ru_ref: " + form.ru_ref.text)
             return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=form.ru_ref.text))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -57,7 +57,6 @@ def create_message():
             print("This is the value of ru_ref: " + ruRef)
             logger.debug("This is the value of hidden_survey: " + survey)
             print("This is the value of hidden_survey: " + survey)
-            
             return redirect(url_for('reporting_unit_bp.view_reporting_unit', ru_ref=ruRef))
         except (ApiError, InternalError):
             form = _repopulate_form_with_submitted_data(form)

--- a/tests/views/test_change_response_status.py
+++ b/tests/views/test_change_response_status.py
@@ -115,10 +115,10 @@ class TestChangeResponseStatus(TestCase):
         mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercise_list)
         mock_request.get(url_get_party_by_ru_ref, status_code=500)
 
-        response = self.client.get(f'/case/{ru_ref}/response-status?survey={short_name}&period={period}',
-                                   follow_redirects=True)
+        response = self.client.get(f'/case/{ru_ref}/response-status?survey={short_name}&period={period}')
 
         self.assertIn("Server error (Error 500)".encode(), response.data)
+        self.assertIn("Message sent.".encode(), response.data)
 
     @requests_mock.mock()
     def test_get_available_status_case_fail(self, mock_request):

--- a/tests/views/test_change_response_status.py
+++ b/tests/views/test_change_response_status.py
@@ -115,10 +115,10 @@ class TestChangeResponseStatus(TestCase):
         mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercise_list)
         mock_request.get(url_get_party_by_ru_ref, status_code=500)
 
-        response = self.client.get(f'/case/{ru_ref}/response-status?survey={short_name}&period={period}')
+        response = self.client.get(f'/case/{ru_ref}/response-status?survey={short_name}&period={period}',
+                                   follow_redirects=True)
 
         self.assertIn("Server error (Error 500)".encode(), response.data)
-        self.assertIn("Message sent.".encode(), response.data)
 
     @requests_mock.mock()
     def test_get_available_status_case_fail(self, mock_request):

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -503,7 +503,7 @@ class TestMessage(ViewTestCase):
         mock_request.get(ru_ref_url, status_code=200)
 
         with self.app.app_context():
-            response = self.client.post("/messages/create-message", data=self.message_form, follow_redirects=True)
+            response = self.client.post("/messages/create-message", data=self.message_form)
 
         self.assertIn("Message sent.".encode(), response.data)
         self.assertIn("Messages".encode(), response.data)

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -437,12 +437,14 @@ class TestMessage(ViewTestCase):
         self.assertIn("Please enter a subject".encode(), response.data)
         self.assertIn("Please enter a message".encode(), response.data)
 
-    message_form = {'body': "TEST BODY",
+    message_form = {'create-message': 'create-message-view',
+                    'body': "TEST BODY",
                     'subject': "TEST SUBJECT",
                     'hidden_survey': "ASHE",
                     'ru_ref': "49900000280",
                     'hidden_ru_ref': "49900000280"}
-    FDI_message = {'body': "AIFDI BODY",
+    FDI_message = {'create-message': 'create-message-view',
+                   'body': "AIFDI BODY",
                    'subject': "AIFDI SUBJECT",
                    'hidden_survey': "AIFDI",
                    'ru_ref': "49900000280",

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -505,9 +505,10 @@ class TestMessage(ViewTestCase):
         with self.app.app_context():
             response = self.client.post("/messages/create-message", data=self.message_form, follow_redirects=True)
 
+        self.assertIn(f'reporting-units/{ru_ref_value}', response.location)
         self.assertIn("Message sent.".encode(), response.data)
         self.assertIn("Messages".encode(), response.data)
-        self.assertIn(f'reporting-units/{ru_ref_value}', response.location)
+        
 
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -440,13 +440,13 @@ class TestMessage(ViewTestCase):
     message_form = {'body': "TEST BODY",
                     'subject': "TEST SUBJECT",
                     'hidden_survey': "ASHE",
-                    'ru_ref': "11110000019",
-                    'hidden_ru_ref': "11110000019"}
+                    'ru_ref': "49900000280",
+                    'hidden_ru_ref': "49900000280"}
     FDI_message = {'body': "AIFDI BODY",
                    'subject': "AIFDI SUBJECT",
                    'hidden_survey': "AIFDI",
-                   'ru_ref': "11110000019",
-                   'hidden_ru_ref': "11110000019"}
+                   'ru_ref': "49900000280",
+                   'hidden_ru_ref': "49900000280"}
     AIFDI_response = {
         "id": "41320b22-b425-4fba-a90e-718898f718ce",
         "shortName": "AIFDI",

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -495,10 +495,10 @@ class TestMessage(ViewTestCase):
         ru_ref_value = self.message_form["ru_ref"]
         mock_get_jwt.return_value = "blah"
         mock_request.post(url_send_message, json=threads_no_unread_list, status_code=201)
-        #mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
-        #mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
-        #mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        #mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
+        # mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
+        # mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
+        # mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
+        # mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
         ru_ref_url = f'{url_get_survey_by_ru_ref}{ru_ref_value}'
         mock_request.get(ru_ref_url, status_code=200)
 

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -491,13 +491,14 @@ class TestMessage(ViewTestCase):
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
     def test_form_submit_with_valid_data(self, mock_request, mock_get_jwt):
+        ru_ref_value = self.message_form["ru_ref"]
         mock_get_jwt.return_value = "blah"
         mock_request.post(url_send_message, json=threads_no_unread_list, status_code=201)
         mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
         mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
-        party_get_by_ru_ref = f'{url_get_party_by_ru_ref}{self.message_form["ru_ref"]}'
+        party_get_by_ru_ref = f'{url_get_party_by_ru_ref}{ru_ref_value}'
         mock_request.get(party_get_by_ru_ref, status_code=200)
 
         with self.app.app_context():

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -504,7 +504,6 @@ class TestMessage(ViewTestCase):
 
         with self.app.app_context():
             response = self.client.post("/messages/create-message", data=self.message_form, follow_redirects=True)
-            
         print("This is the location of the response: " + str(response.location))
 
         self.assertIn(f'reporting-units/{ru_ref_value}', response.location)

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -508,7 +508,6 @@ class TestMessage(ViewTestCase):
         self.assertIn(f'reporting-units/{ru_ref_value}', response.location)
         self.assertIn("Message sent.".encode(), response.data)
         self.assertIn("Messages".encode(), response.data)
-        
 
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -437,18 +437,16 @@ class TestMessage(ViewTestCase):
         self.assertIn("Please enter a subject".encode(), response.data)
         self.assertIn("Please enter a message".encode(), response.data)
 
-    message_form = {'create-message': 'create-message-view',
-                    'body': "TEST BODY",
+    message_form = {'body': "TEST BODY",
                     'subject': "TEST SUBJECT",
                     'hidden_survey': "ASHE",
-                    'ru_ref': "49900000280",
-                    'hidden_ru_ref': "49900000280"}
-    FDI_message = {'create-message': 'create-message-view',
-                   'body': "AIFDI BODY",
+                    'ru_ref': "11100000280",
+                    'hidden_ru_ref': "11100000280"}
+    FDI_message = {'body': "AIFDI BODY",
                    'subject': "AIFDI SUBJECT",
                    'hidden_survey': "AIFDI",
-                   'ru_ref': "49900000280",
-                   'hidden_ru_ref': "49900000280"}
+                   'ru_ref': "11100000280",
+                   'hidden_ru_ref': "11100000280"}
     AIFDI_response = {
         "id": "41320b22-b425-4fba-a90e-718898f718ce",
         "shortName": "AIFDI",

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -12,6 +12,15 @@ from response_operations_ui.views.messages import _get_to_id, _calculate_page
 from response_operations_ui.views.messages import _get_unread_status
 from tests.views import ViewTestCase
 
+respondent_party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
+business_party_id = 'b3ba864b-7cbc-4f44-84fe-88dc018a1a4c'
+collection_exercise_id_1 = '14fb3e68-4dca-46db-bf49-04b84e07e77c'
+collection_exercise_id_2 = '9af403f8-5fc5-43b1-9fca-afbd9c65da5c'
+survey_id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+ru_ref = '50012345678'
+iac_1 = 'jkbvyklkwj88'
+iac_2 = 'ljbgg3kgstr4'
+
 url_get_party_by_ru_ref = f'{TestingConfig.PARTY_URL}/party-api/v1/parties/type/B/ref/'
 shortname_url = f'{TestingConfig.SURVEY_URL}/surveys/shortname'
 url_sign_in_data = f'{TestingConfig.UAA_SERVICE_URL}/oauth/token'
@@ -23,7 +32,14 @@ url_messages = f'{TestingConfig.SECURE_MESSAGE_URL}/messages'
 url_update_label = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/modify/ae46748b-c6e6-4859-a57a-86e01db2dcbc'
 url_modify_label_base = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/modify/'
 url_select_survey = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/select-survey'
-url_get_survey_by_ru_ref = f'{TestingConfig.REPORT_URL}/reporting-units/'
+
+url_get_case_groups_by_business_party_id = f'{TestingConfig.CASE_URL}/cases/partyid/{business_party_id}'
+url_get_collection_exercise_by_id = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'
+url_get_business_attributes = f'{TestingConfig.PARTY_URL}/party-api/v1/businesses/id/{business_party_id}/attributes'
+url_get_survey_by_id = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}'
+url_get_respondent_party_by_list = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents?id={respondent_party_id}'
+url_get_iac = f'{TestingConfig.IAC_URL}/iacs'
+
 
 survey_id = '6aa8896f-ced5-4694-800c-6cd661b0c8b2'
 params = f'?survey={survey_id}&page=1&limit=10'
@@ -57,6 +73,30 @@ with open('tests/test_data/message/threads_unread.json') as json_data:
 
 with open('tests/test_data/message/thread_unread.json') as json_data:
     thread_unread_json = json.load(json_data)
+
+with open('tests/test_data/party/business_reporting_unit.json') as fp:
+    business_reporting_unit = json.load(fp)
+
+with open('tests/test_data/case/cases_list.json') as fp:
+    cases_list = json.load(fp)
+
+with open('tests/test_data/collection_exercise/collection_exercise.json') as fp:
+    collection_exercise = json.load(fp)
+
+with open('tests/test_data/collection_exercise/collection_exercise_2.json') as fp:
+    collection_exercise_2 = json.load(fp)
+
+with open('tests/test_data/party/business_attributes.json') as fp:
+    business_attributes = json.load(fp)
+
+with open('tests/test_data/survey/single_survey.json') as fp:
+    survey = json.load(fp)
+
+with open('tests/test_data/party/respondent_party_list.json') as fp:
+    respondent_party_list = json.load(fp)
+
+with open('tests/test_data/iac/iac.json') as fp:
+    iac = json.load(fp)
 
 
 class TestMessage(ViewTestCase):
@@ -441,13 +481,11 @@ class TestMessage(ViewTestCase):
     message_form = {'body': "TEST BODY",
                     'subject': "TEST SUBJECT",
                     'hidden_survey': "ASHE",
-                    'ru_ref': "11100000280",
-                    'hidden_ru_ref': "11100000280"}
+                    'ru_ref': ru_ref}
     FDI_message = {'body': "AIFDI BODY",
                    'subject': "AIFDI SUBJECT",
                    'hidden_survey': "AIFDI",
-                   'ru_ref': "11100000280",
-                   'hidden_ru_ref': "11100000280"}
+                   'ru_ref': ru_ref}
     AIFDI_response = {
         "id": "41320b22-b425-4fba-a90e-718898f718ce",
         "shortName": "AIFDI",
@@ -492,21 +530,26 @@ class TestMessage(ViewTestCase):
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
     def test_form_submit_with_valid_data(self, mock_request, mock_get_jwt):
-        ru_ref_value = self.message_form["ru_ref"]
         mock_get_jwt.return_value = "blah"
         mock_request.post(url_send_message, json=threads_no_unread_list, status_code=201)
-        # mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
-        # mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
-        # mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        # mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
-        ru_ref_url = f'{url_get_survey_by_ru_ref}{ru_ref_value}'
-        mock_request.get(ru_ref_url, status_code=200)
+        mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
+        mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
+        mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
+        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
+
+        mock_request.get(url_get_party_by_ru_ref + ru_ref, json=business_reporting_unit)
+        mock_request.get(url_get_case_groups_by_business_party_id, json=cases_list)
+        mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
+        mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise_2)
+        mock_request.get(url_get_business_attributes, json=business_attributes)
+        mock_request.get(url_get_survey_by_id, json=survey)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
+        mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
+        mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
         with self.app.app_context():
             response = self.client.post("/messages/create-message", data=self.message_form, follow_redirects=True)
-        print("This is the location of the response: " + str(response.location))
 
-        self.assertIn(f'reporting-units/{ru_ref_value}', response.location)
         self.assertIn("Message sent.".encode(), response.data)
         self.assertIn("Messages".encode(), response.data)
 
@@ -518,6 +561,16 @@ class TestMessage(ViewTestCase):
         mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
+
+        mock_request.get(url_get_party_by_ru_ref + ru_ref, json=business_reporting_unit)
+        mock_request.get(url_get_case_groups_by_business_party_id, json=cases_list)
+        mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
+        mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_2}', json=collection_exercise_2)
+        mock_request.get(url_get_business_attributes, json=business_attributes)
+        mock_request.get(url_get_survey_by_id, json=survey)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
+        mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
+        mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
         # Mocking FDI responses
         mock_request.get(shortname_url + "/QIFDI", json=self.QIFDI_response)

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -440,11 +440,13 @@ class TestMessage(ViewTestCase):
     message_form = {'body': "TEST BODY",
                     'subject': "TEST SUBJECT",
                     'hidden_survey': "ASHE",
-                    'ru_ref': "11110000019"}
+                    'ru_ref': "11110000019",
+                    'hidden_ru_ref': "11110000019"}
     FDI_message = {'body': "AIFDI BODY",
                    'subject': "AIFDI SUBJECT",
                    'hidden_survey': "AIFDI",
-                   'ru_ref': "11110000019"}
+                   'ru_ref': "11110000019",
+                   'hidden_ru_ref': "11110000019"}
     AIFDI_response = {
         "id": "41320b22-b425-4fba-a90e-718898f718ce",
         "shortName": "AIFDI",

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -23,6 +23,7 @@ url_messages = f'{TestingConfig.SECURE_MESSAGE_URL}/messages'
 url_update_label = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/modify/ae46748b-c6e6-4859-a57a-86e01db2dcbc'
 url_modify_label_base = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/modify/'
 url_select_survey = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/select-survey'
+url_get_survey_by_ru_ref = f'{TestingConfig.REPORT_URL}/reporting-units/'
 
 survey_id = '6aa8896f-ced5-4694-800c-6cd661b0c8b2'
 params = f'?survey={survey_id}&page=1&limit=10'
@@ -498,8 +499,8 @@ class TestMessage(ViewTestCase):
         mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
         mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
-        party_get_by_ru_ref = f'{url_get_party_by_ru_ref}{ru_ref_value}'
-        mock_request.get(party_get_by_ru_ref, status_code=200)
+        ru_ref_url = f'{url_get_survey_by_ru_ref}{ru_ref_value}'
+        mock_request.get(ru_ref_url, status_code=200)
 
         with self.app.app_context():
             response = self.client.post("/messages/create-message", data=self.message_form, follow_redirects=True)

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -439,10 +439,12 @@ class TestMessage(ViewTestCase):
 
     message_form = {'body': "TEST BODY",
                     'subject': "TEST SUBJECT",
-                    'hidden_survey': "ASHE"}
+                    'hidden_survey': "ASHE",
+                    'ru_ref': "11110000019"}
     FDI_message = {'body': "AIFDI BODY",
                    'subject': "AIFDI SUBJECT",
-                   'hidden_survey': "AIFDI"}
+                   'hidden_survey': "AIFDI",
+                   'ru_ref': "11110000019"}
     AIFDI_response = {
         "id": "41320b22-b425-4fba-a90e-718898f718ce",
         "shortName": "AIFDI",

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -497,7 +497,7 @@ class TestMessage(ViewTestCase):
         mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
         mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
-        party_get_by_ru_ref = f'{url_get_party_by_ru_ref}{message_form.ru_ref}'
+        party_get_by_ru_ref = f'{url_get_party_by_ru_ref}{self.message_form["ru_ref"]}'
         mock_request.get(party_get_by_ru_ref, status_code=200)
 
         with self.app.app_context():

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -504,6 +504,8 @@ class TestMessage(ViewTestCase):
 
         with self.app.app_context():
             response = self.client.post("/messages/create-message", data=self.message_form, follow_redirects=True)
+            
+        print("This is the location of the response: " + str(response.location))
 
         self.assertIn(f'reporting-units/{ru_ref_value}', response.location)
         self.assertIn("Message sent.".encode(), response.data)

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -495,10 +495,10 @@ class TestMessage(ViewTestCase):
         ru_ref_value = self.message_form["ru_ref"]
         mock_get_jwt.return_value = "blah"
         mock_request.post(url_send_message, json=threads_no_unread_list, status_code=201)
-        mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
-        mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
-        mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
+        #mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
+        #mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
+        #mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
+        #mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
         ru_ref_url = f'{url_get_survey_by_ru_ref}{ru_ref_value}'
         mock_request.get(ru_ref_url, status_code=200)
 

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -503,10 +503,11 @@ class TestMessage(ViewTestCase):
         mock_request.get(ru_ref_url, status_code=200)
 
         with self.app.app_context():
-            response = self.client.post("/messages/create-message", data=self.message_form)
+            response = self.client.post("/messages/create-message", data=self.message_form, follow_redirects=True)
 
         self.assertIn("Message sent.".encode(), response.data)
         self.assertIn("Messages".encode(), response.data)
+        self.assertIn(f'reporting-units/{ru_ref_value}', response.location)
 
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -532,11 +532,7 @@ class TestMessage(ViewTestCase):
     def test_form_submit_with_valid_data(self, mock_request, mock_get_jwt):
         mock_get_jwt.return_value = "blah"
         mock_request.post(url_send_message, json=threads_no_unread_list, status_code=201)
-        mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
-        mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-        mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
-
         mock_request.get(url_get_party_by_ru_ref + ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_case_groups_by_business_party_id, json=cases_list)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
@@ -558,10 +554,7 @@ class TestMessage(ViewTestCase):
     def test_form_submit_with_FDI_data(self, mock_request, mock_get_jwt):
         mock_get_jwt.return_value = "blah"
         mock_request.post(url_send_message, json=threads_no_unread_list, status_code=201)
-        mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
-        mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
-
         mock_request.get(url_get_party_by_ru_ref + ru_ref, json=business_reporting_unit)
         mock_request.get(url_get_case_groups_by_business_party_id, json=cases_list)
         mock_request.get(f'{url_get_collection_exercise_by_id}/{collection_exercise_id_1}', json=collection_exercise)
@@ -571,12 +564,6 @@ class TestMessage(ViewTestCase):
         mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
-
-        # Mocking FDI responses
-        mock_request.get(shortname_url + "/QIFDI", json=self.QIFDI_response)
-        mock_request.get(shortname_url + "/QOFDI", json=self.QOFDI_response)
-        mock_request.get(shortname_url + "/AIFDI", json=self.AIFDI_response)
-        mock_request.get(shortname_url + "/AOFDI", json=self.AOFDI_response)
 
         with self.app.app_context():
             response = self.client.post("/messages/create-message", data=self.FDI_message, follow_redirects=True)

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -497,6 +497,8 @@ class TestMessage(ViewTestCase):
         mock_request.get(url_get_threads_list, json=thread_list, status_code=200)
         mock_request.get(url_get_surveys_list, json=self.surveys_list_json)
         mock_request.get(shortname_url + "/ASHE", json=ashe_info['survey'])
+        party_get_by_ru_ref = f'{url_get_party_by_ru_ref}{message_form.ru_ref}'
+        mock_request.get(party_get_by_ru_ref, status_code=200)
 
         with self.app.app_context():
             response = self.client.post("/messages/create-message", data=self.message_form, follow_redirects=True)

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -96,7 +96,7 @@ class TestReportingUnits(TestCase):
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
-        response = self.client.get("/reporting-units/50012345678")
+        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Bolts and Ratchets Ltd".encode(), response.data)

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -106,6 +106,7 @@ class TestReportingUnits(TestCase):
         self.assertIn("Jacky Turner".encode(), response.data)
         self.assertIn("Enabled".encode(), response.data)
         self.assertIn("Active".encode(), response.data)
+        self.assertIn("Message sent.".encode(), response.data)
 
     @requests_mock.mock()
     def test_get_reporting_unit_party_ru_fail(self, mock_request):

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -106,7 +106,6 @@ class TestReportingUnits(TestCase):
         self.assertIn("Jacky Turner".encode(), response.data)
         self.assertIn("Enabled".encode(), response.data)
         self.assertIn("Active".encode(), response.data)
-        self.assertIn("Message sent.".encode(), response.data)
 
     @requests_mock.mock()
     def test_get_reporting_unit_party_ru_fail(self, mock_request):

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -96,7 +96,7 @@ class TestReportingUnits(TestCase):
         mock_request.get(f'{url_get_iac}/{iac_1}', json=iac)
         mock_request.get(f'{url_get_iac}/{iac_2}', json=iac)
 
-        response = self.client.get("/reporting-units/50012345678", follow_redirects=True)
+        response = self.client.get("/reporting-units/50012345678")
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Bolts and Ratchets Ltd".encode(), response.data)


### PR DESCRIPTION
# Motivation and Context
rOps users needed to be sent back to the reporting unit page after sending a message, because it's tedious having to navigate back after it sends you to the message thread list.

# What has changed
The `/create-messages` endpoint now redirects the user back to the previously selected responding unit page after a message is sent.

# How to test?
On response-ops, find a reporting unit, click on a survey, find a respondent, and click create message. Then, type in a message and send it. It should redirect you back to the reporting unit page.
# Links
[Trello card](https://trello.com/c/XrN8aya6)
