### PR TITLE
Add total CI count to CE

### DIFF
--- a/config.py
+++ b/config.py
@@ -100,7 +100,7 @@ class Config(object):
 
     TEST_MODE = strtobool(os.getenv("TEST_MODE", "False"))
     WTF_CSRF_ENABLED = strtobool(os.getenv("WTF_CSRF_ENABLED", "True"))
-    MULTI_MODE_ENABLED = strtobool(os.getenv("MULTI_MODE_ENABLED", "True"))
+    MULTI_MODE_ENABLED = strtobool(os.getenv("MULTI_MODE_ENABLED", "False"))
 
 
 class DevelopmentConfig(Config):

--- a/config.py
+++ b/config.py
@@ -100,7 +100,7 @@ class Config(object):
 
     TEST_MODE = strtobool(os.getenv("TEST_MODE", "False"))
     WTF_CSRF_ENABLED = strtobool(os.getenv("WTF_CSRF_ENABLED", "True"))
-    MULTI_MODE_ENABLED = strtobool(os.getenv("MULTI_MODE_ENABLED", "False"))
+    MULTI_MODE_ENABLED = strtobool(os.getenv("MULTI_MODE_ENABLED", "True"))
 
 
 class DevelopmentConfig(Config):

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -6,13 +6,13 @@ import redis
 from flask import Flask, flash, redirect, session, url_for
 from flask_assets import Environment
 from flask_login import LoginManager
+from flask_session import Session
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFError, CSRFProtect
 from jinja2 import ChainableUndefined
 from structlog import wrap_logger
 
 from config import Config
-from flask_session import Session
 from response_operations_ui.common.jinja_filters import filter_blueprint
 from response_operations_ui.controllers.uaa_controller import user_has_permission
 from response_operations_ui.logger_config import logger_initial_config

--- a/response_operations_ui/__init__.py
+++ b/response_operations_ui/__init__.py
@@ -6,13 +6,13 @@ import redis
 from flask import Flask, flash, redirect, session, url_for
 from flask_assets import Environment
 from flask_login import LoginManager
-from flask_session import Session
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFError, CSRFProtect
 from jinja2 import ChainableUndefined
 from structlog import wrap_logger
 
 from config import Config
+from flask_session import Session
 from response_operations_ui.common.jinja_filters import filter_blueprint
 from response_operations_ui.controllers.uaa_controller import user_has_permission
 from response_operations_ui.logger_config import logger_initial_config

--- a/response_operations_ui/templates/admin/manage-account.html
+++ b/response_operations_ui/templates/admin/manage-account.html
@@ -230,9 +230,6 @@
                     <span class="ons-btn__inner">Cancel</span></a>
             </div>
           </div>
-          <div class="ons-u-mt-xl">
-            <a href=" {{ url_for('admin_bp.get_delete_uaa_user', user_id=user_id) }}">Delete user account</a>
-          </div>
         </section>
     </form>
 {% endblock %}

--- a/response_operations_ui/templates/admin/manage-account.html
+++ b/response_operations_ui/templates/admin/manage-account.html
@@ -230,6 +230,9 @@
                     <span class="ons-btn__inner">Cancel</span></a>
             </div>
           </div>
+          <div class="ons-u-mt-xl">
+            <a href=" {{ url_for('admin_bp.get_delete_uaa_user', user_id=user_id) }}">Delete user account</a>
+          </div>
         </section>
     </form>
 {% endblock %}

--- a/response_operations_ui/templates/admin/manage-user-accounts.html
+++ b/response_operations_ui/templates/admin/manage-user-accounts.html
@@ -109,7 +109,7 @@
                         "value": "Last name",
                     },
                     { 
-                        "value": ""
+                        "value": " "
                     }
                 ]
                 }
@@ -130,8 +130,8 @@
                                 "value": user.lastname,
                             },
                             {
-                                "value": '<a href="' + url_for("admin_bp.get_manage_account_groups", user_id=user.id) + '">Edit or delete user account </a>' if user.show_edit_button else "",
-                                "class": "ons-u-ta-right"
+                                "value": '<a href="' + url_for("admin_bp.get_manage_account_groups", user_id=user.id) + '" > Edit</a>' + '<a style="text-decoration: none"> | </a>' + '<a href="' + url_for("admin_bp.get_delete_uaa_user", user_id=user.id) + '"> Delete </a>' if user.show_edit_button else "", 
+                                "class": "ons-u-ta-right",
                             },
                         ]
                     }

--- a/response_operations_ui/templates/admin/manage-user-accounts.html
+++ b/response_operations_ui/templates/admin/manage-user-accounts.html
@@ -131,7 +131,7 @@
                             },
                             {
                                 "value": '<a href="' + url_for("admin_bp.get_manage_account_groups", user_id=user.id) + '" > Edit</a>' + '<a style="text-decoration: none"> | </a>' + '<a href="' + url_for("admin_bp.get_delete_uaa_user", user_id=user.id) + '"> Delete </a>' if user.show_edit_button else "", 
-                                "class": "ons-u-ta-right",
+                                "tdClasses": "ons-u-ta-right",
                             },
                         ]
                     }

--- a/response_operations_ui/templates/admin/user-delete.html
+++ b/response_operations_ui/templates/admin/user-delete.html
@@ -24,10 +24,6 @@
                   "submitType": "timer"
               })
           }}
-            <div class="ons-grid__col ons-u-ml-s">
-                <a href="{{ url_for('admin_bp.manage_user_accounts') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary" id="btn-option-cancel">
-                    <span class="ons-btn__inner">Cancel</span></a>
-            </div>
           </div>
         </div>
     </form>

--- a/response_operations_ui/templates/admin/user-delete.html
+++ b/response_operations_ui/templates/admin/user-delete.html
@@ -24,11 +24,10 @@
                   "submitType": "timer"
               })
           }}
-          </div>
-          <div class="ons-grid__col ons-u-ml-s">
-            <a href="{{ url_for('admin_bp.get_manage_account_groups', user_id=user_id) }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary" id="btn-option-cancel">
-              <span class="ons-btn__inner">Cancel</span>
-            </a>
+            <div class="ons-grid__col ons-u-ml-s">
+                <a href="{{ url_for('admin_bp.manage_user_accounts') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary" id="btn-option-cancel">
+                    <span class="ons-btn__inner">Cancel</span></a>
+            </div>
           </div>
         </div>
     </form>

--- a/response_operations_ui/templates/admin/user-delete.html
+++ b/response_operations_ui/templates/admin/user-delete.html
@@ -25,11 +25,10 @@
               })
           }}
           </div>
-          <div class="ons-grid__col ons-u-ml-s">
-            <a href="{{ url_for('admin_bp.get_manage_account_groups', user_id=user_id) }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary" id="btn-option-cancel">
-              <span class="ons-btn__inner">Cancel</span>
-            </a>
-          </div>
+            <div class="ons-grid__col ons-u-ml-s">
+                <a href="{{ url_for('admin_bp.manage_user_accounts') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary" id="btn-option-cancel">
+                    <span class="ons-btn__inner">Cancel</span></a>
+            </div>
         </div>
     </form>
 {% endblock %}

--- a/response_operations_ui/templates/admin/user-delete.html
+++ b/response_operations_ui/templates/admin/user-delete.html
@@ -25,6 +25,11 @@
               })
           }}
           </div>
+          <div class="ons-grid__col ons-u-ml-s">
+            <a href="{{ url_for('admin_bp.get_manage_account_groups', user_id=user_id) }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary" id="btn-option-cancel">
+              <span class="ons-btn__inner">Cancel</span>
+            </a>
+          </div>
         </div>
     </form>
 {% endblock %}

--- a/response_operations_ui/templates/collection_exercise/ce-ci-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-ci-section.html
@@ -8,7 +8,20 @@
           section. "
       })
     }}
+  {% set tblHeaders =
+    [
+              {
+              "value": "",
+              },
+              { 
+                    "value":'<em>' + "Total CI " + '(' + total_ci_count + ')' '</em>',
+                    "thClasses": "ons-u-fs-r--b",
+              },
+    ]
+    %}
+  
     {% set  collectionInstrumentTableData = {
+        "ths": tblHeaders,
         "variants": ['compact', 'responsive'],
         "id": "collection-instrument-table",
         "caption": 'Collection Instruments',

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -160,11 +160,7 @@ def view_collection_exercise(short_name, period):
         ce_details["survey"]["shortName"],
         ce_details["collection_exercise"]["exerciseRef"],
     )
-    
-    total_ci_count = 0
-    for ci in ci_table_context:
-        total_ci_count += int(ci['count'])
-    total_ci_count = str(total_ci_count)
+    total_ci_count = get_total_ci_count(ci_table_context)
 
     return render_template(
         "collection_exercise/collection-exercise.html",
@@ -184,6 +180,12 @@ def view_collection_exercise(short_name, period):
         info_panel=info_panel,
         total_ci_count=total_ci_count,
     )
+
+def get_total_ci_count(ci_table_context):
+    total_count = 0
+    for ci in ci_table_context:
+        total_count += int(ci['count'])
+    return str(total_count)
 
 
 def _build_ci_table_context(ci: dict, locked: bool, survey_mode: str, short_name: str, exercise_ref: str) -> list:

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -160,6 +160,11 @@ def view_collection_exercise(short_name, period):
         ce_details["survey"]["shortName"],
         ce_details["collection_exercise"]["exerciseRef"],
     )
+    
+    total_ci_count = 0
+    for ci in ci_table_context:
+        total_ci_count += int(ci['count'])
+    total_ci_count = str(total_ci_count)
 
     return render_template(
         "collection_exercise/collection-exercise.html",
@@ -177,6 +182,7 @@ def view_collection_exercise(short_name, period):
         validation_failed=validation_failed,
         show_msg=show_msg,
         info_panel=info_panel,
+        total_ci_count=total_ci_count,
     )
 
 

--- a/tests/views/test_admin.py
+++ b/tests/views/test_admin.py
@@ -133,7 +133,8 @@ class TestMessage(ViewTestCase):
         self.assertIn("Create new user account".encode(), response.data)
         self.assertIn("Andy0".encode(), response.data)
         self.assertIn("Johnson".encode(), response.data)
-        self.assertIn("Edit or delete user account".encode(), response.data)
+        self.assertIn("Edit".encode(), response.data)
+        self.assertIn("Delete".encode(), response.data)
         self.assertIn("Andy0.Smith@ons.gov.uk".encode(), response.data)
         self.assertIn("Page 1 of 26".encode(), response.data)
 
@@ -149,7 +150,8 @@ class TestMessage(ViewTestCase):
         self.assertIn("Create new user account".encode(), response.data)
         self.assertNotIn("Andy0".encode(), response.data)
         self.assertNotIn("Johnson".encode(), response.data)
-        self.assertIn("Edit or delete user account".encode(), response.data)
+        self.assertIn("Edit".encode(), response.data)
+        self.assertIn("Delete".encode(), response.data)
         self.assertNotIn("Andy0.Smith@ons.gov.uk".encode(), response.data)
         self.assertNotIn("Page 1 of 26".encode(), response.data)
         self.assertIn("Andy155.Smith@ons.gov.uk".encode(), response.data)
@@ -185,7 +187,8 @@ class TestMessage(ViewTestCase):
         self.assertIn("Create new user account".encode(), response.data)
         self.assertIn("Andy0".encode(), response.data)
         self.assertIn("Johnson".encode(), response.data)
-        self.assertIn("Edit or delete user account".encode(), response.data)
+        self.assertIn("Edit".encode(), response.data)
+        self.assertIn("Delete".encode(), response.data)
         self.assertIn("Andy0.Smith@ons.gov.uk".encode(), response.data)
         self.assertIn("Page 1 of 26".encode(), response.data)
         self.assertIn("Andy155.Smith@ons.gov.uk".encode(), response.data)
@@ -296,11 +299,11 @@ class TestMessage(ViewTestCase):
         self.assertEqual(200, response.status_code)
         self.assertIn("Select user permissions".encode(), response.data)
         self.assertIn("ONS User".encode(), response.data)
-        self.assertIn("Delete user account".encode(), response.data)
 
         # Check we're not on manage account page
         self.assertNotIn("Create new user account".encode(), response.data)
-        self.assertNotIn("Edit or delete user account".encode(), response.data)
+        self.assertNotIn("First name".encode(), response.data)
+        self.assertNotIn("Last name".encode(), response.data)
 
     @requests_mock.mock()
     def test_edit_account_get_fail_own_id(self, mock_request):


### PR DESCRIPTION
# What and why?
This PR adds the total collection instrument count to the collection instrument section of a collection exercise. After the introduction of multimode we need to be able to display a total count of collection instruments both of EQ and SEFT.
# How to test?
Set survey mode to EQ AND SEFT.
Navigate to the collection exercise page and upload both EQ and SEFT collection instruments.
Check the Total count is displayed correctly, reflecting the combined total of all collection instruments.
Check EQ Collection exercises and SEFT collection exercises also display a total count. 
# Jira
https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=1493&projectKey=RAS&view=detail&selectedIssue=RAS-680