### PR TITLE
Delete seft collection instrument

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.7.2
+version: 2.7.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.7.2
+appVersion: 2.7.3

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.7.1
+version: 2.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.7.1
+appVersion: 2.7.2

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.7.0
+version: 2.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.7.0
+appVersion: 2.7.1

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -6,12 +6,12 @@ import redis
 from flask import Flask, flash, redirect, session, url_for
 from flask_assets import Environment
 from flask_login import LoginManager
+from flask_session import Session
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFError, CSRFProtect
 from structlog import wrap_logger
 
 from config import Config
-from flask_session import Session
 from response_operations_ui.common.jinja_filters import filter_blueprint
 from response_operations_ui.controllers.uaa_controller import user_has_permission
 from response_operations_ui.logger_config import logger_initial_config

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -6,12 +6,12 @@ import redis
 from flask import Flask, flash, redirect, session, url_for
 from flask_assets import Environment
 from flask_login import LoginManager
-from flask_session import Session
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFError, CSRFProtect
 from structlog import wrap_logger
 
 from config import Config
+from flask_session import Session
 from response_operations_ui.common.jinja_filters import filter_blueprint
 from response_operations_ui.controllers.uaa_controller import user_has_permission
 from response_operations_ui.logger_config import logger_initial_config

--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -182,6 +182,24 @@ def unlink_collection_instrument(ce_id, ci_id):
     return True
 
 
+def delete_seft_collection_instrument(ci_id: str) -> bool:
+    """Deletes a SEFT collection instrument
+
+    :param ci_id: A uuid of a collection instrument
+    :rtype: bool
+    """
+    url = f'{app.config["COLLECTION_INSTRUMENT_URL"]}/collection-instrument-api/1.0.2/delete/{ci_id}'
+    response = requests.delete(url, auth=app.config["BASIC_AUTH"])
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.error(response.text, status=response.status_code)
+        return False
+
+    return True
+
+
 def get_collection_instruments_by_classifier(survey_id=None, collection_exercise_id=None, ci_type=None):
     logger.info(
         "Retrieving collection instruments",

--- a/response_operations_ui/templates/ce-seft-instrument.html
+++ b/response_operations_ui/templates/ce-seft-instrument.html
@@ -136,7 +136,7 @@
                 {% for i in range(surveyTableDataRows | length) %}
                     {% set j = i + 1 %}
                     <script{% if csp_nonce %} nonce="{{ csp_nonce() }}" {% endif %}>
-                    document.getElementById("unlink-ci-{{ j }}").addEventListener('click', function () {
+                    document.getElementById("delete-ci-{{ j }}").addEventListener('click', function () {
                         this.parentNode.submit()
                     });</script>
                 {% endfor %}

--- a/response_operations_ui/templates/ce-seft-instrument.html
+++ b/response_operations_ui/templates/ce-seft-instrument.html
@@ -10,7 +10,6 @@
 
 {% block main %}
     {% include 'collection_exercise/ce-success-panel.html' %}
-    {% include 'collection_exercise/ce-handle-errors.html' %}
     {% include 'collection_exercise/ce-info-panel.html' %}
     {% include 'partials/error-box.html' %}
     <h1 name="page-survey-title" class="ons-u-mb-l">Load Collection instruments for {{survey.shortName}} {{period}}</h1>
@@ -99,16 +98,14 @@
                                     }
                                 ]
                 } %}
-                {% include 'partials/error-box.html' %}
                 {% set surveyTableDataRows = [] %}
                 {% for collection_instrument in collection_instruments %}
                     {% if not locked and surveyEditPermission %}
                         {% set formData = 
-                            '<form id="form-unselect-ci-' + loop.index|string + '" action="" method="post">' +
+                            '<form id="form-delete-ci-' + loop.index|string + '" action="" method="post">' +
                             '<a href=# id="unlink-ci-' + loop.index|string + '">Remove SEFT file</a>' +
-                            '<input type="hidden" name="ce_id" value="' + ce.id + '">' +
                             '<input type="hidden" name="ci_id" value="' + collection_instrument.id + '">' +
-                            '<input type="hidden" name="unselect-ci">' +
+                            '<input type="hidden" name="delete-ci">' +
                             '<input type="hidden" name="csrf_token" value="' + csrf_token() + '" />' +
                             '</form>'
                         %}

--- a/response_operations_ui/templates/ce-seft-instrument.html
+++ b/response_operations_ui/templates/ce-seft-instrument.html
@@ -103,7 +103,7 @@
                     {% if not locked and surveyEditPermission %}
                         {% set formData = 
                             '<form id="form-delete-ci-' + loop.index|string + '" action="" method="post">' +
-                            '<a href=# id="unlink-ci-' + loop.index|string + '">Remove SEFT file</a>' +
+                            '<a href=# id="delete-ci-' + loop.index|string + '">Remove SEFT file</a>' +
                             '<input type="hidden" name="ci_id" value="' + collection_instrument.id + '">' +
                             '<input type="hidden" name="delete-ci">' +
                             '<input type="hidden" name="csrf_token" value="' + csrf_token() + '" />' +

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -425,7 +425,21 @@ def _upload_collection_instrument(short_name, period):
 
 
 def _unselect_collection_instrument(short_name, period):
-    success_panel = _unlink_collection_instrument()
+    success_panel = "Collection instrument removed"
+    ci_id = request.form.get("ci_id")
+    ce_id = request.form.get("ce_id")
+    ci_unlinked = collection_instrument_controllers.unlink_collection_instrument(ce_id, ci_id)
+
+    if not ci_unlinked:
+        success_panel = None
+        session["error"] = json.dumps(
+            {
+                "section": "head",
+                "header": "Error: Failed to remove collection instrument",
+                "message": "Please try again",
+            }
+        )
+
     return redirect(
         url_for(
             "collection_exercise_bp.get_view_sample_ci",
@@ -437,7 +451,6 @@ def _unselect_collection_instrument(short_name, period):
 
 
 def _validate_collection_instrument():
-    error = None
     if "ciFile" in request.files:
         file = request.files["ciFile"]
 
@@ -975,13 +988,25 @@ def get_seft_collection_instrument(short_name, period):
 @login_required
 def post_seft_collection_instrument(short_name, period):
     verify_permission("surveys.edit", session)
-    if "unselect-ci" in request.form:
-        return _unselect_seft_collection_instrument(short_name, period)
+    if "delete-ci" in request.form:
+        return _delete_seft_collection_instrument(short_name, period)
     return _upload_seft_collection_instrument(short_name, period)
 
 
-def _unselect_seft_collection_instrument(short_name, period):
-    success_panel = _unlink_collection_instrument()
+def _delete_seft_collection_instrument(short_name, period):
+    success_panel = "Collection instrument removed"
+    ci_id = request.form.get("ci_id")
+    delete_seft_collection = collection_instrument_controllers.delete_seft_collection_instrument(ci_id)
+
+    if not delete_seft_collection:
+        success_panel = None
+        session["error"] = json.dumps(
+            {
+                "section": "collection-instruments-table",
+                "header": "Error: Failed to remove collection instrument",
+                "message": "Please try again",
+            }
+        )
 
     return redirect(
         url_for(
@@ -991,24 +1016,6 @@ def _unselect_seft_collection_instrument(short_name, period):
             success_panel=success_panel,
         )
     )
-
-
-def _unlink_collection_instrument():
-    success_panel = None
-    ci_id = request.form.get("ci_id")
-    ce_id = request.form.get("ce_id")
-    ci_unlinked = collection_instrument_controllers.unlink_collection_instrument(ce_id, ci_id)
-    if ci_unlinked:
-        success_panel = "Collection instrument removed"
-    else:
-        session["error"] = json.dumps(
-            {
-                "section": "head",
-                "header": "Error: Failed to remove collection instrument",
-                "message": "Please try again",
-            }
-        )
-    return success_panel
 
 
 def _upload_seft_collection_instrument(short_name, period):


### PR DESCRIPTION
# What and why?
This PR updates SEFT collection instruments to call the delete end point in the collection instrument service rather than unlink
 
# How to test?
Deploy this [PR](https://github.com/ONSdigital/ras-collection-instrument/pull/282) to your environment and add and remove seft collection instruments. The other PR has more detailed instructions
# Trello
