### PR TITLE
Properly localise the sample ingest time on a Collection Exercise

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.34
+appVersion: 2.4.35

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from datetime import datetime
+from response_operations_ui.common.dates import localise_datetime
 from dateutil.parser import parse
 
 import iso8601
@@ -392,7 +393,7 @@ def _validate_sample():
 
 def _format_sample_summary(sample):
     if sample and sample.get('ingestDateTime'):
-        submission_datetime = iso8601.parse_date(sample['ingestDateTime'])
+        submission_datetime = localise_datetime(iso8601.parse_date(sample['ingestDateTime']))
         submission_time = submission_datetime.strftime("%I:%M%p on %B %d, %Y")
         sample["ingestDateTime"] = submission_time
 


### PR DESCRIPTION
# What and why?
The time of sample ingest on the collection exercise screen hasn't been modified for DST

# How to test?
Ingest a sample and confirm that it shows the time in UTC+1

# Trello
https://trello.com/c/8VBq10kX/628-bug-sample-uploaded-timestamp-in-response-ops-is-off-by-an-hour