### PR TITLE
Improve test running

### DIFF
--- a/tests/common/test_data/closest_future_collection_exercise.json
+++ b/tests/common/test_data/closest_future_collection_exercise.json
@@ -1,1 +1,0 @@
-../../test_data/collection_exercise/closest_future_collection_exercise.json

--- a/tests/common/test_data/closest_past_collection_exercise.json
+++ b/tests/common/test_data/closest_past_collection_exercise.json
@@ -1,1 +1,0 @@
-../../test_data/collection_exercise/closest_past_collection_exercise.json

--- a/tests/common/test_data/mixed_past_and_future_collection_exercises.json
+++ b/tests/common/test_data/mixed_past_and_future_collection_exercises.json
@@ -1,1 +1,0 @@
-../../test_data/collection_exercise/mixed_past_and_future_collection_exercises.json

--- a/tests/common/test_data/multiple_same_start_collection_exercises.json
+++ b/tests/common/test_data/multiple_same_start_collection_exercises.json
@@ -1,1 +1,0 @@
-../../test_data/collection_exercise/multiple_same_start_collection_exercises.json

--- a/tests/common/test_data/only_future_collection_exercises.json
+++ b/tests/common/test_data/only_future_collection_exercises.json
@@ -1,1 +1,0 @@
-../../test_data/collection_exercise/only_future_collection_exercises.json

--- a/tests/common/test_data/only_past_collection_exercises.json
+++ b/tests/common/test_data/only_past_collection_exercises.json
@@ -1,1 +1,0 @@
-../../test_data/collection_exercise/only_past_collection_exercises.json

--- a/tests/common/test_data/single_new_collection_exercise_for_survey.json
+++ b/tests/common/test_data/single_new_collection_exercise_for_survey.json
@@ -1,1 +1,0 @@
-../../test_data/collection_exercise/single_new_collection_exercise_for_survey.json

--- a/tests/common/test_filters.py
+++ b/tests/common/test_filters.py
@@ -1,9 +1,12 @@
 import json
+import os
 import unittest
 
 from freezegun import freeze_time
 
 from response_operations_ui.common.filters import get_current_collection_exercise, get_nearest_future_key_date
+
+project_root = os.path.dirname(os.path.dirname(__file__))
 
 
 class TestFilters(unittest.TestCase):
@@ -19,9 +22,9 @@ class TestFilters(unittest.TestCase):
     def test_get_nearest_future_key_date_with_blank_collection_exercise(self):
         """Tests a survey with a collection exercise that's in its most empty state will return an empty
         dict."""
-        file_paths = ['test_data/single_new_collection_exercise_for_survey.json',
-                      'tests/test_data/collection_exercise/single_new_collection_exercise_for_survey.json']
-        collection_exercise_list = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"single_new_collection_exercise_for_survey.json") as json_data:
+            collection_exercise_list = json.load(json_data)
 
         expected_output = {}
         output = get_nearest_future_key_date(collection_exercise_list[0]['events'])
@@ -31,9 +34,9 @@ class TestFilters(unittest.TestCase):
     def test_get_nearest_future_key_date_future_dates_only(self):
         """Tests that given set of events with only future dates, the closest future event to 'today'
         will be picked"""
-        file_paths = ['test_data/closest_future_collection_exercise.json',
-                      'tests/test_data/collection_exercise/closest_future_collection_exercise.json']
-        collection_exercise = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"closest_future_collection_exercise.json") as json_data:
+            collection_exercise = json.load(json_data)
 
         expected_output = {"id": "573e60ce-4041-4cd6-8d09-9048457db0af",
                            "collectionExerciseId": "aec41b04-a177-4994-b385-a16136242d05",
@@ -46,9 +49,9 @@ class TestFilters(unittest.TestCase):
     def test_get_nearest_future_key_date_past_dates_only(self):
         """Tests that given set of events with only past dates, the function will return an empty dict as it only
         works for events in the future"""
-        file_paths = ['test_data/closest_past_collection_exercise.json',
-                      'tests/test_data/collection_exercise/closest_past_collection_exercise.json']
-        collection_exercise = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"closest_past_collection_exercise.json") as json_data:
+            collection_exercise = json.load(json_data)
 
         expected_output = {}
         output = get_nearest_future_key_date(collection_exercise['events'])
@@ -65,9 +68,9 @@ class TestFilters(unittest.TestCase):
     def test_get_current_collection_exercise_with_blank_collection_exercise(self):
         """Tests a survey with a collection exercise that's in its most empty state will return an empty
         dict."""
-        file_paths = ['test_data/single_new_collection_exercise_for_survey.json',
-                      'tests/test_data/collection_exercise/single_new_collection_exercise_for_survey.json']
-        collection_exercise_list = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"single_new_collection_exercise_for_survey.json") as json_data:
+            collection_exercise_list = json.load(json_data)
 
         expected_output = {}
         output = get_current_collection_exercise(collection_exercise_list)
@@ -81,9 +84,9 @@ class TestFilters(unittest.TestCase):
                       'tests/test_data/collection_exercise/only_future_collection_exercises.json']
         collection_exercise_list = self.load_file(file_paths)
 
-        file_paths = ['test_data/closest_future_collection_exercise.json',
-                      'tests/test_data/collection_exercise/closest_future_collection_exercise.json']
-        expected_output = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"closest_future_collection_exercise.json") as json_data:
+            expected_output = json.load(json_data)
 
         output = get_current_collection_exercise(collection_exercise_list)
         self.assertEqual(output, expected_output)

--- a/tests/common/test_filters.py
+++ b/tests/common/test_filters.py
@@ -80,9 +80,9 @@ class TestFilters(unittest.TestCase):
     def test_get_current_collection_exercise_future_dates_only(self):
         """Tests that given set of collection exercises with only future dates, the closest date to 'today'
         will be picked"""
-        file_paths = ['test_data/only_future_collection_exercises.json',
-                      'tests/test_data/collection_exercise/only_future_collection_exercises.json']
-        collection_exercise_list = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"only_future_collection_exercises.json") as json_data:
+            collection_exercise_list = json.load(json_data)
 
         with open(f"{project_root}/test_data/collection_exercise/"
                   f"closest_future_collection_exercise.json") as json_data:
@@ -95,13 +95,13 @@ class TestFilters(unittest.TestCase):
     def test_get_current_collection_exercise_past_dates_only(self):
         """Tests that given set of collection exercises with only past dates, the closest date to 'today'
         will be picked"""
-        file_paths = ['test_data/only_past_collection_exercises.json',
-                      'tests/test_data/collection_exercise/only_past_collection_exercises.json']
-        collection_exercise_list = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"only_past_collection_exercises.json") as json_data:
+            collection_exercise_list = json.load(json_data)
 
-        file_paths = ['test_data/closest_past_collection_exercise.json',
-                      'tests/test_data/collection_exercise/closest_past_collection_exercise.json']
-        expected_output = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"closest_past_collection_exercise.json") as json_data:
+            expected_output = json.load(json_data)
 
         output = get_current_collection_exercise(collection_exercise_list)
         self.assertEqual(output, expected_output)
@@ -110,13 +110,13 @@ class TestFilters(unittest.TestCase):
     def test_get_current_collection_exercise_past_and_future_dates(self):
         """Tests that given set of collection exercises with past and future dates, the closest date to 'today'
         will be picked"""
-        file_paths = ['test_data/mixed_past_and_future_collection_exercises.json',
-                      'tests/test_data/collection_exercise/mixed_past_and_future_collection_exercises.json']
-        collection_exercise_list = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"mixed_past_and_future_collection_exercises.json") as json_data:
+            collection_exercise_list = json.load(json_data)
 
-        file_paths = ['test_data/closest_past_collection_exercise.json',
-                      'tests/test_data/collection_exercise/closest_past_collection_exercise.json']
-        expected_output = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"closest_past_collection_exercise.json") as json_data:
+            expected_output = json.load(json_data)
 
         output = get_current_collection_exercise(collection_exercise_list)
         self.assertEqual(output, expected_output)
@@ -125,29 +125,13 @@ class TestFilters(unittest.TestCase):
     def test_get_current_collection_exercise_duplicate_start_dates(self):
         """Tests that when there are two collection exercises with the same start date, the one that was seen first
         will be the one returned."""
-        file_paths = ['test_data/multiple_same_start_collection_exercises.json',
-                      'tests/test_data/collection_exercise/multiple_same_start_collection_exercises.json']
-        collection_exercise_list = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"multiple_same_start_collection_exercises.json") as json_data:
+            collection_exercise_list = json.load(json_data)
 
-        file_paths = ['test_data/closest_past_collection_exercise.json',
-                      'tests/test_data/collection_exercise/closest_past_collection_exercise.json']
-        expected_output = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"closest_past_collection_exercise.json") as json_data:
+            expected_output = json.load(json_data)
 
         output = get_current_collection_exercise(collection_exercise_list)
         self.assertEqual(output, expected_output)
-
-    @staticmethod
-    def load_file(file_paths):
-        """
-        Facilitates running the tests either as a whole with run_tests.py or individually.  Both ways of running the
-        tests start from a different place so relative paths don't work.  Currently only accepts lists of 2.
-        :param file_paths: A list of file paths to test
-        :return: The contents of the file
-        """
-        try:
-            with open(file_paths[0]) as fp:
-                file_data = json.load(fp)
-        except FileNotFoundError:
-            with open(file_paths[1]) as fp:
-                file_data = json.load(fp)
-        return file_data

--- a/tests/common/test_filters.py
+++ b/tests/common/test_filters.py
@@ -22,8 +22,8 @@ class TestFilters(unittest.TestCase):
     def test_get_nearest_future_key_date_with_blank_collection_exercise(self):
         """Tests a survey with a collection exercise that's in its most empty state will return an empty
         dict."""
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"single_new_collection_exercise_for_survey.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'single_new_collection_exercise_for_survey.json') as json_data:
             collection_exercise_list = json.load(json_data)
 
         expected_output = {}
@@ -34,8 +34,8 @@ class TestFilters(unittest.TestCase):
     def test_get_nearest_future_key_date_future_dates_only(self):
         """Tests that given set of events with only future dates, the closest future event to 'today'
         will be picked"""
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"closest_future_collection_exercise.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'closest_future_collection_exercise.json') as json_data:
             collection_exercise = json.load(json_data)
 
         expected_output = {"id": "573e60ce-4041-4cd6-8d09-9048457db0af",
@@ -49,8 +49,8 @@ class TestFilters(unittest.TestCase):
     def test_get_nearest_future_key_date_past_dates_only(self):
         """Tests that given set of events with only past dates, the function will return an empty dict as it only
         works for events in the future"""
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"closest_past_collection_exercise.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'closest_past_collection_exercise.json') as json_data:
             collection_exercise = json.load(json_data)
 
         expected_output = {}
@@ -68,8 +68,8 @@ class TestFilters(unittest.TestCase):
     def test_get_current_collection_exercise_with_blank_collection_exercise(self):
         """Tests a survey with a collection exercise that's in its most empty state will return an empty
         dict."""
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"single_new_collection_exercise_for_survey.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'single_new_collection_exercise_for_survey.json') as json_data:
             collection_exercise_list = json.load(json_data)
 
         expected_output = {}
@@ -80,12 +80,12 @@ class TestFilters(unittest.TestCase):
     def test_get_current_collection_exercise_future_dates_only(self):
         """Tests that given set of collection exercises with only future dates, the closest date to 'today'
         will be picked"""
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"only_future_collection_exercises.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'only_future_collection_exercises.json') as json_data:
             collection_exercise_list = json.load(json_data)
 
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"closest_future_collection_exercise.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'closest_future_collection_exercise.json') as json_data:
             expected_output = json.load(json_data)
 
         output = get_current_collection_exercise(collection_exercise_list)
@@ -95,12 +95,12 @@ class TestFilters(unittest.TestCase):
     def test_get_current_collection_exercise_past_dates_only(self):
         """Tests that given set of collection exercises with only past dates, the closest date to 'today'
         will be picked"""
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"only_past_collection_exercises.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'only_past_collection_exercises.json') as json_data:
             collection_exercise_list = json.load(json_data)
 
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"closest_past_collection_exercise.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'closest_past_collection_exercise.json') as json_data:
             expected_output = json.load(json_data)
 
         output = get_current_collection_exercise(collection_exercise_list)
@@ -110,12 +110,12 @@ class TestFilters(unittest.TestCase):
     def test_get_current_collection_exercise_past_and_future_dates(self):
         """Tests that given set of collection exercises with past and future dates, the closest date to 'today'
         will be picked"""
-        with open(f"{project_root}/test_data/collection_exercise/"
+        with open(f'{project_root}/test_data/collection_exercise/'
                   f"mixed_past_and_future_collection_exercises.json") as json_data:
             collection_exercise_list = json.load(json_data)
 
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"closest_past_collection_exercise.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'closest_past_collection_exercise.json') as json_data:
             expected_output = json.load(json_data)
 
         output = get_current_collection_exercise(collection_exercise_list)
@@ -125,11 +125,11 @@ class TestFilters(unittest.TestCase):
     def test_get_current_collection_exercise_duplicate_start_dates(self):
         """Tests that when there are two collection exercises with the same start date, the one that was seen first
         will be the one returned."""
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"multiple_same_start_collection_exercises.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'multiple_same_start_collection_exercises.json') as json_data:
             collection_exercise_list = json.load(json_data)
 
-        with open(f"{project_root}/test_data/collection_exercise/"
+        with open(f'{project_root}/test_data/collection_exercise/'
                   f"closest_past_collection_exercise.json") as json_data:
             expected_output = json.load(json_data)
 

--- a/tests/common/test_mappers.py
+++ b/tests/common/test_mappers.py
@@ -9,8 +9,8 @@ project_root = os.path.dirname(os.path.dirname(__file__))
 
 class TestMappers(unittest.TestCase):
     def test_convert_event_list_to_dictionary(self):
-        with open(f"{project_root}/test_data/collection_exercise/"
-                  f"closest_future_collection_exercise.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/'
+                  f'closest_future_collection_exercise.json') as json_data:
             collection_exercise = json.load(json_data)
         function_input = collection_exercise['events']
         expected_output = {

--- a/tests/common/test_mappers.py
+++ b/tests/common/test_mappers.py
@@ -1,14 +1,17 @@
 import json
+import os
 import unittest
 
 from response_operations_ui.common.mappers import convert_event_list_to_dictionary, get_display_text_for_event
 
+project_root = os.path.dirname(os.path.dirname(__file__))
+
 
 class TestMappers(unittest.TestCase):
     def test_convert_event_list_to_dictionary(self):
-        file_paths = ['test_data/closest_future_collection_exercise.json',
-                      'tests/test_data/collection_exercise/closest_future_collection_exercise.json']
-        collection_exercise = self.load_file(file_paths)
+        with open(f"{project_root}/test_data/collection_exercise/"
+                  f"closest_future_collection_exercise.json") as json_data:
+            collection_exercise = json.load(json_data)
         function_input = collection_exercise['events']
         expected_output = {
             "mps": "2020-07-01T06:00:00.000Z",

--- a/tests/common/test_mappers.py
+++ b/tests/common/test_mappers.py
@@ -64,19 +64,3 @@ class TestMappers(unittest.TestCase):
             output = get_display_text_for_event(test[0])
             expected_output = test[1]
             self.assertEqual(output, expected_output)
-
-    @staticmethod
-    def load_file(file_paths):
-        """
-        Facilitates running the tests either as a whole with run_tests.py or individually.  Both ways of running the
-        tests start from a different place so relative paths don't work.  Currently only accepts lists of 2.
-        :param file_paths: A list of file paths to test
-        :return: The contents of the file
-        """
-        try:
-            with open(file_paths[0]) as fp:
-                file_data = json.load(fp)
-        except FileNotFoundError:
-            with open(file_paths[1]) as fp:
-                file_data = json.load(fp)
-        return file_data

--- a/tests/controllers/test_case_controller.py
+++ b/tests/controllers/test_case_controller.py
@@ -1,4 +1,5 @@
 import json
+import os
 import responses
 import unittest
 
@@ -8,7 +9,9 @@ from response_operations_ui.controllers import case_controller
 from response_operations_ui.exceptions.exceptions import ApiError
 
 case_id = '10b04906-f478-47f9-a985-783400dd8482'
-with open('tests/test_data/case/case_events.json') as fp:
+project_root = os.path.dirname(os.path.dirname(__file__))
+
+with open(f'{project_root}/test_data/case/case_events.json') as fp:
     case_events = json.load(fp)
 url_get_case_events = f'{TestingConfig.CASE_URL}/cases/{case_id}/events'
 url_get_case_groups = f'{TestingConfig.CASE_URL}/casegroups/partyid/{case_id}'

--- a/tests/controllers/test_collection_exercise_controller.py
+++ b/tests/controllers/test_collection_exercise_controller.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import os
 import unittest
 
 import responses
@@ -13,7 +14,9 @@ ce_id = "4a084bc0-130f-4aee-ae48-1a9f9e50178f"
 ce_events_by_id_url = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises/{ce_id}/events'
 ce_nudge_events_by_id_url = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises/{ce_id}/events/nudge'
 
-with open('tests/test_data/collection_exercise/ce_events_by_id.json') as fp:
+project_root = os.path.dirname(os.path.dirname(__file__))
+
+with open(f'{project_root}/test_data/collection_exercise/ce_events_by_id.json') as fp:
     ce_events = json.load(fp)
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import requests_mock
 import json
@@ -19,14 +20,15 @@ survey_id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 survey_short_name = 'BRES'
 period = '201801'
 tag = 'go_live'
+project_root = os.path.dirname(os.path.dirname(__file__))
 
-with open('tests/test_data/collection_exercise/collection_exercise.json') as json_data:
+with open(f'{project_root}/tests/test_data/collection_exercise/collection_exercise.json') as json_data:
     collection_exercise = json.load(json_data)
-with open('tests/test_data/collection_exercise/collection_exercise_details.json') as json_data:
+with open(f'{project_root}/tests/test_data/collection_exercise/collection_exercise_details.json') as json_data:
     collection_exercise_details = json.load(json_data)
-with open('tests/test_data/survey/single_survey.json') as json_data:
+with open(f'{project_root}/tests/test_data/survey/single_survey.json') as json_data:
     survey = json.load(json_data)
-with open('tests/test_data/collection_exercise/events.json') as json_data:
+with open(f'{project_root}/tests/test_data/collection_exercise/events.json') as json_data:
     events = json.load(json_data)
 url_put_update_event_date = (
     f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'

--- a/tests/views/test_change_response_status.py
+++ b/tests/views/test_change_response_status.py
@@ -1,3 +1,4 @@
+import os
 import json
 from unittest import TestCase
 
@@ -29,29 +30,28 @@ url_post_case_event = f'{TestingConfig.CASE_URL}/cases/{case_id}/events'
 url_get_case_by_case_group_id = f'{TestingConfig.CASE_URL}/cases/casegroupid/{case_group_id}'
 url_get_case_events = f"{TestingConfig.CASE_URL}/cases/{case_id}/events"
 get_respondent_by_id_url = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents/id/{party_id}'
+project_root = os.path.dirname(os.path.dirname(__file__))
 
 
-with open('tests/test_data/survey/single_survey.json') as fp:
+with open(f'{project_root}/test_data/survey/single_survey.json') as fp:
     survey = json.load(fp)
-with open('tests/test_data/collection_exercise/collection_exercise_list.json') as fp:
+with open(f'{project_root}/test_data/collection_exercise/collection_exercise_list.json') as fp:
     collection_exercise_list = json.load(fp)
-with open('tests/test_data/party/business_reporting_unit.json') as fp:
+with open(f'{project_root}/test_data/party/business_reporting_unit.json') as fp:
     business_reporting_unit = json.load(fp)
-with open('tests/test_data/case/case.json') as fp:
+with open(f'{project_root}/test_data/case/case.json') as fp:
     case = json.load(fp)
-with open('tests/test_data/case/case_groups_list.json') as fp:
+with open(f'{project_root}/test_data/case/case_groups_list.json') as fp:
     case_groups = json.load(fp)
-with open('tests/test_data/case/case_groups_list_completed.json') as fp:
+with open(f'{project_root}/test_data/case/case_groups_list_completed.json') as fp:
     case_groups_completed = json.load(fp)
-with open('tests/test_data/case/case_events.json') as fp:
+with open(f'{project_root}/test_data/case/case_events.json') as fp:
     case_events = json.load(fp)
-with open('tests/test_data/case/case_events_without_metadata.json') as fp:
+with open(f'{project_root}/test_data/case/case_events_without_metadata.json') as fp:
     case_events_without_metadata = json.load(fp)
-
-with open('tests/test_data/case/case_events_without_partyId_in_metadata.json') as fp:
+with open(f'{project_root}/test_data/case/case_events_without_partyId_in_metadata.json') as fp:
     case_events_without_partyId_in_metadata = json.load(fp)
-
-with open('tests/test_data/reporting_units/respondent.json') as json_data:
+with open(f'{project_root}/test_data/reporting_units/respondent.json') as json_data:
     respondent = json.load(json_data)
 
 

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -43,16 +43,16 @@ with open(no_sample) as json_data:
 with open(failed_validation) as json_data:
     collection_exercise_details_failedvalidation = json.load(json_data)
 
-with open(f"{project_root}/test_data/survey/edited_survey_ce_details.json") as json_data:
+with open(f'{project_root}/test_data/survey/edited_survey_ce_details.json') as json_data:
     updated_survey_info = json.load(json_data)
 
-with open(f"{project_root}/test_data/survey/survey_by_id.json") as fp:
+with open(f'{project_root}/test_data/survey/survey_by_id.json') as fp:
     survey_by_id = json.load(fp)
 
-with open(f"{project_root}/test_data/collection_exercise/exercise_data.json") as json_data:
+with open(f'{project_root}/test_data/collection_exercise/exercise_data.json') as json_data:
     exercise_data = json.load(json_data)
 
-with open(f"{project_root}/test_data/collection_exercise/ce_details_new_event.json") as fp:
+with open(f'{project_root}/test_data/collection_exercise/ce_details_new_event.json') as fp:
     ce_details_no_events = json.load(fp)
 
 with open(f'{project_root}/test_data/survey/classifier_type_selectors.json') as json_data:
@@ -86,81 +86,37 @@ with open(f'{project_root}/test_data/collection_exercise/events_2030.json') as j
     events_2030 = json.load(json_data)
 
 """Define URLS"""
-url_ce_by_id = (
-    f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises/{collection_exercise_id}'
-)
-url_ce_remove_sample = (
-    f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises/unlink/{collection_exercise_id}'
-    f'/sample/{sample_summary_id}'
-)
-url_ces_by_survey = (
-    f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises/survey/{survey_id}'
-)
-url_collection_exercise_link = (
-    f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises/link'
-    f'/{collection_exercise_id}'
-)
-url_collection_instrument = (
-    f'{TestingConfig.COLLECTION_INSTRUMENT_URL}'
-    f'/collection-instrument-api/1.0.2/upload/{collection_exercise_id}'
-)
-url_collection_instrument_link = (
-    f'{TestingConfig.COLLECTION_INSTRUMENT_URL}'
-    f'/collection-instrument-api/1.0.2/link-exercise'
-    f'/{collection_instrument_id}/{collection_exercise_id}'
-)
-url_collection_instrument_unlink = (
-    f'{TestingConfig.COLLECTION_INSTRUMENT_URL}'
-    f'/collection-instrument-api/1.0.2/unlink-exercise'
-    f'/{collection_instrument_id}/{collection_exercise_id}'
-)
+collection_exercise_root = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'
+url_ce_by_id = f'{collection_exercise_root}/{collection_exercise_id}'
+url_ce_remove_sample = f'{collection_exercise_root}/unlink/{collection_exercise_id}/sample/{sample_summary_id}'
+url_ces_by_survey = f'{collection_exercise_root}/survey/{survey_id}'
+url_collection_exercise_link = f'{collection_exercise_root}/link/{collection_exercise_id}'
+url_get_collection_exercises_link = f'{collection_exercise_root}/link/{collection_exercise_id}'
+url_link_sample = f'{collection_exercise_root}/link/{collection_exercise_id}'
+url_collection_exercise_survey_id = f'{collection_exercise_root}/survey/{survey_id}'
+url_update_ce_user_details = f'{collection_exercise_root}/{collection_exercise_id}/userDescription'
+url_update_ce_period = f'{collection_exercise_root}/{collection_exercise_id}/exerciseRef'
+url_get_collection_exercise_events = f'{collection_exercise_root}/{collection_exercise_id}/events'
+url_create_collection_exercise = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'
+url_execute = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexerciseexecution/{collection_exercise_id}'
+
+collection_instrument_root = f'{TestingConfig.COLLECTION_INSTRUMENT_URL}/collection-instrument-api/1.0.2'
+url_collection_instrument = f'{collection_instrument_root}/upload/{collection_exercise_id}'
+url_collection_instrument_link = \
+    f'{collection_instrument_root}/link-exercise/{collection_instrument_id}/{collection_exercise_id}'
+url_collection_instrument_unlink = \
+    f'{collection_instrument_root}/unlink-exercise/{collection_instrument_id}/{collection_exercise_id}'
+url_get_collection_instrument = f'{collection_instrument_root}/collectioninstrument'
+
 url_survey_shortname = f'{TestingConfig.SURVEY_URL}/surveys/shortname/{short_name}'
+url_get_survey_by_short_name = f'{TestingConfig.SURVEY_URL}/surveys/shortname/{short_name}'
+
+url_get_classifier_type_selectors = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}/classifiertypeselectors'
+url_get_classifier_type = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}/classifiertypeselectors/{ci_selector_id}'
+
 url_sample_service_upload = f'{TestingConfig.SAMPLE_FILE_UPLOADER_URL}/samples/fileupload'
 
-url_collection_exercise_survey_id = (
-    f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises/survey'
-    f'/{survey_id}'
-)
-
-url_update_ce_user_details = (
-    f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'
-    f'/{collection_exercise_id}/userDescription'
-)
-url_update_ce_period = (
-    f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'
-    f'/{collection_exercise_id}/exerciseRef'
-)
-
-url_execute = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexerciseexecution/{collection_exercise_id}'
-url_create_collection_exercise = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'
-url_get_classifier_type_selectors = (
-    f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}/classifiertypeselectors'
-)
-url_get_classifier_type = (
-    f'{TestingConfig.SURVEY_URL}'
-    f'/surveys/{survey_id}/classifiertypeselectors/{ci_selector_id}'
-)
-url_get_collection_exercise_events = (
-    f'{TestingConfig.COLLECTION_EXERCISE_URL}'
-    f'/collectionexercises/{collection_exercise_id}/events'
-)
-url_get_collection_instrument = (
-    f'{TestingConfig.COLLECTION_INSTRUMENT_URL}'
-    f'/collection-instrument-api/1.0.2/collectioninstrument'
-)
-url_get_sample_summary = (
-    f'{TestingConfig.SAMPLE_URL}'
-    f'/samples/samplesummary/{sample_summary_id}'
-)
-url_get_survey_by_short_name = f'{TestingConfig.SURVEY_URL}/surveys/shortname/{short_name}'
-url_link_sample = (
-    f'{TestingConfig.COLLECTION_EXERCISE_URL}'
-    f'/collectionexercises/link/{collection_exercise_id}'
-)
-url_get_collection_exercises_link = (
-    f'{TestingConfig.COLLECTION_EXERCISE_URL}'
-    f'/collectionexercises/link/{collection_exercise_id}'
-)
+url_get_sample_summary = f'{TestingConfig.SAMPLE_URL}/samples/samplesummary/{sample_summary_id}'
 
 ci_search_string = urlencode({'searchString': json.dumps({
     "SURVEY_ID": survey_id,

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -1,3 +1,4 @@
+import os
 import copy
 import json
 from io import BytesIO
@@ -24,10 +25,13 @@ short_name = 'MBS'
 survey_id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 survey_ref = '141'
 
-collex_root = "tests/test_data/collection_exercise/collection_exercise_details"
+project_root = os.path.dirname(os.path.dirname(__file__))
+
+collex_root = f"{project_root}/test_data/collection_exercise/collection_exercise_details"
 no_sample = collex_root + "_no_sample.json"
 failed_validation = collex_root + "_failedvalidation.json"
 collex_details = collex_root + ".json"
+
 
 """Load all the necessary test data"""
 with open(collex_details) as json_data:
@@ -39,46 +43,46 @@ with open(no_sample) as json_data:
 with open(failed_validation) as json_data:
     collection_exercise_details_failedvalidation = json.load(json_data)
 
-with open("tests/test_data/survey/edited_survey_ce_details.json") as json_data:
+with open(f"{project_root}/test_data/survey/edited_survey_ce_details.json") as json_data:
     updated_survey_info = json.load(json_data)
 
-with open("tests/test_data/survey/survey_by_id.json") as fp:
+with open(f"{project_root}/test_data/survey/survey_by_id.json") as fp:
     survey_by_id = json.load(fp)
 
-with open("tests/test_data/collection_exercise/exercise_data.json") as json_data:
+with open(f"{project_root}/test_data/collection_exercise/exercise_data.json") as json_data:
     exercise_data = json.load(json_data)
 
-with open("tests/test_data/collection_exercise/ce_details_new_event.json") as fp:
+with open(f"{project_root}/test_data/collection_exercise/ce_details_new_event.json") as fp:
     ce_details_no_events = json.load(fp)
 
-with open('tests/test_data/survey/classifier_type_selectors.json') as json_data:
+with open(f'{project_root}/test_data/survey/classifier_type_selectors.json') as json_data:
     classifier_type_selectors = json.load(json_data)
 
-with open('tests/test_data/survey/classifier_types.json') as json_data:
+with open(f'{project_root}/test_data/survey/classifier_types.json') as json_data:
     classifier_types = json.load(json_data)
 
-with open('tests/test_data/collection_exercise/formatted_collection_exercise_details.json') as fp:
+with open(f'{project_root}/test_data/collection_exercise/formatted_collection_exercise_details.json') as fp:
     formatted_collection_exercise_details = json.load(fp)
 
-with open('tests/test_data/collection_exercise/seft_collection_exercise_details.json') as seft:
+with open(f'{project_root}/test_data/collection_exercise/seft_collection_exercise_details.json') as seft:
     seft_collection_exercise_details = json.load(seft)
 
-with open('tests/test_data/collection_exercise/collection_exercise.json') as json_data:
+with open(f'{project_root}/test_data/collection_exercise/collection_exercise.json') as json_data:
     collection_exercise = json.load(json_data)
 
-with open('tests/test_data/survey/single_survey.json') as json_data:
+with open(f'{project_root}/test_data/survey/single_survey.json') as json_data:
     survey = json.load(json_data)
 
-with open('tests/test_data/collection_exercise/events.json') as json_data:
+with open(f'{project_root}/test_data/collection_exercise/events.json') as json_data:
     events = json.load(json_data)
 
-with open('tests/test_data/collection_exercise/nudge_events_one.json') as json_data:
+with open(f'{project_root}/test_data/collection_exercise/nudge_events_one.json') as json_data:
     nudge_events_one = json.load(json_data)
 
-with open('tests/test_data/collection_exercise/nudge_events_two.json') as json_data:
+with open(f'{project_root}/test_data/collection_exercise/nudge_events_two.json') as json_data:
     nudge_events_two = json.load(json_data)
 
-with open('tests/test_data/collection_exercise/events_2030.json') as json_data:
+with open(f'{project_root}/test_data/collection_exercise/events_2030.json') as json_data:
     events_2030 = json.load(json_data)
 
 """Define URLS"""
@@ -557,7 +561,7 @@ class TestCollectionExercise(ViewTestCase):
     @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_choose_collection_instrument_when_first(self, mock_request, mock_details):
         with open(
-                "tests/test_data/collection_exercise/formatted_collection_exercise_details_no_ci.json"
+                f'{project_root}/test_data/collection_exercise/formatted_collection_exercise_details_no_ci.json'
         ) as collection_exercise:
             mock_details.return_value = json.load(collection_exercise)
 
@@ -667,7 +671,7 @@ class TestCollectionExercise(ViewTestCase):
     def test_no_upload_sample_when_bad_extension(self, mock_request, mock_details):
         data = {"sampleFile": (BytesIO(b"data"), "test.html"), "load-sample": ""}
         with open(
-                "tests/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json"
+                f'{project_root}/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json'
         ) as collection_exercise:
             mock_details.return_value = json.load(collection_exercise)
         mock_request.get(url_get_survey_by_short_name, status_code=200, json=self.survey_data)
@@ -686,7 +690,7 @@ class TestCollectionExercise(ViewTestCase):
     def test_no_upload_sample_when_no_file(self, mock_request, mock_details):
         data = {"load-sample": ""}
         with open(
-                "tests/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json"
+                f'{project_root}/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json'
         ) as collection_exercise:
             mock_details.return_value = json.load(collection_exercise)
         mock_request.get(url_get_survey_by_short_name, status_code=200, json=self.survey_data)
@@ -792,7 +796,8 @@ class TestCollectionExercise(ViewTestCase):
     @patch('response_operations_ui.views.collection_exercise.build_collection_exercise_details')
     def test_failed_execution(self, mock_request, mock_details):
         with open(
-                "tests/test_data/collection_exercise/formatted_collection_exercise_details_failedvalidation.json"
+                f'{project_root}/test_data/collection_exercise/'
+                f'formatted_collection_exercise_details_failedvalidation.json'
         ) as collection_exercise:
             mock_details.return_value = json.load(collection_exercise)
 
@@ -1200,7 +1205,7 @@ class TestCollectionExercise(ViewTestCase):
     @mock.patch("response_operations_ui.controllers.collection_exercise_controllers.create_collection_exercise_event")
     def test_create_collection_exercise_event_success(self, mock_ce_events, mock_get_ce_details):
         with open(
-                "tests/test_data/collection_exercise/formatted_collection_exercise_details_no_events.json"
+                f'{project_root}/test_data/collection_exercise/formatted_collection_exercise_details_no_events.json'
         ) as collection_exercise:
             mock_get_ce_details.return_value = json.load(collection_exercise)
             mock_ce_events.return_value = None

--- a/tests/views/test_data/closest_past_collection_exercise.json
+++ b/tests/views/test_data/closest_past_collection_exercise.json
@@ -1,1 +1,0 @@
-../../test_data/collection_exercise/closest_past_collection_exercise.json

--- a/tests/views/test_home.py
+++ b/tests/views/test_home.py
@@ -44,8 +44,8 @@ class TestSignIn(unittest.TestCase):
     def test_get_sample_data(self, mock_request):
         """Tests getting sample data when everything is working as expected"""
         mock_request.get(url_dashboard, json=reporting_json, status_code=200)
-        
-        with open(f"{project_root}/test_data/collection_exercise/closest_past_collection_exercise.json") as json_data:
+
+        with open(f'{project_root}/test_data/collection_exercise/closest_past_collection_exercise.json') as json_data:
             collection_exercise = json.load(json_data)
 
         expected_url = 'http://localhost:8078/dashboard/collection-exercise/aec41b04-a177-4994-b385-a16136242d05'
@@ -64,7 +64,7 @@ class TestSignIn(unittest.TestCase):
         will return mostly 'N/A'.  The dashboard url will still present with the info available."""
         mock_request.get(url_dashboard, json={'message': 'Invalid collection exercise or survey ID'}, status_code=404)
 
-        with open(f"{project_root}/test_data/collection_exercise/closest_past_collection_exercise.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/closest_past_collection_exercise.json') as json_data:
             collection_exercise = json.load(json_data)
 
         expected_url = 'http://localhost:8078/dashboard/collection-exercise/aec41b04-a177-4994-b385-a16136242d05'
@@ -85,7 +85,7 @@ class TestSignIn(unittest.TestCase):
         copied_dashboard_response['report']['sampleSize'] = 0
         mock_request.get(url_dashboard, json=copied_dashboard_response, status_code=200)
 
-        with open(f"{project_root}/test_data/collection_exercise/closest_past_collection_exercise.json") as json_data:
+        with open(f'{project_root}/test_data/collection_exercise/closest_past_collection_exercise.json') as json_data:
             collection_exercise = json.load(json_data)
 
         expected_url = 'http://localhost:8078/dashboard/collection-exercise/aec41b04-a177-4994-b385-a16136242d05'

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -17,15 +17,20 @@ respondent_party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
 business_party_id = 'b3ba864b-7cbc-4f44-84fe-88dc018a1a4c'
 collection_exercise_id_1 = '14fb3e68-4dca-46db-bf49-04b84e07e77c'
 collection_exercise_id_2 = '9af403f8-5fc5-43b1-9fca-afbd9c65da5c'
-survey_id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+survey_id_1 = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+survey_id_2 = '6aa8896f-ced5-4694-800c-6cd661b0c8b2'
 ru_ref = '50012345678'
 iac_1 = 'jkbvyklkwj88'
 iac_2 = 'ljbgg3kgstr4'
 
 url_get_party_by_ru_ref = f'{TestingConfig.PARTY_URL}/party-api/v1/parties/type/B/ref/'
+url_get_respondent_party_by_list = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents?id={respondent_party_id}'
+url_get_business_attributes = f'{TestingConfig.PARTY_URL}/party-api/v1/businesses/id/{business_party_id}/attributes'
+
 shortname_url = f'{TestingConfig.SURVEY_URL}/surveys/shortname'
-url_sign_in_data = f'{TestingConfig.UAA_SERVICE_URL}/oauth/token'
 url_get_surveys_list = f'{TestingConfig.SURVEY_URL}/surveys/surveytype/Business'
+url_get_survey_by_id = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id_1}'
+
 url_get_thread = f'{TestingConfig.SECURE_MESSAGE_URL}/threads/fb0e79bd-e132-4f4f-a7fd-5e8c6b41b9af'
 url_get_threads_list = f'{TestingConfig.SECURE_MESSAGE_URL}/threads'
 url_send_message = f'{TestingConfig.SECURE_MESSAGE_URL}/messages'
@@ -34,16 +39,11 @@ url_update_label = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/modify/ae46748b
 url_modify_label_base = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/modify/'
 url_select_survey = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/select-survey'
 
+url_sign_in_data = f'{TestingConfig.UAA_SERVICE_URL}/oauth/token'
 url_get_case_groups_by_business_party_id = f'{TestingConfig.CASE_URL}/cases/partyid/{business_party_id}'
 url_get_collection_exercise_by_id = f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'
-url_get_business_attributes = f'{TestingConfig.PARTY_URL}/party-api/v1/businesses/id/{business_party_id}/attributes'
-url_get_survey_by_id = f'{TestingConfig.SURVEY_URL}/surveys/{survey_id}'
-url_get_respondent_party_by_list = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents?id={respondent_party_id}'
 url_get_iac = f'{TestingConfig.IAC_URL}/iacs'
 
-
-survey_id = '6aa8896f-ced5-4694-800c-6cd661b0c8b2'
-params = f'?survey={survey_id}&page=1&limit=10'
 project_root = os.path.dirname(os.path.dirname(__file__))
 
 with open(f'{project_root}/test_data/message/thread.json') as json_data:
@@ -76,28 +76,28 @@ with open(f'{project_root}/test_data/message/threads_unread.json') as json_data:
 with open(f'{project_root}/test_data/message/thread_unread.json') as json_data:
     thread_unread_json = json.load(json_data)
 
-with open('tests/test_data/party/business_reporting_unit.json') as fp:
+with open(f'{project_root}/test_data/party/business_reporting_unit.json') as fp:
     business_reporting_unit = json.load(fp)
 
-with open('tests/test_data/case/cases_list.json') as fp:
+with open(f'{project_root}/test_data/case/cases_list.json') as fp:
     cases_list = json.load(fp)
 
-with open('tests/test_data/collection_exercise/collection_exercise.json') as fp:
+with open(f'{project_root}/test_data/collection_exercise/collection_exercise.json') as fp:
     collection_exercise = json.load(fp)
 
-with open('tests/test_data/collection_exercise/collection_exercise_2.json') as fp:
+with open(f'{project_root}/test_data/collection_exercise/collection_exercise_2.json') as fp:
     collection_exercise_2 = json.load(fp)
 
-with open('tests/test_data/party/business_attributes.json') as fp:
+with open(f'{project_root}/test_data/party/business_attributes.json') as fp:
     business_attributes = json.load(fp)
 
-with open('tests/test_data/survey/single_survey.json') as fp:
+with open(f'{project_root}/test_data/survey/single_survey.json') as fp:
     survey = json.load(fp)
 
-with open('tests/test_data/party/respondent_party_list.json') as fp:
+with open(f'{project_root}/test_data/party/respondent_party_list.json') as fp:
     respondent_party_list = json.load(fp)
 
-with open('tests/test_data/iac/iac.json') as fp:
+with open(f'{project_root}/test_data/iac/iac.json') as fp:
     iac = json.load(fp)
 
 
@@ -1041,7 +1041,7 @@ class TestMessage(ViewTestCase):
                                           business_id=business_id_filter,
                                           conversation_tab=conversation_tab)
 
-        query = f'survey={survey_id}&is_closed=true&my_conversations=false&new_respondent_conversations=false&' \
+        query = f'survey={survey_id_2}&is_closed=true&my_conversations=false&new_respondent_conversations=false&' \
             f'all_conversation_types=false&business_id={business_id_filter}&page={page}&limit={limit}'
         assert self._mock_request_called_with_expected_query(mock_request, query)
 
@@ -1083,7 +1083,7 @@ class TestMessage(ViewTestCase):
                                           business_id=business_id_filter,
                                           conversation_tab=conversation_tab)
 
-        query = f'survey={survey_id}&is_closed=true&my_conversations=false&new_respondent_conversations=false&' \
+        query = f'survey={survey_id_2}&is_closed=true&my_conversations=false&new_respondent_conversations=false&' \
             f'all_conversation_types=false&business_id={business_id_filter}&page={page}&limit={limit}'
         assert self._mock_request_called_with_expected_query(mock_request, query)
 

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -1,3 +1,4 @@
+import os
 import copy
 import json
 from unittest.mock import patch
@@ -26,35 +27,36 @@ url_select_survey = f'{TestingConfig.SECURE_MESSAGE_URL}/messages/select-survey'
 
 survey_id = '6aa8896f-ced5-4694-800c-6cd661b0c8b2'
 params = f'?survey={survey_id}&page=1&limit=10'
+project_root = os.path.dirname(os.path.dirname(__file__))
 
-with open('tests/test_data/message/thread.json') as json_data:
+with open(f'{project_root}/test_data/message/thread.json') as json_data:
     thread_json = json.load(json_data)
 
-with open('tests/test_data/message/thread_missing_subject.json') as json_data:
+with open(f'{project_root}/test_data/message/thread_missing_subject.json') as json_data:
     thread_missing_subject = json.load(json_data)
 
-with open('tests/test_data/message/threads.json') as json_data:
+with open(f'{project_root}/test_data/message/threads.json') as json_data:
     thread_list = json.load(json_data)
 
-with open('tests/test_data/message/threads_multipage.json') as json_data:
+with open(f'{project_root}/test_data/message/threads_multipage.json') as json_data:
     thread_list_multi_page = json.load(json_data)
 
-with open('tests/test_data/message/threads_multipage_multi_ru.json') as json_data:
+with open(f'{project_root}/test_data/message/threads_multipage_multi_ru.json') as json_data:
     thread_list_multi_page_multi_ru = json.load(json_data)
 
-with open('tests/test_data/survey/survey_list.json') as json_data:
+with open(f'{project_root}/test_data/survey/survey_list.json') as json_data:
     survey_list = json.load(json_data)
 
-with open('tests/test_data/survey/ashe_response.json') as json_data:
+with open(f'{project_root}/test_data/survey/ashe_response.json') as json_data:
     ashe_info = json.load(json_data)
 
-with open('tests/test_data/message/threads_no_unread.json') as json_data:
+with open(f'{project_root}/test_data/message/threads_no_unread.json') as json_data:
     threads_no_unread_list = json.load(json_data)
 
-with open('tests/test_data/message/threads_unread.json') as json_data:
+with open(f'{project_root}/test_data/message/threads_unread.json') as json_data:
     threads_unread_list = json.load(json_data)
 
-with open('tests/test_data/message/thread_unread.json') as json_data:
+with open(f'{project_root}/test_data/message/thread_unread.json') as json_data:
     thread_unread_json = json.load(json_data)
 
 
@@ -117,7 +119,7 @@ class TestMessage(ViewTestCase):
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
     def test_threads_list_with_missing_atmsg_to(self, mock_request, mock_get_jwt):
         mock_get_jwt.return_value = "blah"
-        with open('tests/test_data/message/threads_missing_atmsg_to.json') as thread_json:
+        with open(f'{project_root}/test_data/message/threads_missing_atmsg_to.json') as thread_json:
             malformed_thread_list = json.load(thread_json)
         mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
@@ -134,7 +136,7 @@ class TestMessage(ViewTestCase):
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
     def test_threads_list_with_missing_atmsg_from(self, mock_request, mock_get_jwt):
         mock_get_jwt.return_value = "blah"
-        with open('tests/test_data/message/threads_missing_atmsg_from.json') as thread_json:
+        with open(f'{project_root}/test_data/message/threads_missing_atmsg_from.json') as thread_json:
             malformed_thread_list = json.load(thread_json)
         mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
@@ -151,7 +153,7 @@ class TestMessage(ViewTestCase):
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
     def test_threads_list_with_missing_msg_to(self, mock_request, mock_get_jwt):
         mock_get_jwt.return_value = "blah"
-        with open('tests/test_data/message/threads_missing_msg_to.json') as thread_json:
+        with open(f'{project_root}/test_data/message/threads_missing_msg_to.json') as thread_json:
             malformed_thread_list = json.load(thread_json)
         mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
@@ -168,7 +170,7 @@ class TestMessage(ViewTestCase):
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
     def test_threads_list_with_missing_date(self, mock_request, mock_get_jwt):
         mock_get_jwt.return_value = "blah"
-        with open('tests/test_data/message/threads_missing_sent_date.json') as thread_json:
+        with open(f'{project_root}/test_data/message/threads_missing_sent_date.json') as thread_json:
             malformed_thread_list = json.load(thread_json)
         mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
@@ -185,7 +187,7 @@ class TestMessage(ViewTestCase):
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
     def test_threads_list_with_missing_ru_ref(self, mock_request, mock_get_jwt):
         mock_get_jwt.return_value = "blah"
-        with open('tests/test_data/message/threads_missing_ru_ref.json') as thread_json:
+        with open(f'{project_root}/test_data/message/threads_missing_ru_ref.json') as thread_json:
             malformed_thread_list = json.load(thread_json)
         mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
@@ -202,7 +204,7 @@ class TestMessage(ViewTestCase):
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
     def test_threads_list_with_missing_business_name(self, mock_request, mock_get_jwt):
         mock_get_jwt.return_value = "blah"
-        with open('tests/test_data/message/threads_missing_business_name.json') as thread_json:
+        with open(f'{project_root}/test_data/message/threads_missing_business_name.json') as thread_json:
             malformed_thread_list = json.load(thread_json)
         mock_request.get(url_messages + '/count', json={"total": 1}, status_code=200)
         mock_request.get(url_get_threads_list, json=malformed_thread_list)
@@ -322,7 +324,7 @@ class TestMessage(ViewTestCase):
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
     def test_get_thread_with_deleted_user_cannot_be_replied_to(self, mock_request, mock_get_jwt):
         mock_get_jwt.return_value = "blah"
-        with open('tests/test_data/message/thread_missing_respondent.json') as thread_json:
+        with open(f'{project_root}/test_data/message/thread_missing_respondent.json') as thread_json:
             missing_user_json = json.load(thread_json)
         mock_request.get(url_get_thread, json=missing_user_json)
         mock_request.put(url_update_label)
@@ -727,13 +729,13 @@ class TestMessage(ViewTestCase):
         self.assertIn("FDI Messages".encode(), response.data)
 
     def test_get_to_id(self):
-        with open('tests/test_data/message/threads.json') as fp:
+        with open(f'{project_root}/test_data/message/threads.json') as fp:
             conversation = json.load(fp)
         self.assertEqual(conversation['messages'][0]['msg_to'][0],
                          _get_to_id(conversation['messages'][0]))
 
     def test_get_to_id_index_error(self):
-        with open('tests/test_data/message/threads.json') as fp:
+        with open(f'{project_root}/test_data/message/threads.json') as fp:
             conversation = json.load(fp)
         del conversation['messages'][0]['msg_to'][0]
         self.assertEqual(None, _get_to_id(conversation['messages'][0]))

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -1,3 +1,4 @@
+import os
 import json
 import re
 from unittest import TestCase
@@ -42,39 +43,40 @@ url_get_respondent_party_by_list = f'{TestingConfig.PARTY_URL}/party-api/v1/resp
 url_get_iac = f'{TestingConfig.IAC_URL}/iacs'
 url_get_case = f'{TestingConfig.CASE_URL}/cases/{case_id}?iac=true'
 
+project_root = os.path.dirname(os.path.dirname(__file__))
 
-with open('tests/test_data/reporting_units/respondent.json') as fp:
+with open(f'{project_root}/test_data/reporting_units/respondent.json') as fp:
     respondent = json.load(fp)
-with open('tests/test_data/reporting_units/respondent_with_pending_email.json') as fp:
+with open(f'{project_root}/test_data/reporting_units/respondent_with_pending_email.json') as fp:
     respondent_with_pending_email = json.load(fp)
-with open('tests/test_data/case/case.json') as fp:
+with open(f'{project_root}/test_data/case/case.json') as fp:
     case = json.load(fp)
 
-with open('tests/test_data/party/business_reporting_unit.json') as fp:
+with open(f'{project_root}/test_data/party/business_reporting_unit.json') as fp:
     business_reporting_unit = json.load(fp)
-with open('tests/test_data/case/cases_list.json') as fp:
+with open(f'{project_root}/test_data/case/cases_list.json') as fp:
     cases_list = json.load(fp)
-with open('tests/test_data/case/cases_list_completed.json') as fp:
+with open(f'{project_root}/test_data/case/cases_list_completed.json') as fp:
     cases_list_completed = json.load(fp)
-with open('tests/test_data/case/case_groups_list.json') as fp:
+with open(f'{project_root}/test_data/case/case_groups_list.json') as fp:
     case_groups = json.load(fp)
-with open('tests/test_data/collection_exercise/collection_exercise.json') as fp:
+with open(f'{project_root}/test_data/collection_exercise/collection_exercise.json') as fp:
     collection_exercise = json.load(fp)
-with open('tests/test_data/collection_exercise/collection_exercise_2.json') as fp:
+with open(f'{project_root}/test_data/collection_exercise/collection_exercise_2.json') as fp:
     collection_exercise_2 = json.load(fp)
-with open('tests/test_data/party/business_party.json') as fp:
+with open(f'{project_root}/test_data/party/business_party.json') as fp:
     business_party = json.load(fp)
-with open('tests/test_data/party/business_attributes.json') as fp:
+with open(f'{project_root}/test_data/party/business_attributes.json') as fp:
     business_attributes = json.load(fp)
-with open('tests/test_data/case/case_group_statuses.json') as fp:
+with open(f'{project_root}/test_data/case/case_group_statuses.json') as fp:
     case_group_statuses = json.load(fp)
-with open('tests/test_data/survey/single_survey.json') as fp:
+with open(f'{project_root}/test_data/survey/single_survey.json') as fp:
     survey = json.load(fp)
-with open('tests/test_data/party/respondent_party.json') as fp:
+with open(f'{project_root}/test_data/party/respondent_party.json') as fp:
     respondent_party = json.load(fp)
-with open('tests/test_data/party/respondent_party_list.json') as fp:
+with open(f'{project_root}/test_data/party/respondent_party_list.json') as fp:
     respondent_party_list = json.load(fp)
-with open('tests/test_data/iac/iac.json') as fp:
+with open(f'{project_root}/test_data/iac/iac.json') as fp:
     iac = json.load(fp)
 
 

--- a/tests/views/test_respondents.py
+++ b/tests/views/test_respondents.py
@@ -1,5 +1,6 @@
 import json
 import mock
+import os
 from bs4 import BeautifulSoup
 
 import requests_mock
@@ -9,6 +10,7 @@ from tests.views import ViewTestCase
 from tests.views.test_reporting_units import url_edit_contact_details, url_get_party_by_ru_ref, \
     url_get_cases_by_business_party_id, url_get_survey_by_id, url_get_respondent_party_by_party_id, \
     url_get_collection_exercise_by_id, url_get_iac, url_change_respondent_status
+
 respondent_party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
 business_party_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
 party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
@@ -32,31 +34,33 @@ iac_2 = 'ljbgg3kgstr4'
 get_respondent_root = 'http://localhost:8085/party-api/v1/respondents/'
 get_respondent_root_with_trailing_slash = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents/'
 
-with open('tests/test_data/reporting_units/respondent.json') as json_data:
+project_root = os.path.dirname(os.path.dirname(__file__))
+
+with open(f'{project_root}/test_data/reporting_units/respondent.json') as json_data:
     respondent = json.load(json_data)
-with open('tests/test_data/reporting_units/reporting_unit.json') as json_data:
+with open(f'{project_root}/test_data/reporting_units/reporting_unit.json') as json_data:
     reporting_unit = json.load(json_data)
-with open('tests/test_data/survey/survey_by_id.json') as json_data:
+with open(f'{project_root}/test_data/survey/survey_by_id.json') as json_data:
     survey_by_id = json.load(json_data)
-with open('tests/test_data/party/business_reporting_unit.json') as fp:
+with open(f'{project_root}/test_data/party/business_reporting_unit.json') as fp:
     business_reporting_unit = json.load(fp)
-with open('tests/test_data/case/cases_list.json') as fp:
+with open(f'{project_root}/test_data/case/cases_list.json') as fp:
     cases_list = json.load(fp)
-with open('tests/test_data/case/case_groups_list.json') as fp:
+with open(f'{project_root}/test_data/case/case_groups_list.json') as fp:
     case_groups = json.load(fp)
-with open('tests/test_data/case/case_groups_list_completed.json') as fp:
+with open(f'{project_root}/test_data/case/case_groups_list_completed.json') as fp:
     case_groups_completed = json.load(fp)
-with open('tests/test_data/collection_exercise/collection_exercise.json') as fp:
+with open(f'{project_root}/test_data/collection_exercise/collection_exercise.json') as fp:
     collection_exercise = json.load(fp)
-with open('tests/test_data/party/business_party.json') as fp:
+with open(f'{project_root}/test_data/party/business_party.json') as fp:
     business_party = json.load(fp)
-with open('tests/test_data/case/case_group_statuses.json') as fp:
+with open(f'{project_root}/test_data/case/case_group_statuses.json') as fp:
     case_group_statuses = json.load(fp)
-with open('tests/test_data/survey/single_survey.json') as fp:
+with open(f'{project_root}/test_data/survey/single_survey.json') as fp:
     survey = json.load(fp)
-with open('tests/test_data/party/respondent_party.json') as fp:
+with open(f'{project_root}/test_data/party/respondent_party.json') as fp:
     respondent_party = json.load(fp)
-with open('tests/test_data/iac/iac.json') as fp:
+with open(f'{project_root}/test_data/iac/iac.json') as fp:
     iac = json.load(fp)
 
 
@@ -132,7 +136,7 @@ class TestRespondents(ViewTestCase):
     # Respondent Search UI Testing
     @staticmethod
     def _mock_party_data(search_respondents_mock, total=1000):
-        with open('tests/test_data/party/mock_search_respondents_data.json', 'r') as json_file:
+        with open(f'{project_root}/test_data/party/mock_search_respondents_data.json', 'r') as json_file:
             data = json.load(json_file)
             search_respondents_mock.return_value = {
                 'data': data,

--- a/tests/views/test_survey.py
+++ b/tests/views/test_survey.py
@@ -1,3 +1,4 @@
+import os
 import json
 from contextlib import suppress
 from unittest.mock import MagicMock
@@ -19,22 +20,22 @@ survey_id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 url_get_survey_list = f'{TestingConfig.SURVEY_URL}/surveys/surveytype/Business'
 url_get_legal_basis_list = f'{TestingConfig.SURVEY_URL}/legal-bases'
 url_create_survey = f'{TestingConfig.SURVEY_URL}/surveys'
-
-with open('tests/test_data/survey/survey_list.json') as f:
-    survey_list = json.load(f)
-with open('tests/test_data/survey/legal_basis_list.json') as f:
-    legal_basis_list = json.load(f)
-
 url_get_survey_by_short_name = f'{TestingConfig.SURVEY_URL}/surveys/shortname/bres'
 url_get_survey_by_qbs = f'{TestingConfig.SURVEY_URL}/surveys/shortname/QBS'
-with open('tests/test_data/survey/survey.json') as f:
-    survey_info = json.load(f)
-with open('tests/test_data/survey/survey_states.json') as f:
-    survey_info_states = json.load(f)
 url_update_survey_details = f'{TestingConfig.SURVEY_URL}/surveys/ref/222'
-with open('tests/test_data/survey/updated_survey_list.json') as f:
+project_root = os.path.dirname(os.path.dirname(__file__))
+
+with open(f'{project_root}/test_data/survey/survey_list.json') as f:
+    survey_list = json.load(f)
+with open(f'{project_root}/test_data/survey/legal_basis_list.json') as f:
+    legal_basis_list = json.load(f)
+with open(f'{project_root}/test_data/survey/survey.json') as f:
+    survey_info = json.load(f)
+with open(f'{project_root}/test_data/survey/survey_states.json') as f:
+    survey_info_states = json.load(f)
+with open(f'{project_root}/test_data/survey/updated_survey_list.json') as f:
     updated_survey_list = json.load(f)
-with open('tests/test_data/survey/create_survey_response.json') as f:
+with open(f'{project_root}/test_data/survey/create_survey_response.json') as f:
     create_survey_response = json.load(f)
 url_get_collection_exercises = (
     f'{TestingConfig.COLLECTION_EXERCISE_URL}'
@@ -516,7 +517,7 @@ class TestSurvey(ViewTestCase):
 
     def test_sort_collection_exercise(self):
         # Given there are collection exercises loaded for a survey
-        with open('tests/test_data/survey/multiple_ces.json') as f:
+        with open(f'{project_root}/test_data/survey/multiple_ces.json') as f:
             collection_exercises = json.load(f)
 
         # When collection exercises are sorted

--- a/tests/views/test_update_event_date.py
+++ b/tests/views/test_update_event_date.py
@@ -1,3 +1,4 @@
+import os
 import json
 from urllib.parse import urlparse
 
@@ -12,18 +13,19 @@ survey_id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 survey_short_name = 'BRES'
 period = '201801'
 tag = 'go_live'
+project_root = os.path.dirname(os.path.dirname(__file__))
 
-with open('tests/test_data/collection_exercise/collection_exercise.json') as json_data:
+with open(f'{project_root}/test_data/collection_exercise/collection_exercise.json') as json_data:
     collection_exercise = json.load(json_data)
-with open('tests/test_data/collection_exercise/collection_exercise_details.json') as json_data:
+with open(f'{project_root}/test_data/collection_exercise/collection_exercise_details.json') as json_data:
     collection_exercise_details = json.load(json_data)
-with open('tests/test_data/survey/single_survey.json') as json_data:
+with open(f'{project_root}/test_data/survey/single_survey.json') as json_data:
     survey = json.load(json_data)
-with open('tests/test_data/collection_exercise/events.json') as json_data:
+with open(f'{project_root}/test_data/collection_exercise/events.json') as json_data:
     events = json.load(json_data)
-with open('tests/test_data/collection_exercise/nudge_events_two.json') as json_data:
+with open(f'{project_root}/test_data/collection_exercise/nudge_events_two.json') as json_data:
     nudge_events_two = json.load(json_data)
-with open('tests/test_data/collection_exercise/events_2030.json') as json_data:
+with open(f'{project_root}/test_data/collection_exercise/events_2030.json') as json_data:
     events_2030 = json.load(json_data)
 url_put_update_event_date = (
     f'{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises'


### PR DESCRIPTION
# Motivation and Context
Before the only decent way to run the majority of the tests was to `make test`, this change makes the tests smarter about finding test data relative to where the test is being run. This means you can run an increased number of them individually (via pycharm or whatever else) as opposed to being forced to sit through the whole suite.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
