### PR TITLE
Fix table ordering

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.3
+appVersion: 2.5.4

--- a/response_operations_ui/templates/reporting-unit-survey.html
+++ b/response_operations_ui/templates/reporting-unit-survey.html
@@ -157,7 +157,7 @@
                             respondent_last_name=respondent.lastName, business_id=ru.id, trading_as=ru.trading_as, change_flag="DISABLED", tab="reporting_units") + '" id="change-enrolment-status">Disable</a>' %}
                     {% elif respondent.enrolmentStatus == 'PENDING' %}
                         {% set enrolment_status_class = 'status--info' %}
-                        {% set change_status_link = '<a href="' + url_for("reporting_unit_bp.view_resend_verification", ru_ref=ru_ref, party_id=respondent.id) + '">Re-send verification email</a>' %}
+                        {% set change_status_link = '<a href="' + url_for("reporting_unit_bp.view_resend_verification", ru_ref=ru.sampleUnitRef, party_id=respondent.id) + '">Re-send verification email</a>' %}
                     {% else %}
                         {% set enrolment_status_class = 'status--dead' %}
                         {% set change_status_link = '<a href="' + url_for("reporting_unit_bp.confirm_change_enrolment_status", ru_ref=ru.sampleUnitRef, ru_name=ru.name, survey_id=survey.id,

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -60,7 +60,7 @@
       {
         "tds": [
           {
-            "value": '<a href="' + url_for("reporting_unit_bp.view_reporting_unit_survey", ru_ref=ru.sampleUnitRef, survey=survey[0]) + '" id="survey-' + survey[1].shortName + '" >' + survey[1].surveyName + '</a>',
+            "value": '<a href="' + url_for("reporting_unit_bp.view_reporting_unit_survey", ru_ref=ru.sampleUnitRef, survey=survey[1].surveyId) + '" id="survey-' + survey[1].shortName + '" >' + survey[1].surveyName + '</a>',
             "data": "Survey",
             "name": "tbl-surveys-survey"
           },

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -62,8 +62,9 @@ def build_survey_table_data_dict(collection_exercises: list, case_groups: list) 
                 continue
 
         survey = get_survey_by_id(ce['surveyId'])
-        table_data[ce['surveyId']] = {
+        table_data[survey['surveyRef']] = {
             "surveyName": f"{survey['surveyRef']} {survey['shortName']}",
+            "surveyId": ce['surveyId'],
             "shortName": survey['shortName'],
             "period": ce['exerciseRef'],
             "goLive": ce['scheduledStartDateTime'],


### PR DESCRIPTION
# What and why?
Fixes both the survey ordering in the reporting unit page (was ordering on the survey's hidden uuid rather then the displayed  reference number (009, 023, etc) and the broken resend verification url link (the ru_ref wasn't being set correctly)


# How to test?

# Trello
