### PR TITLE
Add my account page

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.11
+version: 2.6.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.11
+appVersion: 2.6.12

--- a/response_operations_ui/controllers/uaa_controller.py
+++ b/response_operations_ui/controllers/uaa_controller.py
@@ -94,6 +94,31 @@ def get_user_by_email(email, access_token=None):
     return response.json()
 
 
+def get_user_by_id(user_id, access_token=None):
+    if access_token is None:
+        access_token = login_admin()
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Authorization": f"Bearer {access_token}",
+    }
+
+    url = f"{app.config['UAA_SERVICE_URL']}/Users/{user_id}"
+    response = requests.get(url, headers=headers)
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        logger.error(
+            "Error retrieving user from UAA",
+            status_code=response.status_code,
+            user_id=user_id
+        )
+        return
+
+    return response.json()
+
+
 def retrieve_user_code(access_token, username):
     headers = {
         "Content-Type": "application/json",

--- a/response_operations_ui/controllers/uaa_controller.py
+++ b/response_operations_ui/controllers/uaa_controller.py
@@ -109,11 +109,7 @@ def get_user_by_id(user_id, access_token=None):
     try:
         response.raise_for_status()
     except HTTPError:
-        logger.error(
-            "Error retrieving user from UAA",
-            status_code=response.status_code,
-            user_id=user_id
-        )
+        logger.error("Error retrieving user from UAA", status_code=response.status_code, user_id=user_id)
         return
 
     return response.json()

--- a/response_operations_ui/controllers/uaa_controller.py
+++ b/response_operations_ui/controllers/uaa_controller.py
@@ -94,10 +94,14 @@ def get_user_by_email(email, access_token=None):
     return response.json()
 
 
-def get_user_by_id(user_id, access_token=None):
-    if access_token is None:
-        access_token = login_admin()
+def get_user_by_id(user_id: str) -> dict:
+    """
+    Gets the user details from uaa, using the id of the user.
 
+    :param user_id: The id of the user in uaa
+    :return: The user details from uaa in dictionary form.
+    """
+    access_token = login_admin()
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",

--- a/response_operations_ui/templates/account/my-account.html
+++ b/response_operations_ui/templates/account/my-account.html
@@ -49,7 +49,7 @@
                           "term": "Password:",
                           "descriptions": [ 
                               {
-                                  "description": "****** (last changed " + user.password_last_changed + " ago)",
+                                  "description": "****** (last changed on " + user.password_last_changed + ")",
                                   "id": "password"
                               },                            
                           ]

--- a/response_operations_ui/templates/account/my-account.html
+++ b/response_operations_ui/templates/account/my-account.html
@@ -49,7 +49,7 @@
                           "term": "Password:",
                           "descriptions": [ 
                               {
-                                  "description": "******",
+                                  "description": "****** (last changed " + user.password_last_changed + " ago)",
                                   "id": "password"
                               },                            
                           ]

--- a/response_operations_ui/templates/account/my-account.html
+++ b/response_operations_ui/templates/account/my-account.html
@@ -1,0 +1,63 @@
+{% extends "layouts/base.html" %}
+{% from "components/metadata/_macro.njk" import onsMetadata %}
+{% set page_title = "Respondents" %}
+
+{% block main %}
+
+{% include 'partials/flashed-messages.html' %}
+
+<section>
+  <h1 id="respondent-name">Account details</h1>
+  <div class="grid grid--gutterless">
+      <div class="grid__col col-10@m">
+          {{ 
+              onsMetadata({
+                  "metadataLabel": "Account details",
+                  "termCol": "3",
+                  "descriptionCol": "9",
+                  "itemsList": [
+                      {
+                          "term": "Username:",
+                          "descriptions": [ 
+                              {
+                                  "description": user.username,
+                                  "id": "username",
+                                  "name": "username"
+                              }
+                          ]
+                      },
+                      {
+                          "term": "Name:",
+                          "descriptions": [ 
+                              {
+                                  "description": user.name,
+                                  "id": "name",
+                                  "name": "name"
+                              },                                  
+                          ]
+                      },
+                      {
+                          "term": "Email address:",
+                          "descriptions": [ 
+                              {
+                                  "description": user.email,
+                                  "id": "email-address"
+                              },                            
+                          ]
+                      },
+                      {
+                          "term": "Password:",
+                          "descriptions": [ 
+                              {
+                                  "description": "******",
+                                  "id": "password"
+                              },                            
+                          ]
+                      }
+                  ]
+              }) 
+          }}
+      </div>
+  </div>
+</section>
+{% endblock %}

--- a/response_operations_ui/templates/account/my-account.html
+++ b/response_operations_ui/templates/account/my-account.html
@@ -1,6 +1,8 @@
 {% extends "layouts/base.html" %}
 {% from "components/metadata/_macro.njk" import onsMetadata %}
-{% set page_title = "Respondents" %}
+{% set page_title = "Account details" %}
+
+</details>" %}
 
 {% block main %}
 
@@ -8,56 +10,17 @@
 
 <section>
   <h1 id="respondent-name">Account details</h1>
-  <div class="grid grid--gutterless">
-      <div class="grid__col col-10@m">
-          {{ 
-              onsMetadata({
-                  "metadataLabel": "Account details",
-                  "termCol": "3",
-                  "descriptionCol": "9",
-                  "itemsList": [
-                      {
-                          "term": "Username:",
-                          "descriptions": [ 
-                              {
-                                  "description": user.username,
-                                  "id": "username",
-                                  "name": "username"
-                              }
-                          ]
-                      },
-                      {
-                          "term": "Name:",
-                          "descriptions": [ 
-                              {
-                                  "description": user.name,
-                                  "id": "name",
-                                  "name": "name"
-                              },                                  
-                          ]
-                      },
-                      {
-                          "term": "Email address:",
-                          "descriptions": [ 
-                              {
-                                  "description": user.email,
-                                  "id": "email-address"
-                              },                            
-                          ]
-                      },
-                      {
-                          "term": "Password:",
-                          "descriptions": [ 
-                              {
-                                  "description": "****** (last changed on " + user.password_last_changed + ")",
-                                  "id": "password"
-                              },                            
-                          ]
-                      }
-                  ]
-              }) 
-          }}
-      </div>
-  </div>
+  <dl class="metadata metadata__list grid grid--gutterless u-cf u-mb-l" title="" aria-label="">
+  <dt class="metadata__term grid__col col-4@m">Username:</dt>
+  <dd class="metadata__value grid__col col-8@m">{{ user.username }}</dd>
+  <dt class="metadata__term grid__col col-4@m">Name:</dt>
+  <dd class="metadata__value grid__col col-8@m">{{ user.name }}</dd>
+  <dt class="metadata__term grid__col col-4@m">Email address:</dt>
+  <dd class="metadata__value grid__col col-8@m">{{ user.email }}</dd>
+  <dt class="metadata__term grid__col col-4@m">Password:</dt>
+  <dd class="metadata__value grid__col col-8@m">●●●●●●●●</dd>
+  <dd class="metadata__value grid__col col-8@m u-ml-no u-mb-xs u-fs-s">(Last changed on {{ user.password_last_changed }})</dd>
+</dl>
+    <hr class="u-mb-l col-8@m">
 </section>
 {% endblock %}

--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -8,23 +8,23 @@
       <script type="text/javascript" src="{{ url_for('static', filename='js/main.min.js') }}"></script>
     {% endassets %}
     {% if config.GOOGLE_TAG_MANAGER %}
-      <!-- Google Tag Manager -->	
+      <!-- Google Tag Manager -->
       <script{% if csp_nonce %} nonce="{{ csp_nonce() }}"{% endif %}>
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':	
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],	
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=	
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl+'&gtm_auth={{ config.GOOGLE_TAG_MANAGER_PROP }}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);	
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl+'&gtm_auth={{ config.GOOGLE_TAG_MANAGER_PROP }}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','{{ config.GOOGLE_TAG_MANAGER }}');
-      </script>	
+      </script>
       <!-- End Google Tag Manager -->
     {% endif %}
 {% endblock %}
-{% block bodyStart %}	
+{% block bodyStart %}
   {% if config.GOOGLE_TAG_MANAGER %}
-    <!-- Google Tag Manager (noscript) -->	
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ config.GOOGLE_TAG_MANAGER }}&gtm_auth={{ config.GOOGLE_TAG_MANAGER_PROP }}&gtm_cookies_win=x"	
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>	
-    <!-- End Google Tag Manager (noscript) -->	
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ config.GOOGLE_TAG_MANAGER }}&gtm_auth={{ config.GOOGLE_TAG_MANAGER_PROP }}&gtm_cookies_win=x"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
    {% endif %}
 {% endblock %}
 {% if current_user.is_authenticated %}
@@ -36,7 +36,7 @@
       },
       {
         "text": "Sign out",
-        "url": "/signout"
+        "url": "/logout"
       }
     ]
   } %}
@@ -67,7 +67,6 @@
 } %}
 
 {% include 'layouts/configs/navigation.html' %}
-{% include 'layouts/configs/signout-button.html' %}
 {% include 'layouts/configs/footer.html' %}
 {% from "components/panel/_macro.njk" import onsPanel %}
 
@@ -79,10 +78,10 @@
   <div class="page__container container container--wide">
     {% block preMain %}
       {% if availability_message %}
-        {{ 
+        {{
             onsPanel({
                 body: availability_message
-            }) 
+            })
         }}
       {% endif %}
       {% if breadcrumbs and hide_breadcrumbs != true %}
@@ -96,5 +95,5 @@
         </main>
       </div>
     </div>
-  </div>  
+  </div>
 {% endblock pageContent -%}

--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -37,6 +37,18 @@
     "logo": "ons-logo-neg-en",
     "mobileLogo": "ons-logo-stacked-neg-en"
   },
+  "serviceLinks": {
+    "itemsList": [
+      {
+        "text": "My account",
+        "url": "/account/my-account"
+      },
+      {
+        "text": "Sign out",
+        "url": "/signout"
+      }
+    ]
+  },
   "toggleButton": {
     "text": "Menu",
     "ariaLabel": "Toggle main navigation"

--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -31,10 +31,6 @@
   {% set serviceLinks = {
     "itemsList": [
       {
-        "text": "My account",
-        "url": "/account/my-account"
-      },
-      {
         "text": "Sign out",
         "url": "/logout"
       }

--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -27,17 +27,8 @@
     <!-- End Google Tag Manager (noscript) -->	
    {% endif %}
 {% endblock %}
-
-{% set pageConfig = { 
-  "title": page_title + " | Survey Data Collection" if page_title else "Survey Data Collection",
-  "wide": true,
-  "header": {
-    "title": "Survey Data Collection",
-    "classes": "header--internal header--thin",
-    "logo": "ons-logo-neg-en",
-    "mobileLogo": "ons-logo-stacked-neg-en"
-  },
-  "serviceLinks": {
+{% if current_user.is_authenticated %}
+  {% set serviceLinks = {
     "itemsList": [
       {
         "text": "My account",
@@ -48,7 +39,27 @@
         "url": "/signout"
       }
     ]
+  } %}
+{% else %}
+  {% set serviceLinks = {
+    "itemsList": [
+      {
+        "text": "Sign in",
+        "url": "/"
+      },
+    ]
+  } %}
+{% endif %}
+{% set pageConfig = {
+  "title": page_title + " | Survey Data Collection" if page_title else "Survey Data Collection",
+  "wide": true,
+  "header": {
+    "title": "Survey Data Collection",
+    "classes": "header--internal header--thin",
+    "logo": "ons-logo-neg-en",
+    "mobileLogo": "ons-logo-stacked-neg-en"
   },
+  "serviceLinks": serviceLinks,
   "toggleButton": {
     "text": "Menu",
     "ariaLabel": "Toggle main navigation"

--- a/response_operations_ui/views/accounts.py
+++ b/response_operations_ui/views/accounts.py
@@ -30,6 +30,7 @@ def get_my_account():
         "username": user_from_uaa["userName"],
         "name": f"{first_name} {last_name}",
         "email": user_from_uaa["emails"][0]["value"],
+        "password_last_changed": user_from_uaa["passwordLastModified"]
     }
     return render_template("account/my-account.html", user=user)
 

--- a/response_operations_ui/views/accounts.py
+++ b/response_operations_ui/views/accounts.py
@@ -1,8 +1,8 @@
 import logging
 
-from flask import Blueprint
+from flask import Blueprint, abort
 from flask import current_app as app
-from flask import abort, flash, jsonify, redirect, render_template, request, session, url_for
+from flask import flash, jsonify, redirect, render_template, request, session, url_for
 from flask_login import login_required
 from itsdangerous import BadData, BadSignature, SignatureExpired, URLSafeSerializer
 from structlog import wrap_logger

--- a/response_operations_ui/views/accounts.py
+++ b/response_operations_ui/views/accounts.py
@@ -2,7 +2,7 @@ import logging
 
 from flask import Blueprint
 from flask import current_app as app
-from flask import flash, redirect, render_template, request, url_for
+from flask import flash, redirect, render_template, request, session, url_for
 from itsdangerous import BadData, BadSignature, SignatureExpired, URLSafeSerializer
 from structlog import wrap_logger
 
@@ -15,6 +15,21 @@ from response_operations_ui.forms import CreateAccountForm, RequestAccountForm
 logger = wrap_logger(logging.getLogger(__name__))
 
 account_bp = Blueprint("account_bp", __name__, static_folder="static", template_folder="templates")
+
+
+@account_bp.route("/my-account", methods=["GET"])
+def get_my_account():
+    logger.info(session)
+    user_id = session["user_id"]
+    user_from_uaa = uaa_controller.get_user_by_id(user_id)
+    first_name = user_from_uaa["name"]["givenName"]
+    last_name = user_from_uaa["name"]["familyName"]
+    user = {
+        "username": user_from_uaa["userName"],
+        "name": f"{first_name} {last_name}",
+        "email": user_from_uaa["emails"][0]["value"]
+    }
+    return render_template("account/my-account.html", user=user)
 
 
 @account_bp.route("/request-new-account", methods=["GET"])

--- a/response_operations_ui/views/accounts.py
+++ b/response_operations_ui/views/accounts.py
@@ -3,6 +3,7 @@ import logging
 from flask import Blueprint
 from flask import current_app as app
 from flask import flash, redirect, render_template, request, session, url_for
+from flask_login import login_required
 from itsdangerous import BadData, BadSignature, SignatureExpired, URLSafeSerializer
 from structlog import wrap_logger
 
@@ -18,6 +19,7 @@ account_bp = Blueprint("account_bp", __name__, static_folder="static", template_
 
 
 @account_bp.route("/my-account", methods=["GET"])
+@login_required
 def get_my_account():
     logger.info(session)
     user_id = session["user_id"]
@@ -27,7 +29,7 @@ def get_my_account():
     user = {
         "username": user_from_uaa["userName"],
         "name": f"{first_name} {last_name}",
-        "email": user_from_uaa["emails"][0]["value"]
+        "email": user_from_uaa["emails"][0]["value"],
     }
     return render_template("account/my-account.html", user=user)
 

--- a/response_operations_ui/views/accounts.py
+++ b/response_operations_ui/views/accounts.py
@@ -2,12 +2,12 @@ import logging
 
 from flask import Blueprint
 from flask import current_app as app
-from flask import flash, redirect, render_template, request, session, url_for
+from flask import flash, jsonify, redirect, render_template, request, session, url_for
 from flask_login import login_required
 from itsdangerous import BadData, BadSignature, SignatureExpired, URLSafeSerializer
 from structlog import wrap_logger
 
-from response_operations_ui.common import token_decoder
+from response_operations_ui.common import dates, token_decoder
 from response_operations_ui.controllers import uaa_controller
 from response_operations_ui.controllers.notify_controller import NotifyController
 from response_operations_ui.exceptions.exceptions import NotifyError
@@ -21,18 +21,21 @@ account_bp = Blueprint("account_bp", __name__, static_folder="static", template_
 @account_bp.route("/my-account", methods=["GET"])
 @login_required
 def get_my_account():
-    logger.info(session)
-    user_id = session["user_id"]
-    user_from_uaa = uaa_controller.get_user_by_id(user_id)
-    first_name = user_from_uaa["name"]["givenName"]
-    last_name = user_from_uaa["name"]["familyName"]
-    user = {
-        "username": user_from_uaa["userName"],
-        "name": f"{first_name} {last_name}",
-        "email": user_from_uaa["emails"][0]["value"],
-        "password_last_changed": user_from_uaa["passwordLastModified"]
-    }
-    return render_template("account/my-account.html", user=user)
+    try:
+        user_id = session["user_id"]
+        user_from_uaa = uaa_controller.get_user_by_id(user_id)
+        first_name = user_from_uaa["name"]["givenName"]
+        last_name = user_from_uaa["name"]["familyName"]
+        formatted_date = dates.format_datetime_to_string(user_from_uaa["passwordLastModified"], date_format="%d %b %Y")
+        user = {
+            "username": user_from_uaa["userName"],
+            "name": f"{first_name} {last_name}",
+            "email": user_from_uaa["emails"][0]["value"],
+            "password_last_changed": formatted_date,
+        }
+        return render_template("account/my-account.html", user=user)
+    except Exception as e:
+        return jsonify(e)
 
 
 @account_bp.route("/request-new-account", methods=["GET"])

--- a/response_operations_ui/views/accounts.py
+++ b/response_operations_ui/views/accounts.py
@@ -2,7 +2,7 @@ import logging
 
 from flask import Blueprint
 from flask import current_app as app
-from flask import flash, jsonify, redirect, render_template, request, session, url_for
+from flask import abort, flash, jsonify, redirect, render_template, request, session, url_for
 from flask_login import login_required
 from itsdangerous import BadData, BadSignature, SignatureExpired, URLSafeSerializer
 from structlog import wrap_logger
@@ -22,6 +22,8 @@ account_bp = Blueprint("account_bp", __name__, static_folder="static", template_
 @login_required
 def get_my_account():
     try:
+        # Remove once we redisplay the 'my account' link
+        abort(404)
         user_id = session["user_id"]
         user_from_uaa = uaa_controller.get_user_by_id(user_id)
         first_name = user_from_uaa["name"]["givenName"]

--- a/tests/test_data/uaa/user_by_id.json
+++ b/tests/test_data/uaa/user_by_id.json
@@ -1,0 +1,102 @@
+{
+  "id": "fe2dc842-b3b3-4647-8317-858dab82ab94",
+  "meta": {
+    "version": 0,
+    "created": "2022-02-01T08:35:48.194Z",
+    "lastModified": "2022-02-01T08:35:48.194Z"
+  },
+  "userName": "uaa_user",
+  "name": {
+    "familyName": "User",
+    "givenName": "ONS"
+  },
+  "emails": [
+    {
+      "value": "ons@ons.fake",
+      "primary": "False"
+    }
+  ],
+  "groups": [
+    {
+      "value": "f90d8e45-af19-4102-aa38-03fb580e6691",
+      "display": "uaa.user",
+      "type": "DIRECT"
+    },
+    {
+      "value": "3f66eff8-041e-4490-b2ac-12f8d9e1a87a",
+      "display": "user_attributes",
+      "type": "DIRECT"
+    },
+    {
+      "value": "85380310-bdfb-4329-862c-e5079eba187a",
+      "display": "approvals.me",
+      "type": "DIRECT"
+    },
+    {
+      "value": "4f9d16e0-17fe-4db2-9b30-f6b4ac52ec71",
+      "display": "cloud_controller.write",
+      "type": "DIRECT"
+    },
+    {
+      "value": "884098ef-a670-46de-b3c5-b9063edf3015",
+      "display": "scim.userids",
+      "type": "DIRECT"
+    },
+    {
+      "value": "07a5cfd5-703b-40e4-b577-ceeaf4aee5da",
+      "display": "scim.me",
+      "type": "DIRECT"
+    },
+    {
+      "value": "ac9a8713-9063-4140-b310-a15c4810a63b",
+      "display": "openid",
+      "type": "DIRECT"
+    },
+    {
+      "value": "302299da-15cf-479c-a2c3-bae8718f60e1",
+      "display": "roles",
+      "type": "DIRECT"
+    },
+    {
+      "value": "83e21063-3357-480c-b641-d5cbcc5fbac8",
+      "display": "profile",
+      "type": "DIRECT"
+    },
+    {
+      "value": "6486a9ee-3c27-44ad-aec5-74a073bf14ae",
+      "display": "password.write",
+      "type": "DIRECT"
+    },
+    {
+      "value": "16bde578-d74e-4463-865a-a94c05342a3b",
+      "display": "cloud_controller_service_permissions.read",
+      "type": "DIRECT"
+    },
+    {
+      "value": "e764f9af-0aad-4b0e-92d7-ebffe68d228d",
+      "display": "cloud_controller.read",
+      "type": "DIRECT"
+    },
+    {
+      "value": "cd5cfb52-fcf8-4ff9-9a84-7f4a174b96c3",
+      "display": "oauth.approvals",
+      "type": "DIRECT"
+    },
+    {
+      "value": "aefeacca-0f84-4111-b57b-271ab916490e",
+      "display": "uaa.offline_token",
+      "type": "DIRECT"
+    }
+  ],
+  "approvals": [],
+  "active": "True",
+  "verified": "True",
+  "origin": "uaa",
+  "zoneId": "uaa",
+  "passwordLastModified": "2022-02-01T08:35:48.000Z",
+  "previousLogonTime": 1643706599842,
+  "lastLogonTime": 1643715883095,
+  "schemas": [
+    "urn:scim:schemas:core:1.0"
+  ]
+}

--- a/tests/views/test_accounts.py
+++ b/tests/views/test_accounts.py
@@ -36,21 +36,22 @@ class TestAccounts(unittest.TestCase):
         self.assertIn(b"admin password", response.data)
         self.assertEqual(response.status_code, 200)
 
-    @requests_mock.mock()
-    def test_my_account_page(self, mock_request):
-        with self.client.session_transaction() as session:
-            session["user_id"] = user_id
-        mock_request.post(url_uaa_token, json={"access_token": self.access_token}, status_code=201)
-        mock_request.get(url_uaa_get_user_by_id, json=uaa_user_by_id_json, status_code=200)
-        response = self.client.get("/account/my-account", follow_redirects=True)
-
-        self.assertIn(b"Email address:", response.data)
-        self.assertIn(b"ons@ons.fake", response.data)
-        self.assertIn(b"Username:", response.data)
-        self.assertIn(b"uaa_user", response.data)
-        self.assertIn(b"Name:", response.data)
-        self.assertIn(b"ONS User", response.data)
-        self.assertEqual(response.status_code, 200)
+    # Uncomment once my-account page is enabled in future PR
+    # @requests_mock.mock()
+    # def test_my_account_page(self, mock_request):
+    #     with self.client.session_transaction() as session:
+    #         session["user_id"] = user_id
+    #     mock_request.post(url_uaa_token, json={"access_token": self.access_token}, status_code=201)
+    #     mock_request.get(url_uaa_get_user_by_id, json=uaa_user_by_id_json, status_code=200)
+    #     response = self.client.get("/account/my-account", follow_redirects=True)
+    #
+    #     self.assertIn(b"Email address:", response.data)
+    #     self.assertIn(b"ons@ons.fake", response.data)
+    #     self.assertIn(b"Username:", response.data)
+    #     self.assertIn(b"uaa_user", response.data)
+    #     self.assertIn(b"Name:", response.data)
+    #     self.assertIn(b"ONS User", response.data)
+    #     self.assertEqual(response.status_code, 200)
 
     @requests_mock.mock()
     def test_request_account(self, mock_request):

--- a/tests/views/test_sign_in.py
+++ b/tests/views/test_sign_in.py
@@ -52,7 +52,8 @@ class TestSignIn(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Choose a survey".encode(), response.data)
         self.assertIn("Sign out".encode(), response.data)
-        self.assertIn("My account".encode(), response.data)
+        # Uncomment once my account link is made visible again
+        # self.assertIn("My account".encode(), response.data)
         self.assertNotIn("Sign in".encode(), response.data)
 
     @requests_mock.mock()

--- a/tests/views/test_sign_in.py
+++ b/tests/views/test_sign_in.py
@@ -34,6 +34,7 @@ class TestSignIn(unittest.TestCase):
         self.assertIn(b"Password", response.data)
         self.assertEqual(response.status_code, 200)
         self.assertNotIn(b"Sign out", response.data)
+        self.assertNotIn(b"My account", response.data)
 
     def test_logout(self):
         response = self.client.get("/logout", follow_redirects=True)
@@ -51,6 +52,8 @@ class TestSignIn(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Choose a survey".encode(), response.data)
         self.assertIn("Sign out".encode(), response.data)
+        self.assertIn("My account".encode(), response.data)
+        self.assertNotIn("Sign in".encode(), response.data)
 
     @requests_mock.mock()
     def test_sign_in_unable_to_decode_token(self, mock_request):


### PR DESCRIPTION
# What and why?

This is the basis for the new 'my account' page in response ops.  This includes a page that displays the data held on an internal user in uaa.  It also moves the sign out link to the top header instead of the middle header.

Note:  This PR doesn't include the link to the page and aborts as soon as you try and use it.  This will be removed and the page 'switched on' in a following story once we have the ability to change any of those details.

# How to test?

# Trello
