### PR TITLE
Add optional param for number of cases

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.7.1
+version: 2.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.7.1
+appVersion: 2.7.2

--- a/response_operations_ui/controllers/case_controller.py
+++ b/response_operations_ui/controllers/case_controller.py
@@ -90,13 +90,13 @@ def get_case_groups_by_business_party_id(business_party_id):
     return response.json()
 
 
-def get_cases_by_business_party_id(business_party_id):
+def get_cases_by_business_party_id(business_party_id, number_of_cases):
     logger.info("Retrieving cases", business_party_id=business_party_id)
     url = f'{app.config["CASE_URL"]}/cases/partyid/{business_party_id}'
     response = requests.get(
         url,
         auth=app.config["BASIC_AUTH"],
-        params={"iac": "True", "max_cases_per_survey": app.config["MAX_CASES_RETRIEVED_PER_SURVEY"]},
+        params={"iac": "True", "max_cases_per_survey": number_of_cases},
     )
 
     try:

--- a/response_operations_ui/controllers/case_controller.py
+++ b/response_operations_ui/controllers/case_controller.py
@@ -90,13 +90,21 @@ def get_case_groups_by_business_party_id(business_party_id):
     return response.json()
 
 
-def get_cases_by_business_party_id(business_party_id, number_of_cases):
+def get_cases_by_business_party_id(business_party_id: str, max_number_of_cases: str) -> dict:
+    """
+    Gets the case details for a given business from the case service.  The cases will be returned most recent
+    first, so having 12 cases maximum will result in getting the 12 most recent cases for each survey.
+
+    :param business_party_id: party uuid of the business
+    :param max_number_of_cases: Maximum number of cases that will be returned
+    :return: A dictionary containing all the case data
+    """
     logger.info("Retrieving cases", business_party_id=business_party_id)
     url = f'{app.config["CASE_URL"]}/cases/partyid/{business_party_id}'
     response = requests.get(
         url,
         auth=app.config["BASIC_AUTH"],
-        params={"iac": "True", "max_cases_per_survey": number_of_cases},
+        params={"iac": "True", "max_cases_per_survey": max_number_of_cases},
     )
 
     try:

--- a/response_operations_ui/templates/reporting-unit-survey.html
+++ b/response_operations_ui/templates/reporting-unit-survey.html
@@ -7,6 +7,7 @@
 {% set isMessageEditPermission = hasPermission('messages.edit') %}
 {% block main %}
 
+    {% include 'partials/flashed-messages.html' %}
     <div class="ons-grid ons-u-mb-xs">
       {{
             onsButton({

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -147,8 +147,8 @@ def view_reporting_unit_survey(ru_ref, survey_id):
     logger.info("Gathering data to view reporting unit survey data", ru_ref=ru_ref, survey_id=survey_id)
     # Make some initial calls to retrieve some data we'll need
     reporting_unit = party_controller.get_business_by_ru_ref(ru_ref)
-    number_of_cases = request.args.get("number-of-cases", app.config["MAX_CASES_RETRIEVED_PER_SURVEY"])
-    cases = case_controller.get_cases_by_business_party_id(reporting_unit["id"], number_of_cases)
+    max_number_of_cases = request.args.get("number-of-cases", app.config["MAX_CASES_RETRIEVED_PER_SURVEY"])
+    cases = case_controller.get_cases_by_business_party_id(reporting_unit["id"], max_number_of_cases)
     case_groups = [case["caseGroup"] for case in cases]
 
     # Get all collection exercises for retrieved case groups and only for the survey we care about.

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -148,6 +148,9 @@ def view_reporting_unit_survey(ru_ref, survey_id):
     # Make some initial calls to retrieve some data we'll need
     reporting_unit = party_controller.get_business_by_ru_ref(ru_ref)
     max_number_of_cases = request.args.get("max-number-of-cases", app.config["MAX_CASES_RETRIEVED_PER_SURVEY"])
+    if int(max_number_of_cases) == 0:
+        flash("Maximum number of cases cannot be 0.  Using default maximum instead", "error")
+        max_number_of_cases = app.config["MAX_CASES_RETRIEVED_PER_SURVEY"]
     cases = case_controller.get_cases_by_business_party_id(reporting_unit["id"], max_number_of_cases)
     case_groups = [case["caseGroup"] for case in cases]
 

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -36,7 +36,9 @@ def view_reporting_unit(ru_ref):
     # Make some initial calls to retrieve some data we'll need
     reporting_unit = party_controller.get_business_by_ru_ref(ru_ref)
 
-    cases = case_controller.get_cases_by_business_party_id(reporting_unit["id"])
+    cases = case_controller.get_cases_by_business_party_id(
+        reporting_unit["id"], app.config["MAX_CASES_RETRIEVED_PER_SURVEY"]
+    )
     case_groups = [case["caseGroup"] for case in cases]
 
     # Get all collection exercises for retrieved case groups
@@ -145,8 +147,8 @@ def view_reporting_unit_survey(ru_ref, survey_id):
     logger.info("Gathering data to view reporting unit survey data", ru_ref=ru_ref, survey_id=survey_id)
     # Make some initial calls to retrieve some data we'll need
     reporting_unit = party_controller.get_business_by_ru_ref(ru_ref)
-
-    cases = case_controller.get_cases_by_business_party_id(reporting_unit["id"])
+    number_of_cases = request.args.get("number-of-cases", app.config["MAX_CASES_RETRIEVED_PER_SURVEY"])
+    cases = case_controller.get_cases_by_business_party_id(reporting_unit["id"], number_of_cases)
     case_groups = [case["caseGroup"] for case in cases]
 
     # Get all collection exercises for retrieved case groups and only for the survey we care about.

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -147,7 +147,7 @@ def view_reporting_unit_survey(ru_ref, survey_id):
     logger.info("Gathering data to view reporting unit survey data", ru_ref=ru_ref, survey_id=survey_id)
     # Make some initial calls to retrieve some data we'll need
     reporting_unit = party_controller.get_business_by_ru_ref(ru_ref)
-    max_number_of_cases = request.args.get("number-of-cases", app.config["MAX_CASES_RETRIEVED_PER_SURVEY"])
+    max_number_of_cases = request.args.get("max-number-of-cases", app.config["MAX_CASES_RETRIEVED_PER_SURVEY"])
     cases = case_controller.get_cases_by_business_party_id(reporting_unit["id"], max_number_of_cases)
     case_groups = [case["caseGroup"] for case in cases]
 

--- a/tests/controllers/test_case_controller.py
+++ b/tests/controllers/test_case_controller.py
@@ -99,5 +99,5 @@ class TestCaseControllers(unittest.TestCase):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_cases, json=[], status=204, content_type="application/json")
             with self.app.app_context():
-                get_case_events = case_controller.get_cases_by_business_party_id(case_id)
+                get_case_events = case_controller.get_cases_by_business_party_id(case_id, 12)
                 self.assertEqual(get_case_events, [])

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -218,6 +218,37 @@ class TestReportingUnits(ViewTestCase):
         self.assertEqual(response.status_code, 500)
 
     @requests_mock.mock()
+    def test_get_reporting_unit_survey_max_no_of_cases_0_causes_warning(self, mock_request):
+        """
+        If the max-number-of-cases url parameter is 0 then a flashed warning will be displayed saying that it'll use
+        the default value instead.
+        """
+        mock_request.post(url_sign_in_data, json={"access_token": self.access_token}, status_code=201)
+        mock_request.get(url_surveys, json=self.surveys_list_json, status_code=200)
+        mock_request.get(url_permission_url, json=user_permission_reporting_unit_edit_json, status_code=200)
+        self.client.post("/sign-in", follow_redirects=True, data={"username": "user", "password": "pass"})
+        mock_request.get(url_get_business_by_ru_ref, json=business_reporting_unit)
+        mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
+        mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
+        mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
+        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_business_attributes, json=business_attributes)
+        mock_request.get(url_get_survey_by_id, json=survey)
+        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
+        mock_request.get(f"{url_get_iac}/{iac_1}", json=iac)
+        mock_request.get(f"{url_get_iac}/{iac_2}", json=iac)
+        mock_request.get(url_permission_url, json=user_permission_reporting_unit_edit_json, status_code=200)
+
+        response = self.client.get(
+            "/reporting-units/50012345678/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87?max-number-of-cases=0",
+            follow_redirects=True,
+        )
+
+        self.assertIn("Maximum number of cases cannot be 0.  Using default maximum instead".encode(), response.data)
+        self.assertIn("Back to surveys".encode(), response.data)
+        self.assertEqual(response.status_code, 200)
+
+    @requests_mock.mock()
     def test_get_reporting_unit_survey_reporting_unit_edit_role(self, mock_request):
         mock_request.post(url_sign_in_data, json={"access_token": self.access_token}, status_code=201)
         mock_request.get(url_surveys, json=self.surveys_list_json, status_code=200)


### PR DESCRIPTION
# What and why?

Currently it's only possible to see the 12 most recent cases, if you want more (say, to change a status) then we have to go to the database for this.  This PR adds a 'hidden' url parameter, as in there is no UI element for it, `max-number-of-cases` that you can add to the `/reporting-units/<ru_ref>/surveys/<survey_id>` url to make it display more.

This is only really a temporary 'fix' until the work is done to make it possible to easily see all the cases for a survey.  It should, however, reduce the ops burden for us until it's implemented.

# How to test?

# Trello
