### PR TITLE
Removing time from ref period start and end dates

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.45
+appVersion: 2.4.46

--- a/response_operations_ui/templates/create-ce-event.html
+++ b/response_operations_ui/templates/create-ce-event.html
@@ -112,7 +112,7 @@
             </div>
           </div>
         </fieldset>
-        {% if tag not in ['ref_period_start', 'ref_period_end'] %}
+        {% if tag not in ['ref_period_start', 'ref_period_end', 'employment'] %}
         <fieldset class="fieldgroup fieldgroup--time" data-qa="widget-time">
           <legend class="fieldgroup__title u-fs-r--b u-mb-xs">Time (Newport)</legend>
           <div class="field-group">

--- a/response_operations_ui/templates/create-ce-event.html
+++ b/response_operations_ui/templates/create-ce-event.html
@@ -112,6 +112,7 @@
             </div>
           </div>
         </fieldset>
+        {% if tag not in ['ref_period_start', 'ref_period_end'] %}
         <fieldset class="fieldgroup fieldgroup--time" data-qa="widget-time">
           <legend class="fieldgroup__title u-fs-r--b u-mb-xs">Time (Newport)</legend>
           <div class="field-group">
@@ -125,6 +126,7 @@
             </div>
           </div>
         </fieldset>
+        {% endif %}
       </div>
         {{
             onsButton({

--- a/response_operations_ui/templates/update-event-date.html
+++ b/response_operations_ui/templates/update-event-date.html
@@ -104,7 +104,7 @@
             </div>
           </div>
         </fieldset>
-        {% if ('ref_period_start' not in event_name) and ('ref_period_end' not in event_name) %}
+        {% if event_tag not in ['ref_period_start', 'ref_period_end'] %}
         <fieldset class="fieldgroup fieldgroup--time u-mt-l" data-qa="widget-time">
           <legend class="fieldgroup__title u-fs-r--b">Time (Newport)</legend>
           <div class="field-group">

--- a/response_operations_ui/templates/update-event-date.html
+++ b/response_operations_ui/templates/update-event-date.html
@@ -104,7 +104,7 @@
             </div>
           </div>
         </fieldset>
-        {% if event_tag not in ['ref_period_start', 'ref_period_end'] %}
+        {% if tag not in ['ref_period_start', 'ref_period_end'] %}
         <fieldset class="fieldgroup fieldgroup--time u-mt-l" data-qa="widget-time">
           <legend class="fieldgroup__title u-fs-r--b">Time (Newport)</legend>
           <div class="field-group">

--- a/response_operations_ui/templates/update-event-date.html
+++ b/response_operations_ui/templates/update-event-date.html
@@ -104,6 +104,7 @@
             </div>
           </div>
         </fieldset>
+        {% if ('ref_period_start' in event_name) or ('ref_period_end' in event_name) %}
         <fieldset class="fieldgroup fieldgroup--time u-mt-l" data-qa="widget-time">
           <legend class="fieldgroup__title u-fs-r--b">Time (Newport)</legend>
           <div class="field-group">
@@ -118,6 +119,7 @@
             </div>
           </div>
         </fieldset>
+        {% endif %}
       </div>
       {% if ('nudge' in event_name) or (show is true) %}
         {%- call onsField({                    

--- a/response_operations_ui/templates/update-event-date.html
+++ b/response_operations_ui/templates/update-event-date.html
@@ -104,7 +104,7 @@
             </div>
           </div>
         </fieldset>
-        {% if ('ref_period_start' in event_name) or ('ref_period_end' in event_name) %}
+        {% if ('ref_period_start' not in event_name) and ('ref_period_end' not in event_name) %}
         <fieldset class="fieldgroup fieldgroup--time u-mt-l" data-qa="widget-time">
           <legend class="fieldgroup__title u-fs-r--b">Time (Newport)</legend>
           <div class="field-group">

--- a/response_operations_ui/templates/update-event-date.html
+++ b/response_operations_ui/templates/update-event-date.html
@@ -104,7 +104,7 @@
             </div>
           </div>
         </fieldset>
-        {% if tag not in ['ref_period_start', 'ref_period_end'] %}
+        {% if tag not in ['ref_period_start', 'ref_period_end', 'employment'] %}
         <fieldset class="fieldgroup fieldgroup--time u-mt-l" data-qa="widget-time">
           <legend class="fieldgroup__title u-fs-r--b">Time (Newport)</legend>
           <div class="field-group">

--- a/response_operations_ui/views/update_event_date.py
+++ b/response_operations_ui/views/update_event_date.py
@@ -123,11 +123,12 @@ def update_event_date_submit(short_name, period, tag):
         logger.error('Failed to find collection exercise by period',
                      short_name=short_name, period=period)
         abort(404)
+
     submitted_dt = datetime(year=int(form.year.data),
                             month=int(form.month.data),
                             day=int(form.day.data),
-                            hour=int(form.hour.data),
-                            minute=int(form.minute.data),
+                            hour=int(form.hour.data) if form.hour.data else 1,
+                            minute=int(form.minute.data) if form.minute.data else 0,
                             tzinfo=tz.gettz('Europe/London'))
 
     """Attempts to create the event, returns None if success or returns an error message upon failure."""

--- a/response_operations_ui/views/update_event_date.py
+++ b/response_operations_ui/views/update_event_date.py
@@ -53,7 +53,7 @@ def update_event_date(short_name, period, tag):
                            event_name=event_name,
                            date_restriction_text=date_restriction_text,
                            show=show,
-                           event_tag=tag)
+                           tag=tag)
 
 
 def is_viewed_reminder_last_in_sequence(events, tag):

--- a/response_operations_ui/views/update_event_date.py
+++ b/response_operations_ui/views/update_event_date.py
@@ -128,8 +128,8 @@ def update_event_date_submit(short_name, period, tag):
     submitted_dt = datetime(year=int(form.year.data),
                             month=int(form.month.data),
                             day=int(form.day.data),
-                            hour=int(form.hour.data) if form.hour.data else 1,
-                            minute=int(form.minute.data) if form.minute.data else 0,
+                            hour=int(form.hour.data),
+                            minute=int(form.minute.data),
                             tzinfo=tz.gettz('Europe/London'))
 
     """Attempts to create the event, returns None if success or returns an error message upon failure."""

--- a/response_operations_ui/views/update_event_date.py
+++ b/response_operations_ui/views/update_event_date.py
@@ -52,7 +52,8 @@ def update_event_date(short_name, period, tag):
                            survey=survey,
                            event_name=event_name,
                            date_restriction_text=date_restriction_text,
-                           show=show)
+                           show=show,
+                           event_tag=tag)
 
 
 def is_viewed_reminder_last_in_sequence(events, tag):


### PR DESCRIPTION
# What and why?
Ref period start, Ref period end and employment date are date fields rather than datetime fields. This PR stops the user being able to set the time element.

# How to test?
Set up a CE and check that the time field is not displayed for the fields ref period start, ref period end and employment.
Once set up check, repeat the same check for updating the fields.


# Trello
https://trello.com/c/IRR0NUpx/666-bug-ritm0581287-this-is-now-sorted-but-need-to-query-how-the-reference-period-start-date-is-picked-up-by-eq-there-is-an-issue-wi