### PR TITLE
Fix double 'not started' radio bug on response status page

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.64
+version: 2.6.65
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.64
+appVersion: 2.6.65

--- a/response_operations_ui/controllers/case_controller.py
+++ b/response_operations_ui/controllers/case_controller.py
@@ -115,11 +115,6 @@ def get_cases_by_business_party_id(business_party_id):
     return response.json()
 
 
-def is_allowed_status(status):
-    allowed_statuses = {"COMPLETEDBYPHONE", "NOLONGERREQUIRED", "NOTSTARTED"}
-    return status in allowed_statuses
-
-
 def get_case_group_by_collection_exercise(case_groups, collection_exercise_id):
     return next(
         (case_group for case_group in case_groups if case_group["collectionExerciseId"] == collection_exercise_id), None

--- a/response_operations_ui/templates/response-status.html
+++ b/response_operations_ui/templates/response-status.html
@@ -103,7 +103,7 @@
                     } %}
 
                     {% set radios = [] %}
-                    {% for event, status in statuses.items() %}
+                    {% for event, status in allowed_transitions_for_case.items() %}
                         {% do radios.append(
                             {
                                 "id": 'state-' ~ loop.index,

--- a/response_operations_ui/views/case.py
+++ b/response_operations_ui/views/case.py
@@ -57,9 +57,7 @@ def get_response_statuses(ru_ref, error=None):
     allowed_statuses = {"COMPLETEDBYPHONE", "NOLONGERREQUIRED"}
     statuses = case_controller.get_available_case_group_statuses_direct(exercise["id"], ru_ref)
     available_statuses = {
-        event: map_ce_response_status(status)
-        for event, status in statuses.items()
-        if status in allowed_statuses
+        event: map_ce_response_status(status) for event, status in statuses.items() if status in allowed_statuses
     }
 
     case_groups = case_controller.get_case_groups_by_business_party_id(reporting_unit["id"])

--- a/response_operations_ui/views/case.py
+++ b/response_operations_ui/views/case.py
@@ -26,6 +26,7 @@ from response_operations_ui.controllers.party_controller import (
 from response_operations_ui.forms import ChangeGroupStatusForm
 
 COMPLETE_STATE = ["COMPLETE", "COMPLETEDBYPHONE"]
+ALLOWED_TRANSITIONS = ["COMPLETEDBYPHONE", "NOLONGERREQUIRED"]
 COMPLETED_CASE_EVENTS = ["OFFLINE_RESPONSE_PROCESSED", "SUCCESSFUL_RESPONSE_UPLOAD", "COMPLETED_BY_PHONE"]
 SUCCESSFUL_CASE_EVENTS = ["OFFLINE_RESPONSE_PROCESSED", "SUCCESSFUL_RESPONSE_UPLOAD", "ONLINE_QUESTIONNAIRE_RESPONSE"]
 case_bp = Blueprint("case_bp", __name__, static_folder="static", template_folder="templates")
@@ -46,18 +47,15 @@ def get_response_statuses(ru_ref, error=None):
     exercise = collection_exercise_controllers.get_collection_exercise_from_list(exercises, period)
     reporting_unit = party_controller.get_business_by_ru_ref(ru_ref)
 
-    # The statuses variable is a dict that contains the action as the key (EQ_LAUNCH for example) and the value is
-    # the new state it will be in (e.g., COMPLETE, INPROGRESS, etc).
-    # The available_statuses are the statuses that we allow a case to switch to.  We currently only allow changing to
-    # COMPLETEDBYPHONE and NOLONGERREQUIRED, and no other, states via the UI.
-    # Historically we've not allowed changing back to NOTSTARTED as case wasn't smart enough to reset the case to a
-    # state where it would start sending communications out (e.g., reminder emails), if this changes then we can add it
-    # to this list though it would need to be written to be a bit more clever about which radio buttons to present as
-    # this implementation is very basic.
-    allowed_statuses = {"COMPLETEDBYPHONE", "NOLONGERREQUIRED"}
-    statuses = case_controller.get_available_case_group_statuses_direct(exercise["id"], ru_ref)
-    available_statuses = {
-        event: map_ce_response_status(status) for event, status in statuses.items() if status in allowed_statuses
+    # The possible_transitions_for_case variable is a dict that contains the action as the key (EQ_LAUNCH for example)
+    # and the value is the new state it will be in (e.g., COMPLETE, INPROGRESS, etc).
+    # The allowed_transitions_for_case are the statuses that we allow a case to switch to.  We currently only allow
+    # a subset of them via the UI as case can't handle switching between certain states correctly.
+    possible_transitions_for_case = case_controller.get_available_case_group_statuses_direct(exercise["id"], ru_ref)
+    allowed_transitions_for_case = {
+        event: map_ce_response_status(status)
+        for event, status in possible_transitions_for_case.items()
+        if status in ALLOWED_TRANSITIONS
     }
 
     case_groups = case_controller.get_case_groups_by_business_party_id(reporting_unit["id"])
@@ -66,9 +64,9 @@ def get_response_statuses(ru_ref, error=None):
     case_id = get_case_by_case_group_id(case_group["id"]).get("id")
     is_complete = case_group_status in COMPLETE_STATE
     completed_timestamp = get_timestamp_for_completed_case_event(case_id) if is_complete else None
-    case_events = get_case_events_by_case_id(case_id=case_id)
 
     if case_group_status == "COMPLETE":
+        case_events = get_case_events_by_case_id(case_id=case_id)
         case_event = get_case_event_for_seft_or_eq(case_events)
         completed_respondent = get_user_from_case_events(case_event)
 
@@ -80,7 +78,7 @@ def get_response_statuses(ru_ref, error=None):
         survey_short_name=format_short_name(survey["shortName"]),
         survey_ref=survey["surveyRef"],
         ce_period=period,
-        statuses=available_statuses,
+        allowed_transitions_for_case=allowed_transitions_for_case,
         case_group_status=map_ce_response_status(case_group_status),
         case_group_id=case_group["id"],
         error=error,

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -292,7 +292,7 @@ def _upload_sample(short_name, period):
             collection_exercise_controllers.link_sample_summary_to_collection_exercise(
                 collection_exercise_id=exercise["id"], sample_summary_id=sample_summary["id"]
             )
-        except (ApiError) as e:
+        except ApiError as e:
             if e.status_code == 400:
                 error = e.message
             else:

--- a/tests/views/test_change_response_status.py
+++ b/tests/views/test_change_response_status.py
@@ -68,6 +68,9 @@ class TestChangeResponseStatus(TestCase):
             "EQ_LAUNCH": "INPROGRESS",
             "SUCCESSFUL_RESPONSE_UPLOAD": "COMPLETE",
             "COMPLETED_BY_PHONE": "COMPLETEDBYPHONE",
+            "RESPONDENT_ENROLED": "NOTSTARTED",
+            "ACCESS_CODE_AUTHENTICATION_ATTEMPT": "NOTSTARTED",
+            "NO_LONGER_REQUIRED": "NOLONGERREQUIRED",
         }
 
     @requests_mock.mock()
@@ -89,6 +92,10 @@ class TestChangeResponseStatus(TestCase):
         self.assertIn(b"221 BLOCKS", data)
         self.assertIn(b"Not started", data)
         self.assertIn(b"Completed by phone", data)
+
+        # Test that events that end up in the NOTSTARTED state don't get a radio button
+        self.assertNotIn(b"ACCESS_CODE_AUTHENTICATION_ATTEMPT", data)
+        self.assertNotIn(b"RESPONDENT_ENROLED", data)
 
     @requests_mock.mock()
     def test_get_available_status_failures(self, mock_request):

--- a/tests/views/test_change_response_status.py
+++ b/tests/views/test_change_response_status.py
@@ -92,6 +92,7 @@ class TestChangeResponseStatus(TestCase):
         self.assertIn(b"221 BLOCKS", data)
         self.assertIn(b"Not started", data)
         self.assertIn(b"Completed by phone", data)
+        self.assertIn(b"No longer required", data)
 
         # Test that events that end up in the NOTSTARTED state don't get a radio button
         self.assertNotIn(b"ACCESS_CODE_AUTHENTICATION_ATTEMPT", data)


### PR DESCRIPTION
# What and why?

When going to view the response status of a case, if the case was in the NOTSTARTED state then there would be 2 visually identical 'Not started' radio buttons in addition to the 2 that set it into a completed state.  This PR fixes the issue and provides extra clarity in the form of a comment around the code to hopefully prevent it happening again.

For context, it happened because we recently added 2 new valid transitions from the NOTSTARTED state.  These states looped back to NOTSTARTED, but because they resulted in a NOTSTARTED end state, they were deemed 'allowed' and were put onto the screen.  This is because the responses page blindly takes the list of possible transitions and regardless of what state the case is currently in, if any possible transition ends up in the NOTSTARTED, COMPLETEDBYPHONE or NOLONGERREQUIRED states then it'll put it in the list of radio buttons for this page.

If we ever decide to offer UI pages that do more than:
- NOT STARTED -> COMPLETED BY PHONE
- NOT STARTED -> NO LONGER REQUIRED
then we'd want to be a bit smarter about checking the current state and creating the list of radio buttons based on that, instead of the basic way we're doing it now.

# How to test?

- Run acceptance tests
- Log in and go to the reporting units tab, pick any reporting unit, then click on the survey
- On the one case for the survey, click view.  The response chasing page should only have 2 radio buttons.

# Trello
