### PR TITLE
Alphabetise respondents

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.9
+appVersion: 2.5.10

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -118,7 +118,7 @@ def build_respondent_table_data_dict(respondents: list, ru_ref: str):
         table_data[respondent['id']]['surveys'] = sorted(
             table_data[respondent['id']]['surveys'].items(), key=lambda t: t[1]['name'])
 
-    return table_data.values()
+    return sorted(table_data.values(), key=lambda t: t[0])
 
 
 @reporting_unit_bp.route('/<ru_ref>/surveys/<survey>', methods=['GET'])

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -118,7 +118,7 @@ def build_respondent_table_data_dict(respondents: list, ru_ref: str):
         table_data[respondent['id']]['surveys'] = sorted(
             table_data[respondent['id']]['surveys'].items(), key=lambda t: t[1]['name'])
 
-    return sorted(table_data.values(), key=lambda t: t[0])
+    return sorted(table_data.values(), key=lambda t: t['respondent'])
 
 
 @reporting_unit_bp.route('/<ru_ref>/surveys/<survey>', methods=['GET'])


### PR DESCRIPTION
# What and why?
Respondent names aren't currently alphabetised on the new respondent page in the hub and spoke, and the business would prefer they were.

# How to test?
Have a business with >1 respondent and check they're in alphabetical order

# Trello
https://trello.com/c/uNgcm23w/738-rops-overhaul-reporting-unit-hub-and-spoke-design-iteration