### PR TITLE
Fix error layout and apostrophes

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.7.0
+version: 2.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.7.0
+appVersion: 2.7.1

--- a/response_operations_ui/controllers/uaa_controller.py
+++ b/response_operations_ui/controllers/uaa_controller.py
@@ -475,12 +475,12 @@ def get_users_list(
         response.raise_for_status()
         return response.json()
     except HTTPError:
-        logger.error("Failed to retrieve user list.", status_code=response.status_code)
+        logger.error("Failed to retrieve user list.", status_code=response.status_code, exc_info=True)
         return {"error": "Failed to retrieve user list, please try again"}
 
 
 def get_filter_query(filter_criteria: str, filter_value: str, filter_on: str) -> str:
-    return f"{filter_on} {get_filter(filter_criteria)} '{filter_value}'"
+    return f'{filter_on} {get_filter(filter_criteria)} "{filter_value}"'
 
 
 def get_filter(filter_criteria: str):

--- a/response_operations_ui/templates/admin/manage-user-accounts.html
+++ b/response_operations_ui/templates/admin/manage-user-accounts.html
@@ -6,39 +6,29 @@
 
 
 {% block main %}
-    {% with messages = get_flashed_messages(category_filter=["error"]) %}
+      {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
+          {% for category, message in messages %}
+            {% if category == "error" %}
+                {% set type = "error" %}
+            {% else %}
+                {% set type = "success" %}
+            {% endif %}
             {% call
                 onsPanel({
-                        "type": "error",
-                        "classes": "ons-u-mb-l",
-                        "title":  errorTitle
-                    })
-            %}
-                {% for message in messages %}
-                    <p id="flashed-message-{{ loop.index }}">{{ message }}</p>
-                {% endfor %}
-            {% endcall %}
-        {% endif %}
-    {% endwith %}
-    {% with messages = get_flashed_messages() %}
-        {% if messages %}
-            {% call
-                onsPanel({
-                    "type":"success",
-                    "iconType": "check",
-                    "classes": "ons-u-mb-s",
-                    "bodyAttributes": {
-                        "data-qa": "success-body"
-                    }
+                    "type": type,
+                    "classes": "ons-u-mb-l",
+                    "iconType": "check" if type == "success" else null,
                 })
             %}
-                {% for message in messages %}
-                    <p id="flashed-message-{{ loop.index }}">{{ message }}</p>
+                {% for category, message in messages %}
+                  <p id="flashed-message-{{ loop.index }}">{{ message }}</p>
                 {% endfor %}
             {% endcall %}
+          {% endfor %}
         {% endif %}
-    {% endwith %}
+      {% endwith %}
+
     <div class="ons-grid ons-grid--flex ons-grid--between">
         <div class="ons-grid__col">
             <h1 class="ons-u-fs-l u-mb-xs" name="page-messages-title">Manage user accounts</h1>

--- a/response_operations_ui/views/admin/manage_user_accounts.py
+++ b/response_operations_ui/views/admin/manage_user_accounts.py
@@ -70,6 +70,12 @@ def manage_user_accounts():
         query = get_filter_query("equal", search_email, "emails.value")
     if form.errors:
         flash(form.errors["user_search"][0], "error")
+        return render_template(
+            "admin/manage-user-accounts.html",
+            show_pagination=False,
+            form=form,
+            search_email=search_email,
+        )
 
     uaa_user_list = get_users_list(start_index=offset, max_count=limit, query=query)
     if "error" in uaa_user_list:


### PR DESCRIPTION
# What and why?

If you searched for an email with an apostrophe then it would cause an error.  Additionally, any error on the page would cause 2 text boxes to appear.  

# How to test?

- Deploy code and run tests to seed data
- Go to manage user accounts page and search for an an email with an apostrophe (example'blah@example.com) this should work now and not throw an error.
- Input an invalid email address.  You should only see one error message on the screen.

# Trello
