### PR TITLE
Add Link collection instruments for EQ and SEFT on survey page

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.1
+version: 3.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.1
+appVersion: 3.1.2

--- a/response_operations_ui/templates/survey.html
+++ b/response_operations_ui/templates/survey.html
@@ -29,7 +29,7 @@
     {% if collection_exercises|length > 0 %}
     <section class="ce-list">
         {% if surveyEditPermission %}
-            {% if survey.surveyMode == 'EQ' %}
+            {% if survey.surveyMode in ['EQ', 'EQ_AND_SEFT'] %}
                 <p class="ons-field">
                     {{
                         onsButton({


### PR DESCRIPTION
# What and why?
EQ_AND_SEFT currently doesn't show the Link collection instrument on the survey page, this adds it
# How to test?
Make sure the button appears for EQ_AND_SEFT and EQ, but not SEFT
# Trello
