### PR TITLE
Change message category amendments

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.12
+appVersion: 2.5.13


### PR DESCRIPTION
# What and why?

This PR changes bits of the functionality around changing a message category.  It now takes you back to the inbox you were on, rather then back to the message you just changed.
It also marks the thread as unread in the new inbox.

# How to test?

# Trello
