### PR TITLE
Bug fix missing alphabetical selection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10-slim
 WORKDIR /app
 RUN rm -rf node_modules
 COPY . /app
-EXPOSE 8085
+EXPOSE 8086
 RUN apt-get update -y && apt-get install -y python3-pip unzip curl
 RUN pip3 install pipenv && pipenv install --deploy --system
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10-slim
 WORKDIR /app
 RUN rm -rf node_modules
 COPY . /app
-EXPOSE 8086
+EXPOSE 8085
 RUN apt-get update -y && apt-get install -y python3-pip unzip curl
 RUN pip3 install pipenv && pipenv install --deploy --system
 

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.60
+version: 2.6.61
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.60
+appVersion: 2.6.61

--- a/response_operations_ui/templates/admin/manage-user-accounts.html
+++ b/response_operations_ui/templates/admin/manage-user-accounts.html
@@ -74,37 +74,37 @@
             </p>
         </div>
     </div>
+    <table width="100%" style="border-collapse: collapse; table-layout: fixed;">
+        <tr>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='A') }}">A</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='B') }}">B</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='C') }}">C</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='D') }}">D</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='E') }}">E</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='F') }}">F</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='G') }}">G</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='H') }}">H</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='I') }}">I</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='J') }}">J</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='K') }}">K</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='L') }}">L</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='M') }}">M</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='N') }}">N</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='O') }}">O</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='P') }}">P</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='Q') }}">Q</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='R') }}">R</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='S') }}">S</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='T') }}">T</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='U') }}">U</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='V') }}">V</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='W') }}">W</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='X') }}">X</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='Y') }}">Y</a></th>
+            <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='Z') }}">Z</a></th>
+        </tr>
+    </table>
     {% if user_list is defined and user_list|length > 0 %}
-        <table width="100%" style="border-collapse: collapse; table-layout: fixed;">
-            <tr>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='A') }}">A</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='B') }}">B</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='C') }}">C</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='D') }}">D</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='E') }}">E</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='F') }}">F</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='G') }}">G</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='H') }}">H</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='I') }}">I</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='J') }}">J</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='K') }}">K</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='L') }}">L</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='M') }}">M</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='N') }}">N</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='O') }}">O</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='P') }}">P</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='Q') }}">Q</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='R') }}">R</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='S') }}">S</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='T') }}">T</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='U') }}">U</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='V') }}">V</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='W') }}">W</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='X') }}">X</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='Y') }}">Y</a></th>
-                <th style="border-bottom:0; font-weight:normal; text-align: left; padding:0"><a href="{{ url_for('admin_bp.manage_user_accounts', user_with_email='Z') }}">Z</a></th>
-            </tr>
-        </table>
         <section class="ons-u-mt-s">
             {% set userTableData = {
                 "table_class": 'table--dense',
@@ -156,6 +156,8 @@
         </section>
         {% if show_pagination %}{% include 'respondent-search/rs-pagination.html' %}{% endif %}
     {% else %}
-        <p class="u-mt-m">No results found</p>
+        <section class="ons-u-mt-s">
+          <p class="u-mt-m">No results found</p>
+        </section>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
# What and why?
The alphabetical selection menu was missing when a letter was selected and there were no users with this letter. This needed to be fixed so a user didn't have to keep clicking back to the previous selection. I have also added a section for the no user message so that there is even spacing when no users are found.

# How to test?
1. Log in as an admin user
2. Click the 'Manage user accounts' button
3. Click on a letter until the 'No results found' message is returned
4. The alphabetical menu should be present

# Trello
https://trello.com/c/j7eVOjwg/1804-manage-user-accounts-does-not-display-alphabetical-selection-if-result-is-blank
