### PR TITLE
Extend collection instrument error message and add tests

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.6
+version: 3.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.6
+appVersion: 3.1.7

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.5
+version: 3.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.5
+appVersion: 3.1.6

--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -44,14 +44,16 @@ def upload_collection_instrument(collection_exercise_id, file, form_type=None):
             form_type=form_type,
             status=response.status_code,
         )
-        return False
+        if response.headers["Content-Type"] == "application/json":
+            return False, response.json().get("errors")[0]
+        return False, None
 
     logger.info(
         "Successfully uploaded collection instrument",
         collection_exercise_id=collection_exercise_id,
         form_type=form_type,
     )
-    return True
+    return True, None
 
 
 def upload_ru_specific_collection_instrument(collection_exercise_id, file, ru_ref):

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -374,7 +374,6 @@ def _upload_seft_collection_instrument(short_name, period):
         if not exercise:
             return make_response(jsonify({"message": "Collection exercise not found"}), 404)
 
-        error_text = None
         if is_ru_specific_instrument:
             ru_ref = file.filename.split(".")[0]
             upload_success, error_text = collection_instrument_controllers.upload_ru_specific_collection_instrument(
@@ -382,7 +381,7 @@ def _upload_seft_collection_instrument(short_name, period):
             )
         else:
             form_type = _get_form_type(file.filename)
-            upload_success = collection_instrument_controllers.upload_collection_instrument(
+            upload_success, error_text = collection_instrument_controllers.upload_collection_instrument(
                 exercise["id"], file, form_type
             )
 

--- a/tests/controllers/test_collection_instrument_controller.py
+++ b/tests/controllers/test_collection_instrument_controller.py
@@ -119,7 +119,9 @@ class TestCollectionInstrumentController(unittest.TestCase):
             rsps.add(rsps.POST, ci_upload_url, status=401)
             with self.app.app_context():
                 file = self.create_test_file()
-                self.assertFalse(upload_collection_instrument(collection_exercise_id, file))
+                upload_success, error_text = upload_collection_instrument(collection_exercise_id, file)
+                self.assertFalse(upload_success)
+                self.assertEqual(error_text, None)
 
     def test_upload_collection_instrument_failure(self):
         """Tests on failure (500) False is returned"""
@@ -127,7 +129,9 @@ class TestCollectionInstrumentController(unittest.TestCase):
             rsps.add(rsps.POST, ci_upload_url, status=500, json={"errors": ["Failed to publish upload message"]})
             with self.app.app_context():
                 file = self.create_test_file()
-                self.assertFalse(upload_collection_instrument(collection_exercise_id, file))
+                upload_success, error_text = upload_collection_instrument(collection_exercise_id, file)
+                self.assertFalse(upload_success)
+                self.assertEqual(error_text, "Failed to publish upload message")
 
     def test_link_collection_instrument(self):
         """Tests on success (200) True is returned"""


### PR DESCRIPTION
# What and why?
This PR allows the message from CI upload to be displayed, it also adds a missing test
# How to test?
Test in conjunction with https://github.com/ONSdigital/ras-collection-instrument/pull/297
# Trello
