### PR TITLE
changes to incorporate additional flag added to auth.user table

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.33
+appVersion: 2.4.34

--- a/response_operations_ui/controllers/respondent_controllers.py
+++ b/response_operations_ui/controllers/respondent_controllers.py
@@ -54,7 +54,8 @@ def delete_respondent_account_by_username(username):
         'Authorization': 'Basic %s' % base64.b64encode(bytes(auth)).decode("ascii")
     }
     url = f'{app.config["AUTH_URL"]}/api/account/user'
-    form_data = {"username": username}
+    # force_delete will always be true if deletion is initiated from response operations
+    form_data = {"username": username, "force_delete": True}
     response = requests.delete(url, data=form_data, headers=headers)
     try:
         response.raise_for_status()
@@ -71,7 +72,8 @@ def undo_delete_respondent_account_by_username(username):
         'Authorization': 'Basic %s' % base64.b64encode(bytes(auth)).decode("ascii")
     }
     url = f'{app.config["AUTH_URL"]}/api/account/user/{username}'
-    form_data = {"mark_for_deletion": False}
+    # force_delete will always be false if restore is initiated from response operations
+    form_data = {"mark_for_deletion": False, "force_delete": False}
     response = requests.patch(url, data=form_data, headers=headers)
     try:
         response.raise_for_status()


### PR DESCRIPTION
# What and why?
Changes to make sure if the respondent delete is initiated from response operation UI it is forced.

# How to test?
delete respondent, login via frontstage and test its still deleted once picked up via scheduler

# Trello
https://trello.com/c/8Lt4wbOX/632-bug-respondent-delete