### PR TITLE
Fix security account key deprecation

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,8 +1,8 @@
 name: comment
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    branches: [ main ]
 
 env:
   SERVICE: response-operations-ui
@@ -10,17 +10,20 @@ env:
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: contains(github.event.comment.body, '/deploy')
     steps:
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: 'actions/checkout@v3'
+      - name: Authenticate with Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCR_KEY }}'
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCR_KEY }}
-          export_default_credentials: true
-          
       - uses: onsdigital/ras-rm-spinnaker-action@main
         with:
-          comment-body: ${{ github.event.comment.body }}
+          comment-body: '/deploy babbal'
           gcp-project: ${{ secrets.GOOGLE_PROJECT_ID }}
           bot-token: ${{ secrets.BOT_TOKEN }}
           spinnaker-topic: ${{ secrets.SPINNAKER_TOPIC }}

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    if: contains(github.event.comment.body, '/deploy')
     steps:
       - uses: 'actions/checkout@v3'
       - name: Authenticate with Google Cloud
@@ -23,7 +24,7 @@ jobs:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
       - uses: onsdigital/ras-rm-spinnaker-action@main
         with:
-          comment-body: '/deploy babbal'
+          comment-body: ${{ github.event.comment.body }}
           gcp-project: ${{ secrets.GOOGLE_PROJECT_ID }}
           bot-token: ${{ secrets.BOT_TOKEN }}
           spinnaker-topic: ${{ secrets.SPINNAKER_TOPIC }}

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/deploy')
     steps:
-      - uses: 'actions/checkout@v3'
+      - uses: actions/checkout@v3
       - name: Authenticate with Google Cloud
-        id: 'auth'
-        uses: 'google-github-actions/auth@v0'
+        id: auth
+        uses: google-github-actions/auth@v0
         with:
-          credentials_json: '${{ secrets.GCR_KEY }}'
+          credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,8 +1,8 @@
 name: comment
 
 on:
-  pull_request:
-    branches: [ main ]
+  issue_comment:
+    types: [created]
 
 env:
   SERVICE: response-operations-ui

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,11 +56,13 @@ jobs:
           make load-design-system-templates
       - name: Test
         run: make test
-      - uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate with Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v0'
         with:
-          version: '270.0.0'
-          service_account_key: ${{ secrets.GCR_KEY }}
-        # Configure docker to use the gcloud command-line tool as a credential helper
+          credentials_json: '${{ secrets.GCR_KEY }}'
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
       - run: |
           gcloud auth configure-docker
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,10 @@ jobs:
       - name: Test
         run: make test
       - name: Authenticate with Google Cloud
-        id: 'auth'
-        uses: 'google-github-actions/auth@v0'
+        id: auth
+        uses: google-github-actions/auth@v0
         with:
-          credentials_json: '${{ secrets.GCR_KEY }}'
+          credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - run: |

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.57
+version: 2.6.58
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.57
+appVersion: 2.6.58

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.58
+version: 2.6.59
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.58
+appVersion: 2.6.59


### PR DESCRIPTION
# What and why?
This PR updates Github actions to fix "service_account_key" has been deprecated. Replacing it with google-github-actions/auth in both main.yml and comment.yml
# How to test?
Check that the actions have run correctly
main - https://github.com/ONSdigital/response-operations-ui/actions/runs/2621512043
comment - https://github.com/ONSdigital/response-operations-ui/runs/7200697706?check_suite_focus=true 

N.B I have a done a bit of magic with comment - issue_comment in an action will not run till it is merged meaning I couldn't test, however I changed it temporally to pull_request and removed the if in the yaml to prove it works. After which I reverted it back to issue_comment and re-instated the if

![Screenshot 2022-07-05 at 17 56 04](https://user-images.githubusercontent.com/14179817/177525563-017b802c-19e2-4921-9f40-dda563f9c45d.png)

# Trello
