### PR TITLE
Refactor get_users_list to only have one return type

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.57
+version: 2.6.58
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.57
+appVersion: 2.6.58

--- a/response_operations_ui/controllers/uaa_controller.py
+++ b/response_operations_ui/controllers/uaa_controller.py
@@ -414,7 +414,7 @@ def user_has_permission(permission, user_id=None) -> bool:
 
 def get_users_list(
     start_index: int, max_count: int, query: str = None, sort_by: str = "email", sort_order: str = "ascending"
-) -> dict | str:
+) -> dict:
     """
     Gets all users in uaa.  A query can be provided to refine the search.
 
@@ -432,13 +432,12 @@ def get_users_list(
     logger.info("Attempting to fetch user records")
     url = f"{app.config['UAA_SERVICE_URL']}/Users"
     response = requests.get(url, params=param, headers=headers)
-    # TODO Update this function to only have one return type (dict).  Multiple return types isn't great.
     try:
         response.raise_for_status()
         return response.json()
     except HTTPError:
         logger.error("Unauthorised attempt to get user list.", status_code=response.status_code)
-        raise "Unauthorised Access"
+        raise {"error": "Unauthorised Access", "totalResults": 0, "resources": []}
 
 
 def get_filter_query(filter_criteria: str, filter_value: str, filter_on: str):

--- a/response_operations_ui/controllers/uaa_controller.py
+++ b/response_operations_ui/controllers/uaa_controller.py
@@ -423,8 +423,7 @@ def get_users_list(
     :param sort_order:
     :param start_index:
     :param max_count:
-    :return: Either the result as a dict (with the list being in the 'resources' key) or "Unauthorised Access" on a
-             4XX or 5XX result
+    :return: A dict containing the users or an error message
     """
     access_token = login_admin()
     headers = generate_headers(access_token)
@@ -436,8 +435,8 @@ def get_users_list(
         response.raise_for_status()
         return response.json()
     except HTTPError:
-        logger.error("Unauthorised attempt to get user list.", status_code=response.status_code)
-        raise {"error": "Unauthorised Access", "totalResults": 0, "resources": []}
+        logger.error("Failed to retrieve user list.", status_code=response.status_code)
+        return {"error": "Failed to retrieve user list, please try again", "totalResults": 0, "resources": []}
 
 
 def get_filter_query(filter_criteria: str, filter_value: str, filter_on: str):

--- a/response_operations_ui/views/admin/manage_user_accounts.py
+++ b/response_operations_ui/views/admin/manage_user_accounts.py
@@ -49,6 +49,8 @@ def manage_user_accounts():
         flash(form.errors["user_search"][0], "error")
 
     uaa_user_list = get_users_list(start_index=offset, max_count=limit, query=query)
+    if "error" in uaa_user_list:
+        flash(uaa_user_list["error"], "error")
     user_list = _get_refine_user_list(uaa_user_list["resources"])
     pagination = Pagination(
         page=int(page),

--- a/response_operations_ui/views/admin/manage_user_accounts.py
+++ b/response_operations_ui/views/admin/manage_user_accounts.py
@@ -51,6 +51,12 @@ def manage_user_accounts():
     uaa_user_list = get_users_list(start_index=offset, max_count=limit, query=query)
     if "error" in uaa_user_list:
         flash(uaa_user_list["error"], "error")
+        return render_template(
+            "admin/manage-user-accounts.html",
+            show_pagination=False,
+            form=form,
+            search_email=search_email,
+        )
     user_list = _get_refine_user_list(uaa_user_list["resources"])
     pagination = Pagination(
         page=int(page),

--- a/tests/views/test_admin.py
+++ b/tests/views/test_admin.py
@@ -91,15 +91,14 @@ class TestMessage(ViewTestCase):
 
     @requests_mock.mock()
     def test_manage_user_accounts_403(self, mock_request):
-        # TODO Improve this test.  A 500 response isn't what should be happening here, it should be a 200 with a
-        # sensible error screen
         mock_request = self.setup_common_mocks(mock_request)
         mock_request.get(url_surveys, json=self.surveys_list_json, status_code=200)
         mock_request.get(url_uaa_user_list, json={}, status_code=403)
         self.client.post("/sign-in", follow_redirects=True, data={"username": "user", "password": "pass"})
         response = self.client.get("/admin/manage-user-accounts", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Failed to retrieve user list, please try again".encode(), response.data)
 
     @requests_mock.mock()
     def test_manage_user_accounts_success(self, mock_request):


### PR DESCRIPTION
# What and why?
Having a method return >1 type is confusing and a pretty quick way to get errors

# How to test?

# Trello
https://trello.com/c/po2v9sgc/1788-update-getuserslist-in-responseops-to-not-have-multiple-return-types