### PR TITLE
Fix close category in a technical context

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.15
+appVersion: 2.5.16

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.17
+appVersion: 2.5.18

--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -178,7 +178,7 @@ def add_enrolment_status_for_respondent(respondent, ru_ref, survey_id):
 
 def get_respondent_enrolments(respondent, enrolment_status=None):
     enrolments = []
-    if 'association' in respondent:
+    if 'associations' in respondent:
         for association in respondent['associations']:
             business_party = get_business_by_party_id(association['partyId'])
             for enrolment in association['enrolments']:

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -120,8 +120,7 @@ def view_conversation(thread_id):
                                  ru_ref_filter=ru_ref_filter,
                                  business_id_filter=business_id_filter) + "#latest-message"
             flash(Markup(f'Message sent. <a href={thread_url}>View Message</a>'))
-            return redirect(url_for('messages_bp.view_selected_survey',
-                                    selected_survey=refined_thread[0]['survey'],
+            return redirect(url_for('messages_bp.view_select_survey',
                                     page=page, conversation_tab=conversation_tab,
                                     ru_ref_filter=ru_ref_filter,
                                     business_id_filter=business_id_filter))

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -610,14 +610,12 @@ def _refine(message: dict) -> dict:
     Refine a message into a cleaner version that can be more easily used by the display layer
     :param message: A message from secure-message
     """
-    return {
+    refined_message = {
         'thread_id': message.get('thread_id'),
         'subject': _get_message_subject(message),
         'body': message.get('body'),
         'internal': message.get('from_internal'),
         'username': _get_user_summary_for_message(message),
-        'survey_ref': get_survey_ref_by_id(message.get('survey_id')),
-        'survey': get_survey_short_name_by_id(message.get('survey_id')),
         'survey_id': message.get('survey_id'),
         'ru_ref': _get_ru_ref_from_message(message),
         'to_id': _get_to_id(message),
@@ -630,6 +628,15 @@ def _refine(message: dict) -> dict:
         'message_id': message.get('msg_id'),
         'business_id': message.get('business_id'),
     }
+
+    if message.get('survey_id'):
+        refined_message['survey'] = get_survey_short_name_by_id(message.get('survey_id'))
+        refined_message['survey_ref'] = get_survey_ref_by_id(message.get('survey_id'))
+    else:
+        refined_message['survey'] = ''
+        refined_message['survey_ref'] = ''
+
+    return refined_message
 
 
 def _get_survey_id(selected_survey: str) -> list[str]:
@@ -707,14 +714,14 @@ def _get_ru_ref_from_message(message: dict) -> str:
     try:
         return message['@business_details']['sampleUnitRef']
     except (KeyError, TypeError):
-        logger.error("Failed to retrieve RU ref from message", message_id=message.get('msg_id'), exc_info=True)
+        return ''
 
 
 def _get_business_name_from_message(message: dict) -> str:
     try:
         return message['@business_details']['name']
     except (KeyError, TypeError):
-        logger.exception("Failed to retrieve business name from message", message_id=message.get('msg_id'))
+        return ''
 
 
 def _get_human_readable_date(sent_date: str) -> str:

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -715,6 +715,8 @@ class TestMessage(ViewTestCase):
     @requests_mock.mock()
     @patch('response_operations_ui.controllers.message_controllers._get_jwt')
     def test_conversation_reply(self, mock_request, mock_get_jwt):
+        with self.client.session_transaction() as session:
+            session['messages_survey_selection'] = 'ASHE'
         mock_get_jwt.return_value = "blah"
         # Post message on reply
         mock_request.get(url_get_thread, json=thread_json)


### PR DESCRIPTION
# What and why?

If you have a thread that starts as a survey, gets changed to technical/misc, do some more replies, then try and close it, a 500 error would occur.  This is because the most recent messages don't have survey data in them and the `_refine` function used to always assume you'd have something.

# How to test?

# Trello
