### PR TITLE
Better error handling for sample file problems

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.51
+version: 2.6.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.51
+appVersion: 2.6.52

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -281,17 +281,20 @@ def _upload_sample(short_name, period):
 
         if not exercise:
             return make_response(jsonify({"message": "Collection exercise not found"}), 404)
-        sample_summary = sample_controllers.upload_sample(short_name, period, request.files["sampleFile"])
-
-        logger.info(
-            "Linking sample summary with collection exercise",
-            collection_exercise_id=exercise["id"],
-            sample_id=sample_summary["id"],
-        )
-
-        collection_exercise_controllers.link_sample_summary_to_collection_exercise(
-            collection_exercise_id=exercise["id"], sample_summary_id=sample_summary["id"]
-        )
+        try:
+            sample_summary = sample_controllers.upload_sample(short_name, period, request.files["sampleFile"])
+            
+            logger.info(
+                "Linking sample summary with collection exercise",
+                collection_exercise_id=exercise["id"],
+                sample_id=sample_summary["id"],
+            )
+            collection_exercise_controllers.link_sample_summary_to_collection_exercise(
+                collection_exercise_id=exercise["id"], sample_summary_id=sample_summary["id"]
+            )
+        except (ApiError) as e:
+            if e.status_code == 400:
+                error = e.message
 
     return redirect(
         url_for(

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -283,7 +283,7 @@ def _upload_sample(short_name, period):
             return make_response(jsonify({"message": "Collection exercise not found"}), 404)
         try:
             sample_summary = sample_controllers.upload_sample(short_name, period, request.files["sampleFile"])
-            
+
             logger.info(
                 "Linking sample summary with collection exercise",
                 collection_exercise_id=exercise["id"],

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -295,6 +295,9 @@ def _upload_sample(short_name, period):
         except (ApiError) as e:
             if e.status_code == 400:
                 error = e.message
+            else:
+                # For a non-400, just let the error bubble up
+                raise e
 
     return redirect(
         url_for(


### PR DESCRIPTION
# What and why?
When there's an issue with the sample file not caught by the validator, the Sample File Uploader currently throws a 400 or 500. This handles 400s in a better way, bubbling up the message sent to us by the uploader (which should be fine to show to an internal user, e.g. `"Too few columns in CSV file"`)

# How to test?

# Trello
https://trello.com/c/HjIMIYwj/1757-bug-500-raised-when-uploading-a-sample-with-less-than-the-required-columns-track-time