### PR TITLE
Fix issue when EQ CEs don't have an EQ version provided

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.2
+version: 2.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.2
+appVersion: 2.6.3

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -568,7 +568,9 @@ def get_create_collection_exercise_form(survey_ref, short_name):
     logger.info("Retrieving survey data for form", short_name=short_name, survey_ref=survey_ref)
     form = CreateCollectionExerciseDetailsForm(form=request.form)
     survey_details = survey_controllers.get_survey(short_name)
-    survey_eq_version = survey_details["eqVersion"] if survey_details["surveyMode"] != "SEFT" else ""
+    survey_eq_version = "v2"
+    if survey_details["surveyMode"] == "EQ" and "eqVersion" in survey_details:
+        survey_eq_version = survey_details["eqVersion"]
     return render_template(
         "create-collection-exercise.html",
         form=form,


### PR DESCRIPTION
# What and why?
We were getting issues when an EQ version wasn't provided by the survey service when creating a collection exercise. I've chosen to default this to v2 rather than v3 as this feels more likely to be compatible

# How to test?
Find a survey in the survey schema that doesn't have an eqVersion set (or unset it), then create a collection exercise for that survey

# Trello
https://trello.com/c/IMh0i4O7/1188-new-eq-survey-breaks-when-creating-first-collection-exercise
