### PR TITLE
BUG - rOps sampled businesses display 500 error in RU tab

### DIFF
--- a/response_operations_ui/controllers/party_controller.py
+++ b/response_operations_ui/controllers/party_controller.py
@@ -10,7 +10,8 @@ from response_operations_ui.controllers.survey_controllers import get_survey_by_
 from response_operations_ui.exceptions.exceptions import (
     ApiError,
     SearchRespondentsException,
-    UpdateContactDetailsException,
+    UpdateContactDetailsException, 
+    RURetrievalError,
 )
 from response_operations_ui.forms import EditContactDetailsForm
 
@@ -36,7 +37,10 @@ def get_business_by_ru_ref(ru_ref: str):
     except requests.exceptions.HTTPError:
         log_level = logger.warning if response.status_code in (400, 404) else logger.exception
         log_level("Failed to retrieve reporting unit", ru_ref=ru_ref)
-        raise ApiError(response)
+        if response.status_code == 404:
+            raise RURetrievalError(response, ru_ref)
+        else:
+            raise ApiError(response)
 
     logger.info("Successfully retrieved reporting unit", ru_ref=ru_ref)
     return response.json()

--- a/response_operations_ui/exceptions/exceptions.py
+++ b/response_operations_ui/exceptions/exceptions.py
@@ -44,3 +44,11 @@ class NotifyError(Exception):
         self.error = error
         for k, v in kwargs.items():
             self.__dict__[k] = v
+
+
+class RURetrievalError(Exception):
+    def __init__(self, response, ru_ref):
+        self.ru_ref = ru_ref
+        self.url = response.url
+        self.status_code = response.status_code
+        self.message = response.text

--- a/response_operations_ui/templates/errors/ru-error.html
+++ b/response_operations_ui/templates/errors/ru-error.html
@@ -1,0 +1,17 @@
+{% extends "layouts/base.html" %}
+{% set page_title = "Failed to retrieve RU Ref - ONS Business Surveys" %}
+
+{% block main %}
+    <h1 class="ons-u-mt-m">Failed to retrieve RU Ref</h1>
+    {% call
+        onsPanel({
+            "type": "error",
+            "classes": "ons-u-mb-l"
+        })
+    %}
+      <p>We were unable to retrieve RU Ref {{ ru_ref }}. </p>
+      <p>Please try again after the survey has gone live.</p>
+      <p>You may want to visit the <a href="/">homepage</a></p>
+      <p>If you still encounter problems please <a href="/contact-us">contact us</a>. We apologise for any inconvenience this may have caused.</p>
+    {% endcall %}
+{% endblock main %}

--- a/response_operations_ui/views/errors.py
+++ b/response_operations_ui/views/errors.py
@@ -6,6 +6,7 @@ from structlog import wrap_logger
 from response_operations_ui.exceptions.exceptions import (
     ApiError,
     UpdateContactDetailsException,
+    RURetrievalError,
 )
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -50,3 +51,17 @@ def handle_authentication_error(error):
 def server_error(error):
     logger.exception("Generic exception generated", exc_info=error, url=request.url, status_code=500)
     return render_template("errors/500-error.html"), 500
+
+
+@error_bp.app_errorhandler(RURetrievalError)
+def api_error(error):
+    logger.error(
+        error.message,
+        url=request.url,
+        api_status_code=error.status_code,
+        api_url=error.url,
+    )
+    return render_template(
+        "errors/ru-error.html",
+        ru_ref=error.ru_ref,
+    )


### PR DESCRIPTION
# What and why?
An error has been found, where when a sample is loaded with a business that does not exist yet for a survey (before go live), the user searches for the RU ref and clicks the RU ref link. This is an unhelpful 500 error page. 

To create a better user experience, a new error page will be shown for this particular case.

# How to test?
1. Create a new CE
2. Load a sample file with a company RU ref that does not exist yet for a survey  
3. Don't set survey to live
4. Go into Reporting Units tab
5. Load RU of sampled, but not set ready for live business
6. Click on RU to load business details
7. A specific error page should be present for the failed RU ref

# Trello
https://trello.com/c/wB7Vtrxr/2071-bug-rops-sampled-businesses-display-500-error-in-ru-tab-track-time