### PR TITLE
Change email validation and user update order

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.13
+version: 2.6.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.13
+appVersion: 2.6.14

--- a/response_operations_ui/templates/account/change-account-name.html
+++ b/response_operations_ui/templates/account/change-account-name.html
@@ -6,6 +6,7 @@
 {% set page_title =  "Change Name" %}
 
 {% block main %}
+{% include 'partials/flashed-messages.html' %}
   {% if errors|length > 0 %}
     {% if errors|length == 1 %}
       {% set errorTitle = 'There is 1 error on this page' %}

--- a/response_operations_ui/views/accounts.py
+++ b/response_operations_ui/views/accounts.py
@@ -77,15 +77,15 @@ def change_account_name():
                     template_name="update_account_details",
                     personalisation=personalisation,
                 )
+                errors = uaa_controller.update_user_account(user_from_uaa)
+                if errors is None:
+                    return redirect(url_for("logout_bp.logout", message="Your name has been changed"))
+                else:
+                    logger.error("Error changing user information", msg=errors)
+                    flash("You have received an email however your name has not been changed")
             except NotifyError as e:
-                logger.error(
-                    "Error sending change of name acknowledgement email to Notify Gateway", msg=e.description
-                )
-            errors = uaa_controller.update_user_account(user_from_uaa)
-            if errors is None:
-                return redirect(url_for("logout_bp.logout", message="Your name has been changed"))
-            else:
-                flash("You have received an email however your name has not been changed")
+                logger.error("Error sending change of name acknowledgement email to Notify Gateway", msg=e.description)
+                flash("Something went wrong while updating your name. Please try again", category="error")
         else:
             return redirect(url_for("account_bp.get_my_account"))
     return render_template("account/change-account-name.html", user=user, form=form, errors=form.errors)

--- a/response_operations_ui/views/accounts.py
+++ b/response_operations_ui/views/accounts.py
@@ -64,32 +64,28 @@ def change_account_name():
     user_from_uaa["name"] = {"familyName": form.data["last_name"], "givenName": form.data["first_name"]}
     if request.method == "POST" and form.validate():
         if (form.data["first_name"] != user["first_name"]) or (form.data["last_name"] != user["last_name"]):
+            full_name = f"{form.data['first_name']} {form.data['last_name']}"
+            logger.info("Sending update account details email", user_id=user_id)
+            personalisation = {
+                "first_name": user["first_name"],
+                "value_name": "name",
+                "changed_value": full_name,
+            }
+            try:
+                NotifyController().request_to_notify(
+                    email=user_from_uaa["emails"][0]["value"],
+                    template_name="update_account_details",
+                    personalisation=personalisation,
+                )
+            except NotifyError as e:
+                logger.error(
+                    "Error sending change of name acknowledgement email to Notify Gateway", msg=e.description
+                )
             errors = uaa_controller.update_user_account(user_from_uaa)
             if errors is None:
-                full_name = f"{form.data['first_name']} {form.data['last_name']}"
-                logger.info("Sending update account details email", user_id=user_id)
-                personalisation = {
-                    "first_name": user["first_name"],
-                    "value_name": "name",
-                    "changed_value": full_name,
-                }
-                try:
-                    NotifyController().request_to_notify(
-                        email=user_from_uaa["emails"][0]["value"],
-                        template_name="update_account_details",
-                        personalisation=personalisation,
-                    )
-                    return redirect(url_for("logout_bp.logout", message="Your name has been changed"))
-                except NotifyError as e:
-                    logger.error(
-                        "Error sending change of name acknowledgement email to Notify Gateway", msg=e.description
-                    )
-                    return redirect(
-                        url_for(
-                            "logout_bp.logout",
-                            message="Your name has been changed however you may not receive an email",
-                        )
-                    )
+                return redirect(url_for("logout_bp.logout", message="Your name has been changed"))
+            else:
+                flash("You have received an email however your name has not been changed")
         else:
             return redirect(url_for("account_bp.get_my_account"))
     return render_template("account/change-account-name.html", user=user, form=form, errors=form.errors)

--- a/response_operations_ui/views/accounts.py
+++ b/response_operations_ui/views/accounts.py
@@ -82,7 +82,10 @@ def change_account_name():
                     return redirect(url_for("logout_bp.logout", message="Your name has been changed"))
                 else:
                     logger.error("Error changing user information", msg=errors)
-                    flash("You have received an email however your name has not been changed")
+                    flash(
+                        "Something went wrong. Please ignore the email you have received and try again",
+                        category="error",
+                    )
             except NotifyError as e:
                 logger.error("Error sending change of name acknowledgement email to Notify Gateway", msg=e.description)
                 flash("Something went wrong while updating your name. Please try again", category="error")


### PR DESCRIPTION
# What and why?
Making sure that an email is sent before the user is updated to keep in line with IA requirements. 
# How to test?

# Trello
https://trello.com/c/fj13gJEo/1361-rops-ui-self-service-change-name-email-sending-failure