### PR TITLE
Moving sample distribution to not be async

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.31
+appVersion: 2.4.32

--- a/response_operations_ui/controllers/collection_exercise_controllers.py
+++ b/response_operations_ui/controllers/collection_exercise_controllers.py
@@ -173,6 +173,15 @@ def execute_collection_exercise(collection_exercise_id):
             logger.error('Error executing collection exercise', collection_exercise_id=collection_exercise_id)
         raise ApiError(response)
 
+    url = f'{app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises/sample-unit-distribution'
+    response = requests.get(url, auth=app.config['BASIC_AUTH'])
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        logger.error('Failed to trigger sample unit distribution when setting for live',
+                     collection_exercise_id=collection_exercise_id)
+        raise ApiError(response)
+
     logger.info("Successfully began execution of collection exercise", collection_exercise_id=collection_exercise_id)
 
 


### PR DESCRIPTION
# What and why?
Sample distribution is currently on a cron, but there's no real reason for it to be so and we can move it to being called when we hit the set live button

# How to test?

# Trello
https://trello.com/c/HTCVFGNU/556-replace-sample-distribution-cron-job-with-a-synchronous-call-in-collection-exercise
