### PR TITLE
Add missing NoPermissionError to remaining pages

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.37
+version: 3.0.38
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.37
+appVersion: 3.0.38
 

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.38
+version: 3.0.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.38
+appVersion: 3.0.39
 

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.36
+version: 3.0.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.36
+appVersion: 3.0.37
 

--- a/response_operations_ui/views/admin/manage_user_accounts.py
+++ b/response_operations_ui/views/admin/manage_user_accounts.py
@@ -14,7 +14,7 @@ from flask_paginate import Pagination
 from requests import HTTPError
 from structlog import wrap_logger
 
-from response_operations_ui.common import token_decoder
+from response_operations_ui.common import token_decoder, uaa
 from response_operations_ui.controllers.notify_controller import NotifyController
 from response_operations_ui.controllers.uaa_controller import (
     add_group_membership,
@@ -25,9 +25,8 @@ from response_operations_ui.controllers.uaa_controller import (
     get_user_by_id,
     get_users_list,
     remove_group_membership,
-    user_has_permission,
 )
-from response_operations_ui.exceptions.exceptions import NoPermissionError, NotifyError
+from response_operations_ui.exceptions.exceptions import NotifyError
 from response_operations_ui.forms import (
     CreateAccountWithPermissionsForm,
     EditUserGroupsForm,
@@ -54,7 +53,7 @@ def manage_user_accounts():
     This endpoint, by design is only accessible to ROPs admin user.
     This endpoint lists all current user in the system.
     """
-    _verify_user_in_user_admin_group()
+    uaa.verify_permission("users.admin")
     page = request.values.get("page", "1")
     user_with_email = request.values.get("user_with_email", None)
     limit = 20
@@ -111,7 +110,7 @@ def manage_user_accounts():
 @admin_bp.route("/create-account", methods=["GET"])
 @login_required
 def get_create_account():
-    _verify_user_in_user_admin_group()
+    uaa.verify_permission("users.admin")
     form = CreateAccountWithPermissionsForm()
     return render_template("admin/user-create.html", form=form)
 
@@ -119,7 +118,7 @@ def get_create_account():
 @admin_bp.route("/create-account", methods=["POST"])
 @login_required
 def post_create_account():
-    _verify_user_in_user_admin_group()
+    uaa.verify_permission("users.admin")
     form = CreateAccountWithPermissionsForm(request.form)
 
     if not form.validate():
@@ -191,7 +190,7 @@ def post_create_account():
 @admin_bp.route("/manage-account/<user_id>", methods=["GET"])
 @login_required
 def get_manage_account_groups(user_id):
-    _verify_user_in_user_admin_group()
+    uaa.verify_permission("users.admin")
 
     logger.info("Attempting to get user by id", user_id=user_id)
     uaa_user = get_user_by_id(user_id)
@@ -213,7 +212,7 @@ def get_manage_account_groups(user_id):
 @admin_bp.route("/manage-account/<user_id>", methods=["POST"])
 @login_required
 def post_manage_account_groups(user_id):
-    _verify_user_in_user_admin_group()
+    uaa.verify_permission("users.admin")
 
     if user_id == session["user_id"]:
         flash("You cannot modify your own user account", "error")
@@ -283,7 +282,7 @@ def post_manage_account_groups(user_id):
 @admin_bp.route("/manage-account/<user_id>/delete", methods=["GET"])
 @login_required
 def get_delete_uaa_user(user_id):
-    _verify_user_in_user_admin_group()
+    uaa.verify_permission("users.admin")
 
     if user_id == session["user_id"]:
         flash("You cannot delete your own user account", "error")
@@ -303,7 +302,7 @@ def get_delete_uaa_user(user_id):
 @admin_bp.route("/manage-account/<user_id>/delete", methods=["POST"])
 @login_required
 def post_delete_uaa_user(user_id):
-    _verify_user_in_user_admin_group()
+    uaa.verify_permission("users.admin")
 
     if user_id == session["user_id"]:
         flash("You cannot delete your own user account", "error")
@@ -330,15 +329,6 @@ def post_delete_uaa_user(user_id):
     logger.info("User account deleted", administering_user_id=session["user_id"], user_id_deleted=user_id)
     flash("User account has been successfully deleted. An email to inform the user has been sent.")
     return redirect(url_for("admin_bp.manage_user_accounts"))
-
-
-def _verify_user_in_user_admin_group():
-    """
-    Checks if the user is in the 'users.admin' group and aborts with a 401 status code if the user
-    is not in the group.
-    """
-    if not user_has_permission("users.admin"):
-        raise NoPermissionError("users.admin")
 
 
 def _get_refine_user_list(users: list) -> list[dict]:

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -521,7 +521,7 @@ def _get_form_type(file_name):
 @collection_exercise_bp.route("/<short_name>/<period>/edit-collection-exercise-details", methods=["GET"])
 @login_required
 def view_collection_exercise_details(short_name, period):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     logger.info("Retrieving collection exercise data for form", short_name=short_name, period=period)
     ce_details = build_collection_exercise_details(short_name, period)
     form = EditCollectionExerciseDetailsForm(form=request.form)
@@ -546,7 +546,7 @@ def view_collection_exercise_details(short_name, period):
 @collection_exercise_bp.route("/<short_name>/<period>/edit-collection-exercise-details", methods=["POST"])
 @login_required
 def edit_collection_exercise_details(short_name, period):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     form = EditCollectionExerciseDetailsForm(form=request.form)
     if not form.validate():
         logger.info(
@@ -592,7 +592,7 @@ def edit_collection_exercise_details(short_name, period):
 @login_required
 def get_create_collection_exercise_form(survey_ref, short_name):
     previous_period = request.args.get("previous_period")
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     logger.info("Retrieving survey data for form", short_name=short_name, survey_ref=survey_ref)
     form = CreateCollectionExerciseDetailsForm(form=request.form)
 
@@ -608,7 +608,7 @@ def get_create_collection_exercise_form(survey_ref, short_name):
 @collection_exercise_bp.route("/<survey_ref>/<short_name>/create-collection-exercise", methods=["POST"])
 @login_required
 def create_collection_exercise(survey_ref, short_name):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     logger.info("Attempting to create collection exercise", survey_ref=survey_ref, survey=short_name)
     ce_form = CreateCollectionExerciseDetailsForm(form=request.form)
     survey_details = survey_controllers.get_survey(short_name)
@@ -670,7 +670,7 @@ def create_collection_exercise(survey_ref, short_name):
 @collection_exercise_bp.route("/<short_name>/<period>/<ce_id>/confirm-create-event/<tag>", methods=["GET"])
 @login_required
 def get_create_collection_event_form(short_name, period, ce_id, tag):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     logger.info(
         "Retrieving form for create collection exercise event",
         short_name=short_name,
@@ -715,7 +715,7 @@ def get_create_collection_event_form(short_name, period, ce_id, tag):
 @collection_exercise_bp.route("/<short_name>/<period>/<ce_id>/create-event/<tag>", methods=["POST", "GET"])
 @login_required
 def create_collection_exercise_event(short_name, period, ce_id, tag):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     if request.method == "GET":
         redirect(
             url_for(
@@ -824,7 +824,7 @@ def get_view_sample_ci(short_name, period):
 @collection_exercise_bp.route("/<short_name>/<period>/upload-sample-file", methods=["GET"])
 @login_required
 def get_upload_sample_file(short_name, period):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     ce_details = build_collection_exercise_details(short_name, period)
     ce_state = ce_details["collection_exercise"]["state"]
     ce_details["collection_exercise"]["state"] = map_collection_exercise_state(ce_state)  # NOQA
@@ -847,7 +847,7 @@ def get_upload_sample_file(short_name, period):
 @collection_exercise_bp.route("/<short_name>/<period>/upload-sample-file", methods=["POST"])
 @login_required
 def post_upload_sample_file(short_name, period):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     if _validate_sample():
         survey_id = survey_controllers.get_survey_id_by_short_name(short_name)
         exercises = collection_exercise_controllers.get_collection_exercises_by_survey(survey_id)
@@ -896,7 +896,7 @@ def get_confirm_remove_sample(short_name, period):
 @collection_exercise_bp.route("/<short_name>/<period>/confirm-remove-sample", methods=["POST"])
 @login_required
 def remove_loaded_sample(short_name, period):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     ce_details = build_collection_exercise_details(short_name, period)
     sample_summary_id = ce_details["sample_summary"]["id"]
     collection_exercise_id = ce_details["collection_exercise"]["id"]
@@ -981,7 +981,7 @@ def get_seft_collection_instrument(short_name, period):
 @collection_exercise_bp.route("/<short_name>/<period>/load-collection-instruments", methods=["POST"])
 @login_required
 def post_seft_collection_instrument(short_name, period):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     if "delete-ci" in request.form:
         return _delete_seft_collection_instrument(short_name, period)
     return _upload_seft_collection_instrument(short_name, period)

--- a/response_operations_ui/views/respondents.py
+++ b/response_operations_ui/views/respondents.py
@@ -11,6 +11,7 @@ from iso8601 import ParseError, parse_date
 from structlog import wrap_logger
 
 from response_operations_ui.common.respondent_utils import filter_respondents
+from response_operations_ui.common.uaa import verify_permission
 from response_operations_ui.controllers import (
     party_controller,
     reporting_units_controllers,
@@ -21,8 +22,6 @@ from response_operations_ui.controllers.party_controller import (
     delete_pending_surveys_by_batch_number,
     resend_pending_surveys_email,
 )
-from response_operations_ui.controllers.uaa_controller import user_has_permission
-from response_operations_ui.exceptions.exceptions import NoPermissionError
 from response_operations_ui.forms import EditContactDetailsForm, RespondentSearchForm
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -264,8 +263,7 @@ def ordinal_date_formatter(date_format_required: str, date_to_be_formatted: date
 @respondent_bp.route("/edit-contact-details/<respondent_id>", methods=["GET"])
 @login_required
 def view_contact_details(respondent_id):
-    if not user_has_permission("respondents.edit"):
-        raise NoPermissionError("respondents.edit")
+    verify_permission("respondents.edit")
     respondent_detail = party_controller.get_respondent_by_party_id(respondent_id)
 
     form = EditContactDetailsForm(form=request.form, default_values=respondent_detail)
@@ -282,8 +280,7 @@ def view_contact_details(respondent_id):
 @respondent_bp.route("/edit-contact-details/<respondent_id>", methods=["POST"])
 @login_required
 def edit_contact_details(respondent_id):
-    if not user_has_permission("respondents.edit"):
-        raise NoPermissionError("respondents.edit")
+    verify_permission("respondents.edit")
     edit_contact_details_form = EditContactDetailsForm(form=request.form)
     if not edit_contact_details_form.validate():
         contact_details = party_controller.get_respondent_by_party_id(respondent_id)
@@ -316,8 +313,7 @@ def edit_contact_details(respondent_id):
 @respondent_bp.route("/resend-verification/<respondent_id>", methods=["GET"])
 @login_required
 def view_resend_verification(respondent_id):
-    if not user_has_permission("respondents.edit"):
-        raise NoPermissionError("respondents.edit")
+    verify_permission("respondents.edit")
     logger.info("Re-send verification email requested", respondent_id=respondent_id)
     respondent = party_controller.get_respondent_by_party_id(respondent_id)
     is_new_email_verification_request = True if "pendingEmailAddress" in respondent else False
@@ -335,8 +331,7 @@ def view_resend_verification(respondent_id):
 @respondent_bp.route("/resend-verification/<party_id>", methods=["POST"])
 @login_required
 def resend_verification(party_id):
-    if not user_has_permission("respondents.edit"):
-        raise NoPermissionError("respondents.edit")
+    verify_permission("respondents.edit")
     form = request.form
     is_new_account_verification = True if form.get("change") == "new-account-email" else False
     respondent_controllers.resend_verification_email(party_id, is_new_account_verification)
@@ -354,8 +349,7 @@ def resend_verification(party_id):
 @respondent_bp.route("<respondent_id>/change-enrolment-status", methods=["POST"])
 @login_required
 def change_enrolment_status(respondent_id):
-    if not user_has_permission("respondents.edit"):
-        raise NoPermissionError("respondents.edit")
+    verify_permission("respondents.edit")
     reporting_units_controllers.change_enrolment_status(
         business_id=request.args["business_id"],
         respondent_id=respondent_id,
@@ -368,8 +362,7 @@ def change_enrolment_status(respondent_id):
 @respondent_bp.route("/<respondent_id>/change-respondent-status", methods=["POST"])
 @login_required
 def change_respondent_status(respondent_id):
-    if not user_has_permission("respondents.edit"):
-        raise NoPermissionError("respondents.edit")
+    verify_permission("respondents.edit")
     reporting_units_controllers.change_respondent_status(
         respondent_id=respondent_id, change_flag=request.args["change_flag"]
     )
@@ -381,8 +374,7 @@ def change_respondent_status(respondent_id):
 @respondent_bp.route("/<party_id>/change-respondent-status", methods=["GET"])
 @login_required
 def confirm_change_respondent_status(party_id):
-    if not user_has_permission("respondents.edit"):
-        raise NoPermissionError("respondents.edit")
+    verify_permission("respondents.edit")
     respondent = party_controller.get_respondent_by_party_id(party_id)
     return render_template(
         "confirm-respondent-status-change.html",
@@ -398,8 +390,7 @@ def confirm_change_respondent_status(party_id):
 @respondent_bp.route("/delete-respondent/<respondent_id>", methods=["GET", "POST"])
 @login_required
 def delete_respondent(respondent_id):
-    if not user_has_permission("respondents.delete"):
-        raise NoPermissionError("respondents.delete")
+    verify_permission("respondents.delete")
     respondent = party_controller.get_respondent_by_party_id(respondent_id)
 
     if request.method == "POST":
@@ -424,8 +415,7 @@ def delete_respondent(respondent_id):
 @respondent_bp.route("/undo-delete-respondent/<respondent_id>", methods=["GET", "POST"])
 @login_required
 def undo_delete_respondent(respondent_id):
-    if not user_has_permission("respondents.delete"):
-        raise NoPermissionError("respondents.delete")
+    verify_permission("respondents.delete")
     respondent = party_controller.get_respondent_by_party_id(respondent_id)
 
     if request.method == "POST":

--- a/response_operations_ui/views/surveys.py
+++ b/response_operations_ui/views/surveys.py
@@ -86,7 +86,7 @@ def view_survey(short_name):
 @surveys_bp.route("/edit-survey-details/<short_name>", methods=["GET"])
 @login_required
 def view_survey_details(short_name):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     survey_details = survey_controllers.get_survey(short_name)
     form = EditSurveyDetailsForm(form=request.form)
 
@@ -104,7 +104,7 @@ def view_survey_details(short_name):
 @surveys_bp.route("/edit-survey-details/<short_name>", methods=["POST", "GET"])
 @login_required
 def edit_survey_details(short_name):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     form = EditSurveyDetailsForm(form=request.form)
     if not form.validate():
         survey_details = survey_controllers.get_survey(short_name)
@@ -131,7 +131,7 @@ def edit_survey_details(short_name):
 @surveys_bp.route("/create", methods=["GET"])
 @login_required
 def show_create_survey():
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     form = CreateSurveyDetailsForm(form=request.form)
 
     return render_template("create-survey.html", form=form)
@@ -140,7 +140,7 @@ def show_create_survey():
 @surveys_bp.route("/create", methods=["POST"])
 @login_required
 def create_survey():
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     form = CreateSurveyDetailsForm(form=request.form)
     if not form.validate():
         return render_template("create-survey.html", form=form, errors=form.errors.items())
@@ -170,7 +170,7 @@ def create_survey():
 @surveys_bp.route("/<short_name>/link-collection-instrument", methods=["GET"])
 @login_required
 def get_link_collection_instrument(short_name):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     form = LinkCollectionInstrumentForm(form=request.form)
     short_name_lower = str(short_name).lower()
     survey_id = survey_controllers.get_survey_by_shortname(short_name_lower)["id"]
@@ -186,7 +186,7 @@ def get_link_collection_instrument(short_name):
 @surveys_bp.route("/<short_name>/link-collection-instrument", methods=["POST"])
 @login_required
 def post_link_collection_instrument(short_name):
-    verify_permission("surveys.edit", session)
+    verify_permission("surveys.edit")
     form = LinkCollectionInstrumentForm(form=request.form)
     eq_ci_selectors = []
     try:

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -121,6 +121,11 @@ user_permission_surveys_edit_json = {
     "groups": [{"value": "f385f89e-928f-4a0f-96a0-4c48d9007cc3", "display": "surveys.edit", "type": "DIRECT"}],
 }
 
+user_permission_messages_edit_json = {
+    "id": "5902656c-c41c-4b38-a294-0359e6aabe59",
+    "groups": [{"value": "f385f89e-928f-4a0f-96a0-4c48d9007cc3", "display": "messages.edit", "type": "DIRECT"}],
+}
+
 """Define URLS"""
 collection_exercise_root = f"{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises"
 url_ce_by_id = f"{collection_exercise_root}/{collection_exercise_id}"
@@ -2085,6 +2090,8 @@ class TestCollectionExercise(ViewTestCase):
 
     @requests_mock.mock()
     def test_upload_sample_page_no_survey_permission(self, mock_request):
+        # Sign in without correct permissions
+        sign_in_with_permission(self, mock_request, user_permission_messages_edit_json)
         mock_request.get(url_get_survey_by_short_name, json=self.eq_survey_dates)
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)
         mock_request.get(url_ce_by_id, json=collection_exercise_eq_both_ref_date["collection_exercise"])
@@ -2103,11 +2110,18 @@ class TestCollectionExercise(ViewTestCase):
 
         response = self.client.get(f"/surveys/{short_name}/{period}/upload-sample-file")
 
-        self.assertEqual(500, response.status_code)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "You do not have the required permission to "
+            "access this function under your current role profile".encode(),
+            response.data,
+        )
 
     @requests_mock.mock()
     @patch("response_operations_ui.views.collection_exercise.build_collection_exercise_details")
     def test_upload_sample_no_survey_permission(self, mock_request, mock_details):
+        # Sign in without correct permissions
+        sign_in_with_permission(self, mock_request, user_permission_messages_edit_json)
         post_data = {"sampleFile": (BytesIO(b"data"), "test.csv")}
 
         sample_data = {"id": sample_summary_id}
@@ -2125,18 +2139,30 @@ class TestCollectionExercise(ViewTestCase):
             f"/surveys/{short_name}/{period}/upload-sample-file", data=post_data, follow_redirects=True
         )
 
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "You do not have the required permission to "
+            "access this function under your current role profile".encode(),
+            response.data,
+        )
 
     @requests_mock.mock()
     @patch("response_operations_ui.views.collection_exercise.build_collection_exercise_details")
     def test_remove_loaded_sample_no_survey_permission(self, mock_request, mock_details):
+        # Sign in without correct permissions
+        sign_in_with_permission(self, mock_request, user_permission_messages_edit_json)
         mock_details.return_value = formatted_collection_exercise_details
         mock_request.delete(url_party_delete_attributes, status_code=204)
         mock_request.delete(url_ce_remove_sample, status_code=200)
         mock_request.delete(url_delete_sample_summary, status_code=204)
         response = self.client.post(f"/surveys/{short_name}/{period}/confirm-remove-sample", follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "You do not have the required permission to "
+            "access this function under your current role profile".encode(),
+            response.data,
+        )
 
     @requests_mock.mock()
     @patch("response_operations_ui.views.collection_exercise.build_collection_exercise_details")
@@ -2157,6 +2183,8 @@ class TestCollectionExercise(ViewTestCase):
     @requests_mock.mock()
     @patch("response_operations_ui.views.collection_exercise.build_collection_exercise_details")
     def test_load_ci_load_collection_instrument_page_no_survey_permission(self, mock_request, mock_details):
+        # Sign in without correct permissions
+        sign_in_with_permission(self, mock_request, user_permission_messages_edit_json)
         post_data = {"ciFile": (BytesIO(b"data"), "064_201803_0001.xlsx"), "load-ci": ""}
         mock_request.post(url_collection_instrument, status_code=201)
         mock_request.get(url_ces_by_survey, json=exercise_data)
@@ -2167,11 +2195,18 @@ class TestCollectionExercise(ViewTestCase):
             f"/surveys/{short_name}/{period}/load-collection-instruments", data=post_data, follow_redirects=True
         )
 
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "You do not have the required permission to "
+            "access this function under your current role profile".encode(),
+            response.data,
+        )
 
     @requests_mock.mock()
     @patch("response_operations_ui.views.collection_exercise.build_collection_exercise_details")
     def test_remove_ci_load_collection_instrument_page_no_survey_permission(self, mock_request, mock_details):
+        # Sign in without correct permissions
+        sign_in_with_permission(self, mock_request, user_permission_messages_edit_json)
         post_data = {
             "ci_id": collection_instrument_id,
             "ce_id": collection_exercise_id,
@@ -2185,8 +2220,12 @@ class TestCollectionExercise(ViewTestCase):
             f"/surveys/{short_name}/{period}/load-collection-instruments", data=post_data, follow_redirects=True
         )
 
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("Something has gone wrong with the website".encode(), response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "You do not have the required permission to "
+            "access this function under your current role profile".encode(),
+            response.data,
+        )
 
     @requests_mock.mock()
     def test_collection_exercise_no_survey_edit_permission(self, mock_request):


### PR DESCRIPTION
# What and why?

In https://github.com/ONSdigital/response-operations-ui/pull/826 there was a 'no access' page added for users accessing pages they didn't have permission for.  Because we had 2 different ways to check permissions, only half of the permission locked pages got this.  With this PR, all of the pages now function in the same way and all of them check permissions in the same way too for consistency.

# How to test?

# Trello
