### PR TITLE
fixing verification email bug

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.8
+version: 2.6.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.8
+appVersion: 2.6.9

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -15,6 +15,7 @@ from response_operations_ui.controllers import (
     iac_controller,
     party_controller,
     reporting_units_controllers,
+    respondent_controllers,
 )
 from response_operations_ui.controllers.collection_exercise_controllers import (
     get_case_group_status_by_collection_exercise,
@@ -341,7 +342,9 @@ def view_resend_verification(ru_ref, party_id):
 @reporting_unit_bp.route("/resend_verification/<ru_ref>/<party_id>", methods=["POST"])
 @login_required
 def resend_verification(ru_ref, party_id):
-    reporting_units_controllers.resend_verification_email(party_id)
+    form = request.form
+    is_new_account_verification = True if form.get("change") == "new-account-email" else False
+    respondent_controllers.resend_verification_email(party_id, is_new_account_verification)
     logger.info("Re-sent verification email.", party_id=party_id)
     flash("Verification email re-sent")
     return redirect(url_for("reporting_unit_bp.view_reporting_unit", ru_ref=ru_ref))


### PR DESCRIPTION
# What and why?
There was an issue where the verification email link for a pending account wasn't working. This was because the function that was meant to be called was moved to a different class. This PR fixes this, as well as adds a check for the pending status via the Flask form so that the `is_new_account_verification` Boolean can be set to true.

# How to test?
Create a new user and, for a survey that is pending enrolment, click the link to resend the verification e-mail, then click the green button. It should work. You may also want to test it out when a respondent has initiated an e-mail change, but before the respondent has verified it.

# Trello
[Card](https://trello.com/c/LY9PGt49)