### PR TITLE
Improve performance of reporting unit survey page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,13 @@ lint:
 	pipenv check ./response_operations_ui ./tests 
 	pipenv run isort .
 	pipenv run black --line-length 120 .
+	pipenv run flake8
 
 lint-check:
 	pipenv check ./response_operations_ui ./tests
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
+	pipenv run flake8 --exclude ./node_modules
 
 test: lint-check
 	pipenv run python run_tests.py

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,11 @@ lint:
 	pipenv check ./response_operations_ui ./tests 
 	pipenv run isort .
 	pipenv run black --line-length 120 .
-	pipenv run flake8
 
 lint-check:
 	pipenv check ./response_operations_ui ./tests
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
-	pipenv run flake8  --exclude ./node_modules
 
 test: lint-check
 	pipenv run python run_tests.py

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.10
+version: 2.6.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.10
+appVersion: 2.6.11

--- a/response_operations_ui/templates/reporting-unit-respondents.html
+++ b/response_operations_ui/templates/reporting-unit-respondents.html
@@ -51,7 +51,7 @@
     {% for respondent in respondents %}
       {% set survey_string = [] %}
       {% for survey in respondent.surveys %}
-        {% do survey_string.append('<a href="' + url_for("reporting_unit_bp.view_reporting_unit_survey", ru_ref=ru.sampleUnitRef, survey=survey[0]) + '">' + survey[1].name + '</a>') %}
+        {% do survey_string.append('<a href="' + url_for("reporting_unit_bp.view_reporting_unit_survey", ru_ref=ru.sampleUnitRef, survey_id=survey[0]) + '">' + survey[1].name + '</a>') %}
         {% if survey[1].status == "DISABLED" %}
           {% do survey_string.append(" (Account disabled)") %}
         {% endif %}

--- a/response_operations_ui/templates/reporting-unit.html
+++ b/response_operations_ui/templates/reporting-unit.html
@@ -60,7 +60,7 @@
       {
         "tds": [
           {
-            "value": '<a href="' + url_for("reporting_unit_bp.view_reporting_unit_survey", ru_ref=ru.sampleUnitRef, survey=survey[1].surveyId) + '" id="survey-' + survey[1].shortName + '" >' + survey[1].surveyName + '</a>',
+            "value": '<a href="' + url_for("reporting_unit_bp.view_reporting_unit_survey", ru_ref=ru.sampleUnitRef, survey_id=survey[1].surveyId) + '" id="survey-' + survey[1].shortName + '" >' + survey[1].surveyName + '</a>',
             "data": "Survey",
             "name": "tbl-surveys-survey"
           },

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -148,8 +148,10 @@ def view_reporting_unit_survey(ru_ref, survey):
     cases = case_controller.get_cases_by_business_party_id(reporting_unit["id"])
     case_groups = [case["caseGroup"] for case in cases]
 
-    # Get all collection exercises for retrieved case groups
-    collection_exercise_ids = {case_group["collectionExerciseId"] for case_group in case_groups}
+    # Get all collection exercises for retrieved case groups and only for the survey we care about.
+    collection_exercise_ids = {
+        case_group["collectionExerciseId"] for case_group in case_groups if case_group["surveyId"] == survey
+    }
     collection_exercises = [get_collection_exercise_by_id(ce_id) for ce_id in collection_exercise_ids]
     live_collection_exercises = [
         ce for ce in collection_exercises if parse_date(ce["scheduledStartDateTime"]) < datetime.now(timezone.utc)
@@ -166,11 +168,7 @@ def view_reporting_unit_survey(ru_ref, survey):
     ]
 
     survey_collection_exercises = sorted(
-        [
-            collection_exercise
-            for collection_exercise in live_collection_exercises
-            if survey == collection_exercise["surveyId"]
-        ],
+        [collection_exercise for collection_exercise in live_collection_exercises],
         key=lambda ce: ce["scheduledStartDateTime"],
         reverse=True,
     )

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -182,9 +182,9 @@ def view_reporting_unit_survey(ru_ref, survey):
     survey_details["display_name"] = f"{survey_details['surveyRef']} {survey_details['shortName']}"
 
     # If there's an active IAC on the newest case, return it to be displayed
-    collection_exercise_ids = [ce["id"] for ce in survey_collection_exercises]
+    live_collection_exercise_ids = [ce["id"] for ce in survey_collection_exercises]
     valid_cases = [
-        case for case in cases if case.get("caseGroup", {}).get("collectionExerciseId") in collection_exercise_ids
+        case for case in cases if case.get("caseGroup", {}).get("collectionExerciseId") in live_collection_exercise_ids
     ]
     case = next(iter(sorted(valid_cases, key=lambda c: c["createdDateTime"], reverse=True)), None)
     unused_iac = ""

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -89,7 +89,7 @@ def build_survey_table_data_dict(collection_exercises: list, case_groups: list) 
 @reporting_unit_bp.route("/<ru_ref>/respondents", methods=["GET"])
 @login_required
 def view_respondents(ru_ref: str):
-    logger.info("Gathering data to view reporting unit", ru_ref=ru_ref)
+    logger.info("Gathering data to view reporting unit respondents", ru_ref=ru_ref)
     # Make some initial calls to retrieve some data we'll need
     reporting_unit = party_controller.get_business_by_ru_ref(ru_ref)
 
@@ -100,6 +100,7 @@ def view_respondents(ru_ref: str):
     respondent_table_data = build_respondent_table_data_dict(respondents, ru_ref)
 
     breadcrumbs = create_reporting_unit_breadcrumbs(ru_ref)
+    logger.info("Successfully gathered data to view reporting unit respondents", ru_ref=ru_ref)
 
     return render_template(
         "reporting-unit-respondents.html", ru=reporting_unit, respondents=respondent_table_data, breadcrumbs=breadcrumbs
@@ -141,7 +142,7 @@ def build_respondent_table_data_dict(respondents: list, ru_ref: str):
 @reporting_unit_bp.route("/<ru_ref>/surveys/<survey>", methods=["GET"])
 @login_required
 def view_reporting_unit_survey(ru_ref, survey):
-    logger.info("Gathering data to view reporting unit", ru_ref=ru_ref)
+    logger.info("Gathering data to view reporting unit survey data", ru_ref=ru_ref, survey=survey)
     # Make some initial calls to retrieve some data we'll need
     reporting_unit = party_controller.get_business_by_ru_ref(ru_ref)
 
@@ -190,6 +191,8 @@ def view_reporting_unit_survey(ru_ref, survey):
     unused_iac = ""
     if case is not None and iac_controller.is_iac_active(case["iac"]):
         unused_iac = case["iac"]
+
+    logger.info("Successfully gathered data to view reporting unit survey data", ru_ref=ru_ref, survey=survey)
 
     return render_template(
         "reporting-unit-survey.html",

--- a/tests/test_data/case/cases_list.json
+++ b/tests/test_data/case/cases_list.json
@@ -14,6 +14,7 @@
       "collectionExerciseId": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
       "id": "612f5c34-7e11-4740-8e24-cb321a86a917",
       "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+      "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
       "sampleUnitRef": "50012345678",
       "sampleUnitType": "B",
       "caseGroupStatus": "NOTSTARTED"
@@ -36,6 +37,7 @@
       "collectionExerciseId": "9af403f8-5fc5-43b1-9fca-afbd9c65da5c",
       "id": "f68c70d6-4a30-48bf-9c35-0202d3c2893f",
       "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+      "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
       "sampleUnitRef": "50012345678",
       "sampleUnitType": "B",
       "caseGroupStatus": "NOTSTARTED"

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -176,36 +176,36 @@ class TestReportingUnits(TestCase):
         self.assertEqual(len(request_history), 5)
         self.assertEqual(response.status_code, 500)
 
-    @requests_mock.mock()
-    def test_get_reporting_unit_respondent_party_fail(self, mock_request):
-        mock_request.get(url_get_business_by_ru_ref, json=business_reporting_unit)
-        mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
-        mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
-        mock_request.get(url_get_business_attributes, json=business_attributes)
-        mock_request.get(url_get_respondent_party_by_party_id, status_code=500)
+    # @requests_mock.mock()
+    # def test_get_reporting_unit_respondent_party_fail(self, mock_request):
+    #     mock_request.get(url_get_business_by_ru_ref, json=business_reporting_unit)
+    #     mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
+    #     mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
+    #     mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
+    #     mock_request.get(url_get_business_attributes, json=business_attributes)
+    #     mock_request.get(url_get_respondent_party_by_party_id, status_code=500)
+    # 
+    #     response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
+    # 
+    #     request_history = mock_request.request_history
+    #     self.assertEqual(len(request_history), 5)
+    #     self.assertEqual(response.status_code, 500)
 
-        response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
-
-        request_history = mock_request.request_history
-        self.assertEqual(len(request_history), 5)
-        self.assertEqual(response.status_code, 500)
-
-    @requests_mock.mock()
-    def test_get_reporting_unit_iac_fail(self, mock_request):
-        mock_request.get(url_get_business_by_ru_ref, json=business_reporting_unit)
-        mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-        mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
-        mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
-        mock_request.get(url_get_business_attributes, json=business_attributes)
-        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
-        mock_request.get(f"{url_get_iac}/{iac_1}", status_code=500)
-
-        response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
-
-        request_history = mock_request.request_history
-        self.assertEqual(len(request_history), 7)
-        self.assertEqual(response.status_code, 500)
+    # @requests_mock.mock()
+    # def test_get_reporting_unit_iac_fail(self, mock_request):
+    #     mock_request.get(url_get_business_by_ru_ref, json=business_reporting_unit)
+    #     mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
+    #     mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
+    #     mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
+    #     mock_request.get(url_get_business_attributes, json=business_attributes)
+    #     mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
+    #     mock_request.get(f"{url_get_iac}/{iac_1}", status_code=500)
+    # 
+    #     response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
+    # 
+    #     request_history = mock_request.request_history
+    #     self.assertEqual(len(request_history), 7)
+    #     self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_iac_404(self, mock_request):

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -185,7 +185,9 @@ class TestReportingUnits(TestCase):
         mock_request.get(url_get_business_attributes, json=business_attributes)
         mock_request.get(url_get_respondent_party_by_party_id, status_code=500)
 
-        response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
+        response = self.client.get(
+            "/reporting-units/50012345678/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", follow_redirects=True
+        )
 
         request_history = mock_request.request_history
         self.assertEqual(len(request_history), 5)
@@ -201,7 +203,9 @@ class TestReportingUnits(TestCase):
         mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f"{url_get_iac}/{iac_1}", status_code=500)
 
-        response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
+        response = self.client.get(
+            "/reporting-units/50012345678/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", follow_redirects=True
+        )
 
         request_history = mock_request.request_history
         self.assertEqual(len(request_history), 7)

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -176,36 +176,36 @@ class TestReportingUnits(TestCase):
         self.assertEqual(len(request_history), 5)
         self.assertEqual(response.status_code, 500)
 
-    # @requests_mock.mock()
-    # def test_get_reporting_unit_respondent_party_fail(self, mock_request):
-    #     mock_request.get(url_get_business_by_ru_ref, json=business_reporting_unit)
-    #     mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-    #     mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
-    #     mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
-    #     mock_request.get(url_get_business_attributes, json=business_attributes)
-    #     mock_request.get(url_get_respondent_party_by_party_id, status_code=500)
-    #
-    #     response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
-    #
-    #     request_history = mock_request.request_history
-    #     self.assertEqual(len(request_history), 5)
-    #     self.assertEqual(response.status_code, 500)
+    @requests_mock.mock()
+    def test_get_reporting_unit_respondent_party_fail(self, mock_request):
+        mock_request.get(url_get_business_by_ru_ref, json=business_reporting_unit)
+        mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
+        mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
+        mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
+        mock_request.get(url_get_business_attributes, json=business_attributes)
+        mock_request.get(url_get_respondent_party_by_party_id, status_code=500)
 
-    # @requests_mock.mock()
-    # def test_get_reporting_unit_iac_fail(self, mock_request):
-    #     mock_request.get(url_get_business_by_ru_ref, json=business_reporting_unit)
-    #     mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
-    #     mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
-    #     mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
-    #     mock_request.get(url_get_business_attributes, json=business_attributes)
-    #     mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
-    #     mock_request.get(f"{url_get_iac}/{iac_1}", status_code=500)
-    #
-    #     response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
-    #
-    #     request_history = mock_request.request_history
-    #     self.assertEqual(len(request_history), 7)
-    #     self.assertEqual(response.status_code, 500)
+        response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
+
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 5)
+        self.assertEqual(response.status_code, 500)
+
+    @requests_mock.mock()
+    def test_get_reporting_unit_iac_fail(self, mock_request):
+        mock_request.get(url_get_business_by_ru_ref, json=business_reporting_unit)
+        mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
+        mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
+        mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
+        mock_request.get(url_get_business_attributes, json=business_attributes)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
+        mock_request.get(f"{url_get_iac}/{iac_1}", status_code=500)
+
+        response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
+
+        request_history = mock_request.request_history
+        self.assertEqual(len(request_history), 7)
+        self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
     def test_get_reporting_unit_iac_404(self, mock_request):

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -184,9 +184,9 @@ class TestReportingUnits(TestCase):
     #     mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
     #     mock_request.get(url_get_business_attributes, json=business_attributes)
     #     mock_request.get(url_get_respondent_party_by_party_id, status_code=500)
-    # 
+    #
     #     response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
-    # 
+    #
     #     request_history = mock_request.request_history
     #     self.assertEqual(len(request_history), 5)
     #     self.assertEqual(response.status_code, 500)
@@ -200,9 +200,9 @@ class TestReportingUnits(TestCase):
     #     mock_request.get(url_get_business_attributes, json=business_attributes)
     #     mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
     #     mock_request.get(f"{url_get_iac}/{iac_1}", status_code=500)
-    # 
+    #
     #     response = self.client.get("/reporting-units/50012345678/surveys/BLOCKS", follow_redirects=True)
-    # 
+    #
     #     request_history = mock_request.request_history
     #     self.assertEqual(len(request_history), 7)
     #     self.assertEqual(response.status_code, 500)


### PR DESCRIPTION
# What and why?

One of the things that impacted the performance of the page was that it resolved that data for EVERY collection exercise for EVERY case the business was ever part of.  This change makes it only resolve every collection exercise for every case that is related to the survey on the page we're on.

Testing it with a reporting unit that has a massive data set, it went from ~18 seconds to ~10 seconds which is a respectable difference (though still awful in the grand scheme of things, but one improvement at a time!)


# How to test?

# Trello
