### PR TITLE
fix url on case page

### DIFF
--- a/response_operations_ui/templates/response-status.html
+++ b/response_operations_ui/templates/response-status.html
@@ -93,7 +93,7 @@
                 })
             }}
             {% if is_case_complete %}
-                <a href="{{ request.referrer }}" id="close-response">Close</a>
+                <a href="{{ url_for('reporting_unit_bp.view_reporting_unit_survey', ru_ref=ru_ref, survey_id=survey_id) }}" id="close-response">Close</a>
             {% else %}
                 <form action="{{ url_for('case_bp.update_response_status', ru_ref=ru_ref, survey=survey_short_name, case_group_id=case_group_id, period=ce_period) }}" method="post" class="ons-u-mt-s">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
@@ -128,7 +128,7 @@
                         })
                     }}
                     <p>
-                        <a href="{{ request.referrer }}" id="cancel-change">Cancel</a>
+                        <a href="{{ url_for('reporting_unit_bp.view_reporting_unit_survey', ru_ref=ru_ref, survey_id=survey_id) }}">Cancel</a>
                     </p>
                 </form>
             {% endif %}

--- a/response_operations_ui/views/case.py
+++ b/response_operations_ui/views/case.py
@@ -81,6 +81,7 @@ def get_response_statuses(ru_ref, error=None):
         trading_as=reporting_unit["trading_as"],
         survey_short_name=format_short_name(survey["shortName"]),
         survey_ref=survey["surveyRef"],
+        survey_id=survey["id"],
         ce_period=period,
         allowed_transitions_for_case=allowed_transitions_for_case,
         case_group_status=map_ce_response_status(case_group_status),


### PR DESCRIPTION
# What and why?
There was a bug on response-ops where, if a user goes to the case details page for a reporting unit's survey and then refreshes the page, the `cancel` and `close` hyperlinks wouldn't work because they would redirect the user back to the same page. This PR fixes this by explicitly sending the user back to the reporting unit survey details page.

# How to test?
* Run acceptance tests.
* Access the case details page for a reporting unit's survey, refresh the page, and click on `cancel` or `close`. You should get redirected to the previous reporting units survey page without any errors.

# Trello
[Card](https://trello.com/c/xsTGUDP2)
