### PR TITLE
Docker tag latest at the same time as the release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,13 +5,8 @@ name: Build
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - _infra/spinnaker/**
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - _infra/spinnaker/**
-      - _infra/helm/response-operations-ui/Chart.yaml
 
 env:
   IMAGE: response-operations-ui
@@ -153,11 +148,12 @@ jobs:
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
+          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }}
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
       
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.42
+appVersion: 2.4.43


### PR DESCRIPTION
# What and why?
During the release step tag the generated docker image as both the release version and latest.

# How to test?

# Trello
