### PR TITLE
Properly delete sample when removed from a collection exercise

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.40
+version: 2.6.41
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.40
+appVersion: 2.6.41

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.39
+version: 2.6.40
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.39
+appVersion: 2.6.40

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.41
+version: 2.6.42
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.41
+appVersion: 2.6.42

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -6,12 +6,12 @@ import redis
 from flask import Flask, flash, redirect, session, url_for
 from flask_assets import Environment
 from flask_login import LoginManager
+from flask_session import Session
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFError, CSRFProtect
 from structlog import wrap_logger
 
 from config import Config
-from flask_session import Session
 from response_operations_ui.common.jinja_filters import filter_blueprint
 from response_operations_ui.controllers.uaa_controller import user_has_permission
 from response_operations_ui.logger_config import logger_initial_config

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -6,12 +6,12 @@ import redis
 from flask import Flask, flash, redirect, session, url_for
 from flask_assets import Environment
 from flask_login import LoginManager
-from flask_session import Session
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFError, CSRFProtect
 from structlog import wrap_logger
 
 from config import Config
+from flask_session import Session
 from response_operations_ui.common.jinja_filters import filter_blueprint
 from response_operations_ui.controllers.uaa_controller import user_has_permission
 from response_operations_ui.logger_config import logger_initial_config

--- a/response_operations_ui/controllers/collection_exercise_controllers.py
+++ b/response_operations_ui/controllers/collection_exercise_controllers.py
@@ -389,14 +389,13 @@ def unlink_sample_summary(collection_exercise_id, sample_summary_id):
             collection_exercise_id=collection_exercise_id,
             sample_summary_id=sample_summary_id,
         )
-        return False
+        raise ApiError(response)
 
     logger.info(
         "Successfully unlinked sample summary from a collection exercise",
         collection_exercise_id=collection_exercise_id,
         sample_summary_id=sample_summary_id,
     )
-    return True
 
 
 def get_collection_exercise_from_list(exercises, period):

--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -312,6 +312,35 @@ def update_contact_details(respondent_id, form, ru_ref="NOT DEFINED"):
     return contact_details_changed
 
 
+def delete_attributes_by_sample_summary_id(sample_summary_id: str) -> None:
+    """
+    Deletes all the business attributes for a given sample_summary_id.  Each attribute represents a sample that a
+    business was part of, and if the sample is deleted (e.g., a mistake was made in the sample file) then calling
+    this will remove the now not needed data in party that is generated as part of the sample load process.
+
+    :param sample_summary_id: A sample summary id
+    :return: None
+    :raises ApiError: Occurs in the case that party returns a 4XX or 5XX value.  The most likely case being that
+    the sample_summary_id isn't a valid uuid.
+    """
+    logger.info("Deleting business attributes", sample_summary_id=sample_summary_id)
+
+    url = f'{app.config["PARTY_URL"]}/party-api/v1/businesses/attributes/sample-summary/{sample_summary_id}'
+    response = requests.delete(url, auth=app.config["BASIC_AUTH"])
+
+    try:
+        response.raise_for_status()
+    except (HTTPError, RequestException):
+        logger.error(
+            "Failed to delete business attributes by sample summary id",
+            sample_summary_id=sample_summary_id,
+            status_code=response.status_code,
+        )
+        raise ApiError(response)
+    logger.info("Successfully deleted business attributes", sample_summary_id)
+    return
+
+
 def _compare_contact_details(new_contact_details, old_contact_details):
     # Currently the 'get contact details' and 'update respondent details' keys do not match and must be mapped
     contact_details_map = {

--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -330,14 +330,14 @@ def delete_attributes_by_sample_summary_id(sample_summary_id: str) -> None:
 
     try:
         response.raise_for_status()
-    except (HTTPError, RequestException):
+    except HTTPError:
         logger.error(
             "Failed to delete business attributes by sample summary id",
             sample_summary_id=sample_summary_id,
             status_code=response.status_code,
         )
         raise ApiError(response)
-    logger.info("Successfully deleted business attributes", sample_summary_id)
+    logger.info("Successfully deleted business attributes", sample_summary_id=sample_summary_id)
     return
 
 

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -161,6 +161,7 @@ def _delete_sample_data_if_required():
     """
     If a sample data deletion failed as part of the 'remove sample' functionality, then we can try again without having
     to get the user involved.  If the deletion succeeds on this, or a later attempt, then we remove it from the session.
+    If it fails then we leave it in the session, so we can try again.
     """
     sample_summary_id = session.get("retry_sample_delete_id")
     if sample_summary_id:
@@ -818,8 +819,10 @@ def remove_loaded_sample(short_name, period):
         sample_summary_id=sample_summary_id,
     )
 
-    # If the sample summary succeeds but the unlink fails then you can't get back into the exercise.  For now
-    # we'll do the sample delete after the unlink as it's the safest option.
+    # The order for the deletion has to be party, collection exercise then sample.  If either of the first two fail,
+    # then the link is still there, and the 'remove sample' button will be there for the user to click again.  If the
+    # sample data was deleted before collection exercise, then the page would error as it tries to find sample data that
+    # no longer exists.
     try:
         party_controller.delete_attributes_by_sample_summary_id(sample_summary_id)
         collection_exercise_controllers.unlink_sample_summary(collection_exercise_id, sample_summary_id)

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -801,11 +801,13 @@ def remove_loaded_sample(short_name, period):
         sample_summary_id=sample_summary_id,
     )
     # TODO what happens if one of these 3 steps fail?  How do we recover and/or try again?
+    # If the sample summary succeeds but the unlink fails then you can't get back into the exercise.  For now
+    # we'll do the sample delete after the unlink as it's the safest option.
     party_controller.delete_attributes_by_sample_summary_id(sample_summary_id)
-    sample_controllers.delete_sample(sample_summary_id)
     is_successfully_unlinked = collection_exercise_controllers.unlink_sample_summary(
         collection_exercise_id, sample_summary_id
     )
+    sample_controllers.delete_sample(sample_summary_id)
 
     if is_successfully_unlinked:
         return redirect(

--- a/tests/controllers/test_party_controller.py
+++ b/tests/controllers/test_party_controller.py
@@ -1,345 +1,107 @@
-import logging
-from urllib.parse import urlencode
+import json
+import os
+import unittest
+from collections import namedtuple
 
-import requests
-from flask import current_app as app
-from requests.exceptions import HTTPError, RequestException
-from structlog import wrap_logger
+import mock
+import responses
 
-from response_operations_ui.controllers.survey_controllers import get_survey_by_id
+from config import TestingConfig
+from response_operations_ui import create_app
+from response_operations_ui.controllers import party_controller
 from response_operations_ui.exceptions.exceptions import (
     ApiError,
     SearchRespondentsException,
-    UpdateContactDetailsException,
 )
-from response_operations_ui.forms import EditContactDetailsForm
 
-logger = wrap_logger(logging.getLogger(__name__))
+fake_response = namedtuple("Response", "status_code json")
 
+ru_ref = "49900000001"
+business_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
+business_id_2 = "cf3e316a-6644-43b0-a31f-c92b35132b94"
+survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+survey_id_2 = "06cad526-1b1b-41b8-b56b-032e637f0fbd"
+sample_summary_id = "1c82f11a-b46a-4944-8ea3-be1ee79571fc"
+delete_attributes_by_sample_summary_id_url = (
+    f"{TestingConfig.PARTY_URL}/party-api/v1/businesses/attributes/sample-summary/{sample_summary_id}"
+)
+get_business_by_ru_ref_url = f"{TestingConfig.PARTY_URL}/party-api/v1/businesses/ref/{ru_ref}"
+get_business_by_id_url = f"{TestingConfig.PARTY_URL}/party-api/v1/businesses/id/"
+get_survey_by_id_url = f"{TestingConfig.SURVEY_URL}/surveys/"
 
-def get_business_by_ru_ref(ru_ref: str):
-    """
-    Get business by ru_ref
-
-    :param ru_ref: The ru_ref of the business
-    :type ru_ref: str
-    :return: A dict of data about the business
-    :rtype: dict
-    :raises ApiError: Raised if party returns a 4XX or 5XX status code.
-    """
-    logger.info("Retrieving reporting unit", ru_ref=ru_ref)
-    url = f'{app.config["PARTY_URL"]}/party-api/v1/businesses/ref/{ru_ref}'
-    response = requests.get(url, auth=app.config["BASIC_AUTH"])
-
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        log_level = logger.warning if response.status_code in (400, 404) else logger.exception
-        log_level("Failed to retrieve reporting unit", ru_ref=ru_ref)
-        raise ApiError(response)
-
-    logger.info("Successfully retrieved reporting unit", ru_ref=ru_ref)
-    return response.json()
-
-
-def get_business_attributes_by_party_id(business_party_id: str, collection_exercise_ids=None):
-    """
-    Gets the attributes for the business for each collection exercise.  The attributes are the data held
-    on the business at the point it was enrolled onto each collection exercise.  If no exercises are specified
-    then all attributes for the business will be returned
-
-    :param business_party_id: A business id
-    :param collection_exercise_ids: An (optional) list of collection exercise ids
-    :type collection_exercise_ids: list
-    :return: A dict of attributes with each collection exercise id as the keys.
-    :rtype: dict
-    """
-    bound_logger = logger.bind(business_id=business_party_id, collection_exercise_ids=collection_exercise_ids)
-    bound_logger.info("Retrieving business attributes")
-    url = f'{app.config["PARTY_URL"]}/party-api/v1/businesses/id/{business_party_id}/attributes'
-    if collection_exercise_ids:
-        params = urlencode([("collection_exercise_id", uuid) for uuid in collection_exercise_ids])
-        response = requests.get(url, params=params, auth=app.config["BASIC_AUTH"])
-    else:
-        response = requests.get(url, auth=app.config["BASIC_AUTH"])
-
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        bound_logger.error("Error retrieving business attributes")
-        raise ApiError(response)
-
-    bound_logger.info("Successfully retrieved business attributes")
-    return response.json()
+project_root = os.path.dirname(os.path.dirname(__file__))
+with open(f"{project_root}/test_data/party/get_business_by_ru_ref.json") as fp:
+    business_by_ru_ref_json = json.load(fp)
+with open(f"{project_root}/test_data/party/business_party.json") as fp:
+    business_by_id_json = json.load(fp)
+with open(f"{project_root}/test_data/party/business_party_cf3e316a.json") as fp:
+    business_by_id_cf3e316a_json = json.load(fp)
+with open(f"{project_root}/test_data/party/respondent_party_multiple_associations.json") as fp:
+    respondent_json = json.load(fp)
+with open(f"{project_root}/test_data/party/get_respondent_enrolments_output.json") as fp:
+    expected_enrolments_output = json.load(fp)
+with open(f"{project_root}/test_data/survey/survey.json") as fp:
+    survey_json = json.load(fp)
+with open(f"{project_root}/test_data/survey/survey_06cad526.json") as fp:
+    survey_06cad526_json = json.load(fp)
 
 
-def get_business_by_party_id(business_party_id: str, collection_exercise_id=None):
-    logger.info(
-        "Retrieving business party", business_party_id=business_party_id, collection_exercise_id=collection_exercise_id
-    )
-    url = f'{app.config["PARTY_URL"]}/party-api/v1/businesses/id/{business_party_id}'
-    params = {"collection_exercise_id": collection_exercise_id, "verbose": True}
-    response = requests.get(url, params=params, auth=app.config["BASIC_AUTH"])
+class TestPartyController(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app("TestingConfig")
+        self.client = self.app.test_client()
 
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        log_level = logger.warning if response.status_code in (400, 404) else logger.exception
-        log_level(
-            "Error retrieving business party",
-            business_party_id=business_party_id,
-            collection_exercise_id=collection_exercise_id,
-        )
-        raise ApiError(response)
+    def tearDown(self):
+        pass
 
-    logger.info(
-        "Successfully retrieved business party",
-        business_party_id=business_party_id,
-        collection_exercise_id=collection_exercise_id,
-    )
-    return response.json()
+    def test_get_respondent_enrolments(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, get_business_by_id_url + business_id, json=business_by_id_json)
+            rsps.add(rsps.GET, get_business_by_id_url + business_id_2, json=business_by_id_cf3e316a_json)
+            rsps.add(rsps.GET, get_survey_by_id_url + survey_id, json=survey_json)
+            rsps.add(rsps.GET, get_survey_by_id_url + survey_id_2, json=survey_06cad526_json)
 
+            with self.app.app_context():
+                output = party_controller.get_respondent_enrolments(respondent_json)
+            self.assertEqual(output, expected_enrolments_output)
 
-def get_respondent_by_party_id(respondent_party_id):
-    logger.info("Retrieving respondent party", respondent_party_id=respondent_party_id)
-    url = f'{app.config["PARTY_URL"]}/party-api/v1/respondents/id/{respondent_party_id}'
-    response = requests.get(url, auth=app.config["BASIC_AUTH"])
+    @mock.patch("requests.get")
+    def test_import_search_respondents_raises_error_when_request_to_party_fails(self, requests_mock):
+        with self.app.app_context():
+            # Mock setups
+            requests_mock.return_value = fake_response(status_code=400, json=lambda: [])
+            limit = self.app.config["PARTY_RESPONDENTS_PER_PAGE"]
+            # Test and assert
+            with self.assertRaises(SearchRespondentsException):
+                party_controller.search_respondents("firstname", "lastname", "name@email.com", page=1, limit=limit)
 
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        log_level = logger.warning if response.status_code in (400, 404) else logger.exception
-        log_level("Error retrieving respondent party", respondent_party_id=respondent_party_id)
-        if response.status_code == 404:
-            return {}
-        raise ApiError(response)
+    def test_get_respondent_by_party_ids_with_empty_list(self):
+        input_data = []
+        expected_output = []
+        output = party_controller.get_respondent_by_party_ids(input_data)
+        self.assertEqual(output, expected_output)
 
-    logger.info("Successfully retrieved respondent party", respondent_party_id=respondent_party_id)
-    return response.json()
+    def test_get_business_by_ru_ref_success(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, get_business_by_ru_ref_url, json=business_by_ru_ref_json, status=200)
 
+            with self.app.app_context():
+                expected = business_by_ru_ref_json
+                actual = party_controller.get_business_by_ru_ref(ru_ref)
+                self.assertEqual(expected, actual)
 
-def get_pending_surveys_by_party_id(respondent_party_id):
-    """
-    Gets pending surveys list against the originator respondent party uuid
-    :param respondent_party_id: respondent party id
-    :type respondent_party_id: uuid
-    :return: list of pending surveys
-    :rtype: list
-    """
-    logger.info("Retrieving pending surveys", respondent_party_id=respondent_party_id)
-    url = f'{app.config["PARTY_URL"]}/party-api/v1/pending-surveys/originator/{respondent_party_id}'
-    response = requests.get(url, auth=app.config["BASIC_AUTH"])
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        log_level = logger.warning if response.status_code in (400, 404) else logger.exception
-        log_level("Error retrieving pending surveys", respondent_party_id=respondent_party_id)
-        if response.status_code == 404:
-            return {}
-        raise ApiError(response)
+    def test_get_business_by_ru_ref_not_found(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, get_business_by_ru_ref_url, status=404)
 
-    logger.info("Successfully retrieved pending surveys", respondent_party_id=respondent_party_id)
-    return response.json()
+            with self.app.app_context():
+                with self.assertRaises(ApiError):
+                    party_controller.get_business_by_ru_ref(ru_ref)
 
+    def test_delete_attributes_by_sample_summary_id_server_error(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.DELETE, delete_attributes_by_sample_summary_id_url, status=500)
 
-def delete_pending_surveys_by_batch_number(batch_number):
-    """
-    Delete pending surveys record against batch number
-    :param batch_number: batch number
-    :type batch_number: uuid
-    """
-    logger.info("Deleting pending surveys", batch_number=batch_number)
-    url = f'{app.config["PARTY_URL"]}/party-api/v1/pending-surveys/{batch_number}'
-    response = requests.delete(url, auth=app.config["BASIC_AUTH"])
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        log_level = logger.warning if response.status_code in (400, 404) else logger.exception
-        log_level("Error deleting pending survey", batch_number=batch_number)
-        raise ApiError(response)
-
-    logger.info("Successfully deleted pending surveys", batch_number=batch_number)
-
-
-def resend_pending_surveys_email(batch_number):
-    """
-    Resends pending surveys email against batch number
-    :param batch_number: batch number
-    :type batch_number: uuid
-    """
-    logger.info("Resending pending survey email", batch_number=batch_number)
-    url = f'{app.config["PARTY_URL"]}/party-api/v1/pending-surveys/resend-email'
-    response = requests.post(url, json={"batch_number": batch_number}, auth=app.config["BASIC_AUTH"])
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        log_level = logger.warning if response.status_code in (400, 404) else logger.exception
-        log_level("Error sending pending survey email", batch_number=batch_number)
-        return {}
-
-    logger.info("Successfully resend pending survey email", batch_number=batch_number)
-    return response.json()
-
-
-def get_respondent_by_party_ids(uuids):
-    """
-    Gets data for multiple respondents from party.  If the list is empty, returns an empty
-    list without going to party.
-
-    This call will return as many parties as it can find.  If some are missing, no error will
-    be thrown.
-
-    :param uuids: A list of uuid strings of respondent party ids
-    :type uuids: list
-    :return: A list of dicts containing party data
-    """
-    bound_logger = logger.bind(respondent_party_ids=uuids)
-    bound_logger.info("Retrieving respondent data for multiple respondents")
-    if not uuids:
-        bound_logger.info("No party uuids provided.  Returning empty list")
-        return []
-
-    params = urlencode([("id", uuid) for uuid in uuids])
-    url = f'{app.config["PARTY_URL"]}/party-api/v1/respondents'
-    response = requests.get(url, auth=app.config["BASIC_AUTH"], params=params)
-
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        bound_logger.error("Error retrieving respondent data for multiple respondents")
-        raise ApiError(response)
-
-    bound_logger.info("Successfully retrieved respondent data for multiple respondents")
-    return response.json()
-
-
-def survey_ids_for_respondent(respondent, ru_ref):
-    enrolments = [
-        association.get("enrolments")
-        for association in respondent.get("associations")
-        if association["sampleUnitRef"] == ru_ref
-    ][0]
-    return [enrolment.get("surveyId") for enrolment in enrolments]
-
-
-def add_enrolment_status_for_respondent(respondent, ru_ref, survey_id):
-    logger.info("Adding enrolment status to respondent", ru_ref=ru_ref)
-    association = next(
-        (association for association in respondent.get("associations") if association["sampleUnitRef"] == ru_ref), None
-    )
-    enrolment_status = next(
-        (
-            enrolment["enrolmentStatus"]
-            for enrolment in association.get("enrolments")
-            if enrolment["surveyId"] == survey_id
-        ),
-        None,
-    )
-    return {**respondent, "enrolmentStatus": enrolment_status}
-
-
-def get_respondent_enrolments(respondent: dict, enrolment_status=None) -> list:
-    enrolments = []
-    if "associations" in respondent:
-        for association in respondent["associations"]:
-            business_party = get_business_by_party_id(association["partyId"])
-            for enrolment in association["enrolments"]:
-                enrolment_data = {
-                    "business": business_party,
-                    "survey": get_survey_by_id(enrolment["surveyId"]),
-                    "status": enrolment["enrolmentStatus"],
-                }
-                if enrolment_status:
-                    if enrolment_data["status"] == enrolment_status:
-                        enrolments.append(enrolment_data)
-                else:
-                    enrolments.append(enrolment_data)
-
-    return enrolments
-
-
-def search_respondent_by_email(email):
-    logger.info("Search respondent via email")
-
-    request_json = {"email": email}
-    url = f'{app.config["PARTY_URL"]}/party-api/v1/respondents/email'
-    response = requests.get(url, json=request_json, auth=app.config["BASIC_AUTH"])
-
-    if response.status_code == 404:
-        return
-
-    try:
-        response.raise_for_status()
-    except (HTTPError, RequestException):
-        log_level = logger.warning if response.status_code == 400 else logger.exception
-        log_level("Respondent retrieval failed")
-        raise ApiError(response)
-    logger.info("Respondent retrieved successfully")
-
-    return response.json()
-
-
-def search_respondents(first_name, last_name, email_address, page, limit):
-    params = {
-        "firstName": first_name,
-        "lastName": last_name,
-        "emailAddress": email_address,
-        "page": page,
-        "limit": limit,
-    }
-    response = requests.get(
-        f'{app.config["PARTY_URL"]}/party-api/v1/respondents', auth=app.config["BASIC_AUTH"], params=params
-    )
-
-    if response.status_code != 200:
-        raise SearchRespondentsException(
-            response, first_name=first_name, last_name=last_name, email_address=email_address, page=page
-        )
-
-    return response.json()
-
-
-def update_contact_details(respondent_id, form, ru_ref="NOT DEFINED"):
-    logger.info("Updating respondent details", respondent_id=respondent_id, ru_ref=ru_ref)
-
-    new_contact_details = {
-        "firstName": form.get("first_name"),
-        "lastName": form.get("last_name"),
-        "email_address": form.get("hidden_email"),
-        "new_email_address": form.get("email").strip(),
-        "telephone": form.get("telephone"),
-    }
-
-    old_contact_details = get_respondent_by_party_id(respondent_id)
-    contact_details_changed = _compare_contact_details(new_contact_details, old_contact_details)
-
-    if len(contact_details_changed) > 0:
-        url = f'{app.config["PARTY_URL"]}/party-api/v1/respondents/id/{respondent_id}'
-        response = requests.put(url, json=new_contact_details, auth=app.config["BASIC_AUTH"])
-
-        if response.status_code != 200:
-            raise UpdateContactDetailsException(
-                ru_ref, EditContactDetailsForm(form), old_contact_details, response.status_code
-            )
-
-        logger.info(
-            "Respondent details updated", respondent_id=respondent_id, status_code=response.status_code, ru_ref=ru_ref
-        )
-
-    return contact_details_changed
-
-
-def _compare_contact_details(new_contact_details, old_contact_details):
-    # Currently the 'get contact details' and 'update respondent details' keys do not match and must be mapped
-    contact_details_map = {
-        "firstName": "firstName",
-        "lastName": "lastName",
-        "telephone": "telephone",
-        "emailAddress": "new_email_address",
-    }
-
-    return {
-        old_key
-        for old_key, new_key in contact_details_map.items()
-        if old_contact_details[old_key] != new_contact_details[new_key]
-    }
+            with self.app.app_context():
+                with self.assertRaises(ApiError):
+                    party_controller.delete_attributes_by_sample_summary_id(sample_summary_id)

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -1586,8 +1586,6 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.delete(url_party_delete_attributes, status_code=204)
         mock_request.delete(url_ce_remove_sample, status_code=500)
 
-        # TODO Write tests for failed calls to party and sample respectively
-
         response = self.client.post(f"/surveys/{short_name}/{period}/confirm-remove-sample", follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
# What and why?

Currently, when a sample is deleted from a collection exercise, it's only unlinked in collection exercise and the data that gets created in party and sample is simply orphaned.  This PR will call the 2 newly created DELETE endpoints to clean up the data as well doing this unlinking

# How to test?

- Create a collection exercise in response ops
- Load a sample for it.  Verify records are created for it in sample (sample_units and sample_summary), collection exercise (sample_links) and party (business_attributes) database tables.
- Delete the sample. 
- Verify that those records have been deleted in all 3 places

# Trello
