### PR TITLE
Respondent close conversation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint-check:
 	pipenv check ./response_operations_ui ./tests
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
-	pipenv run flake8
+	pipenv run flake8  --exclude ./node_modules
 
 test: lint-check
 	pipenv run python run_tests.py

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.25
+version: 2.5.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.25
+appVersion: 2.5.26

--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -631,7 +631,7 @@ def close_conversation(thread_id):
         subject=refined_thread[0]["subject"],
         business=refined_thread[0]["business_name"],
         ru_ref=refined_thread[0]["ru_ref"],
-        respondent=refined_thread[0]["to"],
+        respondent=refined_thread[0]["to"] if refined_thread[0]["internal"] is True else refined_thread[0]["from"],
         thread_id=thread_id,
         page=page,
         conversation_tab=conversation_tab,

--- a/tests/views/test_message.py
+++ b/tests/views/test_message.py
@@ -1020,6 +1020,7 @@ class TestMessage(ViewTestCase):
         self.assertEqual(200, response.status_code)
         self.assertIn("Conversation closed".encode(), response.data)
         self.assertIn("Ashe Messages".encode(), response.data)
+        self.assertIn("John Example".encode(), response.data)
 
     @requests_mock.mock()
     @patch("response_operations_ui.controllers.message_controllers._get_jwt")
@@ -1139,7 +1140,7 @@ class TestMessage(ViewTestCase):
     @requests_mock.mock()
     @patch("response_operations_ui.controllers.message_controllers._get_jwt")
     def test_closeing_conversation_returns_to_previous_tab_if_page_is_now_too_high(self, mock_request, mock_get_jwt):
-        """if a conversation is closed then it will dissapear from some tabs. That could mean that the page number
+        """if a conversation is closed then it will disappear from some tabs. That could mean that the page number
         specified is now too high, this test validates that if that is the case then the previous page is used"""
 
         limit = 10


### PR DESCRIPTION
# What and why?
If the respondent initiated a secure message, either via the something else help on "my account" or "help with this survey", then when the conversation was being closed the respondent was incorrectly shown as the ONS user. This was because external messages were incorrectly using the "to" field of the refined thread, rather than the "from" field.

# How to test?
Port-forward to dev cluster, and run make test locally on Frontstage. (Or `/deploy` from here to your dev cluster.)
In Frontstage "To-do", click "Get help with this survey" to send a new message. In rOps,  open the new message, and click "Close conversation". In the "Close conversation" dialogue, Respondent should now be correct. On the default data loaded from Acceptance tests, the pre-loaded survey will be "QBS", and the respondent will be "john doe".

# Trello
- https://trello.com/c/QqAgz7Dt