### PR TITLE
Render error text to screen on sample upload failures

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.65
+version: 2.6.66
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.65
+appVersion: 2.6.66

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.64
+version: 2.6.65
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.6.64
+appVersion: 2.6.65

--- a/response_operations_ui/templates/collection_exercise/ce-view-sample-ci.html
+++ b/response_operations_ui/templates/collection_exercise/ce-view-sample-ci.html
@@ -13,6 +13,7 @@
     {% include 'collection_exercise/ce-success-panel.html' %}
     {% include 'collection_exercise/ce-handle-errors.html' %}
     {% include 'collection_exercise/ce-info-panel.html' %}
+    {% include 'partials/flashed-messages.html' %}
     <div class="ons-grid ons-grid--gutterless">
         {% include 'partials/error-box.html' %}
         <h1 name="page-ce-title">Upload sample file & collection instruments</h1>

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -270,9 +270,9 @@ def _set_ready_for_live(short_name, period):
 
 
 def _upload_sample(short_name, period):
-    error = _validate_sample()
+    valid = _validate_sample()
 
-    if not error:
+    if valid:
         survey_id = survey_controllers.get_survey_id_by_short_name(short_name)
         exercises = collection_exercise_controllers.get_collection_exercises_by_survey(survey_id)
 
@@ -292,9 +292,9 @@ def _upload_sample(short_name, period):
             collection_exercise_controllers.link_sample_summary_to_collection_exercise(
                 collection_exercise_id=exercise["id"], sample_summary_id=sample_summary["id"]
             )
-        except (ApiError) as e:
+        except ApiError as e:
             if e.status_code == 400:
-                error = e.message
+                flash(e.message, "error")
             else:
                 # For a non-400, just let the error bubble up
                 raise e
@@ -304,7 +304,6 @@ def _upload_sample(short_name, period):
             "collection_exercise_bp.get_view_sample_ci",
             short_name=short_name,
             period=period,
-            error=error,
             show_msg="true",
         )
     )
@@ -497,18 +496,23 @@ def validate_file_extension_is_correct(file):
     return error
 
 
-def _validate_sample():
-    error = None
-    if "sampleFile" in request.files:
-        file = request.files["sampleFile"]
-        if not str.endswith(file.filename, ".csv"):
-            logger.info("Invalid file format uploaded", filename=file.filename)
-            error = "Invalid file format"
-    else:
+def _validate_sample() -> bool:
+    """
+    Does some light touch validation around the sample file.  It ensures a file got uploaded and that it has the
+    right extension.
+    :return: True if sample is valid, False if it's invalid
+    """
+    if "sampleFile" not in request.files:
         logger.info("No file uploaded")
-        error = "File not uploaded"
+        flash("No file uploaded", "error")
+        return False
 
-    return error
+    file = request.files["sampleFile"]
+    if not str.endswith(file.filename, ".csv"):
+        logger.info("Invalid file format uploaded", filename=file.filename)
+        flash("Invalid file format", "error")
+        return False
+    return True
 
 
 def _format_sample_summary(sample):

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -1108,7 +1108,7 @@ class TestCollectionExercise(ViewTestCase):
         post_data = {"sampleFile": (BytesIO(b"data"), "test.csv"), "load-sample": ""}
 
         with open(
-                f"{project_root}/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json"
+            f"{project_root}/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json"
         ) as collection_exercise:
             mock_details.return_value = json.load(collection_exercise)
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -1067,8 +1067,8 @@ class TestCollectionExercise(ViewTestCase):
         data = {"sampleFile": (BytesIO(b"data"), "test.html"), "load-sample": ""}
         with open(
             f"{project_root}/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json"
-        ) as collection_exercise:
-            mock_details.return_value = json.load(collection_exercise)
+        ) as collection_exercise_no_sample:
+            mock_details.return_value = json.load(collection_exercise_no_sample)
         mock_request.get(url_get_survey_by_short_name, status_code=200, json=self.survey_data)
         mock_request.get(url_ces_by_survey, status_code=200, json=exercise_data)
 
@@ -1079,6 +1079,7 @@ class TestCollectionExercise(ViewTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Sample loaded successfully".encode(), response.data)
         self.assertIn("Sample summary".encode(), response.data)
+        self.assertIn("Invalid file format".encode(), response.data)
 
     @requests_mock.mock()
     @patch("response_operations_ui.views.collection_exercise.build_collection_exercise_details")
@@ -1098,6 +1099,31 @@ class TestCollectionExercise(ViewTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Sample loaded successfully".encode(), response.data)
         self.assertIn("Sample summary".encode(), response.data)
+        self.assertIn("No file uploaded".encode(), response.data)
+
+    @requests_mock.mock()
+    @patch("response_operations_ui.views.collection_exercise.build_collection_exercise_details")
+    def test_upload_sample_csv_too_few_columns(self, mock_request, mock_details):
+        sign_in_with_permission(self, mock_request, user_permission_surveys_edit_json)
+        post_data = {"sampleFile": (BytesIO(b"data"), "test.csv"), "load-sample": ""}
+
+        with open(
+                f"{project_root}/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json"
+        ) as collection_exercise:
+            mock_details.return_value = json.load(collection_exercise)
+        mock_request.get(url_ces_by_survey, json=self.collection_exercises)
+        mock_request.get(url_get_survey_by_short_name, json=self.survey_data)
+        mock_request.get(url_ces_by_survey, json=exercise_data)
+        mock_request.post(url_sample_service_upload, status_code=400, text="Too few columns in CSV file")
+
+        response = self.client.post(
+            f"/surveys/{short_name}/{period}/upload-sample-file", data=post_data, follow_redirects=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Sample loaded successfully".encode(), response.data)
+        self.assertIn("Sample summary".encode(), response.data)
+        self.assertIn("Too few columns in CSV file".encode(), response.data)
 
     @requests_mock.mock()
     @patch("response_operations_ui.views.collection_exercise.build_collection_exercise_details")


### PR DESCRIPTION
# What and why?

Before this PR, if the file extension was incorrect or there were too few columns, the only way to find out was to look at the url and see what random text was in the `error` param.  This PR removes the blobs of text from the url and instead uses `flash` to render the error on screen in the case of a failure in the sample upload process.

Also wrote stricter tests around this functionality as the previous tests were incredibly weak.

# How to test?

- Create a sample file and remove one of the columns
- Create collection exercise
- Go to upload the sample file, it'll now redirect you to the summary page with an error on screen and no junk text in the url.
- You can do the same test by uploading a file with the wrong extension, but you'll need to modify the html for the upload and change the `accepts` from `".csv"` to `".csv, .html" (or whatever wrong file format you wish to try)

# Trello
