### PR TITLE
Remove EQ_VERSION_ENABLED flag

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.56
+version: 2.6.57
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.56
+appVersion: 2.6.57

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -219,8 +219,6 @@ spec:
             {{- else }}
             value: "http://$(SECURE_MESSAGE_SERVICE_HOST):$(SECURE_MESSAGE_SERVICE_PORT)"
             {{- end }}
-          - name: EQ_VERSION_ENABLED
-            value: "{{ .Values.features.v3Enabled }}"
           - name: IS_ROLE_BASED_ACCESS_ENABLED
             value: "{{ .Values.features.isRoleBasedAccessEnabled }}"
           - name: SECURE_MESSAGE_JWT_SECRET

--- a/_infra/helm/response-operations-ui/values.yaml
+++ b/_infra/helm/response-operations-ui/values.yaml
@@ -79,5 +79,4 @@ test:
   enabled: false
   
 features:
-  v3Enabled: true
   isRoleBasedAccessEnabled: false

--- a/config.py
+++ b/config.py
@@ -106,7 +106,6 @@ class Config(object):
 
     TEST_MODE = strtobool(os.getenv("TEST_MODE", "False"))
     WTF_CSRF_ENABLED = strtobool(os.getenv("WTF_CSRF_ENABLED", "True"))
-    EQ_VERSION_ENABLED = strtobool(os.getenv("EQ_VERSION_ENABLED", "True"))
     IS_ROLE_BASED_ACCESS_ENABLED = strtobool(os.getenv("IS_ROLE_BASED_ACCESS_ENABLED", "False"))
 
 


### PR DESCRIPTION
# What and why?

When we removed the feature flag for the eq v3 work, we removed the flag from the code, but forgot to remove it from the helm chart.  This PR removes the remaining config for it.

# How to test?

# Trello
