### PR TITLE
Add view checkboxes for visual clarity

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.54
+version: 2.6.55
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.54
+appVersion: 2.6.55

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.53
+version: 2.6.54
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.53
+appVersion: 2.6.54

--- a/response_operations_ui/templates/admin/manage-account.html
+++ b/response_operations_ui/templates/admin/manage-account.html
@@ -26,6 +26,9 @@
                             <span>Survey Data Collection area</span>
                         </th>
                         <th scope="col" class="ons-table__header">
+                            <span>View</span>
+                        </th>
+                        <th scope="col" class="ons-table__header">
                             <span>Edit</span>
                         </th>
                         <th scope="col" class="ons-table__header">
@@ -37,6 +40,21 @@
                     <tr class="ons-table__row">
                         <td class="ons-table__cell">
                             Surveys
+                        </td>
+                        <td class="ons-table__cell">
+                            {{
+                              onsCheckbox({
+                                  "id": "surveys_view",
+                                  "name": "surveys_view",
+                                  "label": {
+                                      "text": "View surveys"
+                                  },
+                                  "hideLabel": true,
+                                  "value": "y",
+                                  "checked": true,
+                                  "disabled": true,
+                              })
+                          }}
                         </td>
                         <td class="ons-table__cell">
                             {{
@@ -60,6 +78,20 @@
                         </td>
                         <td class="ons-table__cell">
                             {{
+                              onsCheckbox({
+                                  "id": "reporting_units_view",
+                                  "label": {
+                                      "text": "View reporting units"
+                                  },
+                                  "hideLabel": true,
+                                  "value": "y",
+                                  "checked": true,
+                                  "disabled": true,
+                              })
+                          }}
+                        </td>
+                        <td class="ons-table__cell">
+                            {{
                             onsCheckbox({
                                 "id": "reporting_units_edit",
                                 "name": "reporting_units_edit",
@@ -77,6 +109,20 @@
                     <tr class="ons-table__row">
                         <td class="ons-table__cell">
                             Respondents
+                        </td>
+                        <td class="ons-table__cell">
+                            {{
+                              onsCheckbox({
+                                  "id": "respondents_view",
+                                  "label": {
+                                      "text": "View respondents"
+                                  },
+                                  "hideLabel": true,
+                                  "value": "y",
+                                  "checked": true,
+                                  "disabled": true,
+                              })
+                          }}
                         </td>
                         <td class="ons-table__cell">
                         {{
@@ -112,6 +158,20 @@
                             Messages
                         </td>
                         <td class="ons-table__cell">
+                            {{
+                              onsCheckbox({
+                                  "id": "messages_view",
+                                  "label": {
+                                      "text": "View messages"
+                                  },
+                                  "hideLabel": true,
+                                  "value": "y",
+                                  "checked": true,
+                                  "disabled": true,
+                              })
+                          }}
+                        </td>
+                        <td class="ons-table__cell">
                         {{
                             onsCheckbox({
                                 "id": "messages_edit",
@@ -132,7 +192,7 @@
 
           <div class="ons-grid ons-grid--flex ons-grid--gutterless ons-u-mt-m ons-u-mb-m">
             <div class="ons-grid__col ons-col-3@m">
-            <strong>Manage user accounts</strong>
+            <strong>Manager permissions</strong>
             {{
                 onsCheckbox({
                     "id": "users_admin",
@@ -158,7 +218,8 @@
             }}
             </div>
             <div class="ons-grid__col ons-u-ml-m">
-                <a href=" {{ url_for('admin_bp.manage_user_accounts') }}">Cancel</a>
+                <a href="{{ url_for('admin_bp.manage_user_accounts') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary" id="btn-option-cancel">
+                    <span class="ons-btn__inner">Cancel</span></a>
             </div>
           </div>
           <a href=" {{ url_for('admin_bp.get_delete_uaa_user', user_id=user_id) }}">Delete user account</a>


### PR DESCRIPTION
# What and why?

There was a small design iteration needed for the edit user permission page.  This PR adds a purely visual 'view' checkbox against each category so it's clear to the user that the smallest amount of permission still allows viewable records

# How to test?

- Build enviornment
- Run acceptance tests to seed data
- Add the users.admin permission to the 'uaa_user' (in public.groups find the permission, copy the uuid then create a new row in the public.group_membership table for that user for that group) to make the 'manage user accounts' link appear.
- Go to the edit user page and verify that it looks like the design in the attached trello card.

# Trello

https://trello.com/c/78qGT2X1
