### PR TITLE
Update text on 500 error page

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.9
+version: 3.0.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.9
+appVersion: 3.0.10

--- a/response_operations_ui/templates/errors/500-error.html
+++ b/response_operations_ui/templates/errors/500-error.html
@@ -11,6 +11,6 @@
     %}
         <p>Something has gone wrong with the website.</p>
         <p>You may want to visit the <a href="/">homepage</a></p>
-        <p>If you still encounter problems please <a href="/contact-us">contact us</a>. We apologise for any inconvenience this may have caused.</p>
+        <p>If you still encounter problems, please raise a service desk ticket.</p>
     {% endcall %}
 {% endblock main %}


### PR DESCRIPTION
# What and why?

The text on the 500 error page was wrong as there is no 'contact us' page in response ops for the internal users to use.

# How to test?

# Trello
