### PR TITLE
Remove intermediary seft upload page

### DIFF
--- a/config.py
+++ b/config.py
@@ -100,7 +100,7 @@ class Config(object):
 
     TEST_MODE = strtobool(os.getenv("TEST_MODE", "False"))
     WTF_CSRF_ENABLED = strtobool(os.getenv("WTF_CSRF_ENABLED", "True"))
-    MULTI_MODE_ENABLED = strtobool(os.getenv("MULTI_MODE_ENABLED", "True"))
+    MULTI_MODE_ENABLED = strtobool(os.getenv("MULTI_MODE_ENABLED", "False"))
 
 
 class DevelopmentConfig(Config):

--- a/config.py
+++ b/config.py
@@ -100,7 +100,7 @@ class Config(object):
 
     TEST_MODE = strtobool(os.getenv("TEST_MODE", "False"))
     WTF_CSRF_ENABLED = strtobool(os.getenv("WTF_CSRF_ENABLED", "True"))
-    MULTI_MODE_ENABLED = strtobool(os.getenv("MULTI_MODE_ENABLED", "False"))
+    MULTI_MODE_ENABLED = strtobool(os.getenv("MULTI_MODE_ENABLED", "True"))
 
 
 class DevelopmentConfig(Config):

--- a/response_operations_ui/templates/ce-seft-instrument.html
+++ b/response_operations_ui/templates/ce-seft-instrument.html
@@ -65,7 +65,7 @@
                             "classes": cancelClasses,
                             "variants": ['secondary'],
                             "name": "load-ci-cancel",
-                            "url": url_for('collection_exercise_bp.get_view_sample_ci', short_name=survey.shortName, period=ce.exerciseRef, survey_mode='SEFT'),
+                            "url": url_for('collection_exercise_bp.view_collection_exercise', short_name=survey.shortName, period=ce.exerciseRef),
                             "submitType": "timer",
                             "noIcon": "true"
                         })
@@ -149,7 +149,7 @@
                     "id": "btn-upload-ci-done",
                     "variants": primary,
                     "name": "load-ci-done",
-                    "url": url_for('collection_exercise_bp.get_view_sample_ci', short_name=survey.shortName, period=ce.exerciseRef, survey_mode='SEFT'),
+                    "url": url_for('collection_exercise_bp.view_collection_exercise', short_name=survey.shortName, period=ce.exerciseRef),
                     "submitType": "timer",
                     "noIcon": "true"
                 })

--- a/response_operations_ui/templates/collection_exercise/ce-ci-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-ci-section.html
@@ -61,7 +61,7 @@
                     "tdClasses": "ons-u-ta-centre"
                   }, 
                   {
-                    "value": '<a id="seft-upload-link" href="' + url_for('collection_exercise_bp.get_seft_collection_instrument', period=ce.exerciseRef, short_name=survey.shortName.replace(' ', '')) + '">' + ci_type.link_text + '</a>',
+                    "value": '<a href="' + url_for('collection_exercise_bp.get_seft_collection_instrument', period=ce.exerciseRef, short_name=survey.shortName.replace(' ', '')) + '" id="seft-upload-link">' + ci_type.link_text + '</a>',
                     "tdClasses": "ons-u-ta-right"
                   }
                 ] 

--- a/response_operations_ui/templates/collection_exercise/ce-ci-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-ci-section.html
@@ -28,9 +28,8 @@
         %}
     {% do collectionInstrumentTableData | setAttribute("ths", tblHeaders) %}
   {% endif %}
-  
     {% for ci_type in ci_table_context["ci_details"] %}
-      {% if survey["surveyMode"] == "EQ" %}
+      {% if ci_type.type == "eq" %}
         {% do collectionInstrumentTableDataRows.append(
             {
                 "tds": [
@@ -50,7 +49,7 @@
         )
         %}
       {% endif %}
-      {% if survey["surveyMode"] == "SEFT" %}
+      {% if ci_type.type == "seft" %}
         {% do collectionInstrumentTableDataRows.append(
             {
                 "tds": [

--- a/response_operations_ui/templates/collection_exercise/ce-ci-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-ci-section.html
@@ -30,24 +30,46 @@
   {% endif %}
   
     {% for ci_type in ci_table_context["ci_details"] %}
-      {% do collectionInstrumentTableDataRows.append(
-          {
-              "tds": [
-                {
-                  "value": ci_type.title
-                },
-                {
-                  "value": ci_type.count,
-                  "tdClasses": "ons-u-ta-centre"
-                }, 
-                {
-                  "value": '<a href="' + ci_type.url + '" id="view-add-upload-ci-' + ci_type.type + '">' + ci_type.link_text + '</a>',
-                  "tdClasses": "ons-u-ta-right"
-                }
-              ] 
-          }
-      )
-    %}
+      {% if survey["surveyMode"] == "EQ" %}
+        {% do collectionInstrumentTableDataRows.append(
+            {
+                "tds": [
+                  {
+                    "value": ci_type.title
+                  },
+                  {
+                    "value": ci_type.count,
+                    "tdClasses": "ons-u-ta-centre"
+                  }, 
+                  {
+                    "value": '<a href="' + ci_type.url + '" id="view-add-upload-ci-' + ci_type.type + '">' + ci_type.link_text + '</a>',
+                    "tdClasses": "ons-u-ta-right"
+                  }
+                ] 
+            }
+        )
+        %}
+      {% endif %}
+      {% if survey["surveyMode"] == "SEFT" %}
+        {% do collectionInstrumentTableDataRows.append(
+            {
+                "tds": [
+                  {
+                    "value": ci_type.title
+                  },
+                  {
+                    "value": ci_type.count,
+                    "tdClasses": "ons-u-ta-centre"
+                  }, 
+                  {
+                    "value": '<a id="seft-upload-link" href="' + url_for('collection_exercise_bp.get_seft_collection_instrument', period=ce.exerciseRef, short_name=survey.shortName.replace(' ', '')) + '">' + ci_type.link_text + '</a>',
+                    "tdClasses": "ons-u-ta-right"
+                  }
+                ] 
+            }
+        )
+        %}
+      {% endif %}
     {% endfor %}
     {% do collectionInstrumentTableData | setAttribute("trs", collectionInstrumentTableDataRows) %}
     {{ onsTable(collectionInstrumentTableData) }}

--- a/response_operations_ui/templates/collection_exercise/ce-collection-instrument-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-collection-instrument-section.html
@@ -1,55 +1,5 @@
 <section class="ce-section {{'ons-panel ons-panel--simple ons-panel--error' if missing_ci else ''}} ons-u-pt-m ons-u-mb-l ons-u-mt-M">
     {% set surveyEditPermission = hasPermission('surveys.edit') %}
-    {% if surveyEditPermission %}
-        {% set linkText = 'Upload SEFT files' %}
-    {% else %}
-        {% set linkText = 'View SEFT files' %}
-    {% endif %}
-        {% if request.args.get('survey_mode') == "SEFT" %}
-            {{
-                onsTable({
-                    "variants": ['compact', 'responsive'],
-                    "id": "collection-instruments-table",
-                    "caption": 'Collection instruments',
-                    "hideCaption": true,
-                    "ths": [
-                        { 
-                            "value": "Collection instruments library",
-                            "thClasses": "ons-u-fs-r--b"
-                        },
-                        {
-                            "value": "Selected files",
-                            "thClasses": "ons-u-fs-r--b"
-                        },
-                        {
-                            "value": " ",
-                            "thClasses": "ons-u-ta"
-                        }
-                    ],
-                    "trs": [
-                        {
-                            "tds": [
-                                {
-                                    "value": "SEFT collection instruments",
-                                    "tdClasses": "ons-u-ta"
-                                },
-                                {
-                                    "value": collection_instruments["SEFT"]|length|string,
-                                    "name": "total-instruments",
-                                    "tdClasses": "ons-u-ta"
-                                },
-                                {
-                                    "value": '<a id="seft-upload-link" href="' + url_for('collection_exercise_bp.get_seft_collection_instrument', period=ce.exerciseRef, short_name=survey.shortName.replace(' ', '')) + '">' + linkText + '</a>',
-                                    "name": "upload-seft-instruments",
-                                    "tdClasses": "ons-u-ta-right"
-                                }
-                            ]
-                        }
-                    ]
-                })
-            }}
-        {% endif %}
-      
         {% if request.args.get('survey_mode') == "EQ" %}
             {% if collection_instruments %}
                 {% set surveyTableDataHeader = [] %}

--- a/response_operations_ui/templates/collection_exercise/ce-view-sample-ci.html
+++ b/response_operations_ui/templates/collection_exercise/ce-view-sample-ci.html
@@ -16,11 +16,7 @@
     {% include 'partials/flashed-messages.html' %}
     <div class="ons-grid ons-grid--gutterless">
         {% include 'partials/error-box.html' %}
-        {% if survey.surveyMode == 'EQ' %}
           <h1 name="page-ce-title">Select collection instruments</h1>
-        {% else %}
-          <h1 name="page-ce-title">Load collection instruments</h1>
-        {% endif %}
         <div class="ons-grid__col ons-col-7@l">
             {% include 'collection_exercise/ce-collection-instrument-section.html' %}
             {{

--- a/response_operations_ui/templates/collection_exercise/ce-view-sample-ci.html
+++ b/response_operations_ui/templates/collection_exercise/ce-view-sample-ci.html
@@ -16,12 +16,7 @@
     {% include 'partials/flashed-messages.html' %}
     <div class="ons-grid ons-grid--gutterless">
         {% include 'partials/error-box.html' %}
-        {% if survey.surveyMode == 'EQ' %}
-          <h1 name="page-ce-title">Select collection instruments</h1>
-        {% else %}
-          <h1 name="page-ce-title">Load collection instruments</h1>
-        {% endif %}
-          <h1 name="page-ce-title">Select collection instruments</h1>
+        <h1 name="page-ce-title">Select collection instruments</h1>
         <div class="ons-grid__col ons-col-7@l">
             {% include 'collection_exercise/ce-collection-instrument-section.html' %}
             {{

--- a/response_operations_ui/templates/collection_exercise/ce-view-sample-ci.html
+++ b/response_operations_ui/templates/collection_exercise/ce-view-sample-ci.html
@@ -16,6 +16,11 @@
     {% include 'partials/flashed-messages.html' %}
     <div class="ons-grid ons-grid--gutterless">
         {% include 'partials/error-box.html' %}
+        {% if survey.surveyMode == 'EQ' %}
+          <h1 name="page-ce-title">Select collection instruments</h1>
+        {% else %}
+          <h1 name="page-ce-title">Load collection instruments</h1>
+        {% endif %}
           <h1 name="page-ce-title">Select collection instruments</h1>
         <div class="ons-grid__col ons-col-7@l">
             {% include 'collection_exercise/ce-collection-instrument-section.html' %}

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -190,7 +190,7 @@ def _build_ci_table_context(ci: dict, locked: bool, survey_mode: str, short_name
     total_ci_count = 0
     for survey_mode_type in required_survey_mode_types:
         ci_count = len(ci.get(survey_mode_type, []))
-        ci_table_state_text = "no_instrument" if ci_count == 0 else ci_table_state_text
+        ci_table_state_text = "no_instrument" if ci_count == 0 and user_has_permission("surveys.edit") else ci_table_state_text
         ci_details.append(
             {
                 "type": survey_mode_type.lower(),

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -2074,7 +2074,7 @@ class TestCollectionExercise(ViewTestCase):
         self.assertIn("Done".encode(), response.data)
 
     @requests_mock.mock()
-    def test_seft_loaded_sample_view_sample_ci_page_survey_permission(self, mock_request):
+    def test_seft_loaded_load_collection_instruments_page_survey_permission(self, mock_request):
         sign_in_with_permission(self, mock_request, user_permission_surveys_edit_json)
         mock_request.get(url_get_survey_by_short_name, json=self.seft_survey)
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)
@@ -2091,15 +2091,16 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.get(url_link_sample, json=[sample_summary_id])
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
 
-        response = self.client.get(f"/surveys/{short_name}/{period}/view-sample-ci?survey_mode=SEFT")
+        response = self.client.get(f"/surveys/{short_name}/{period}/load-collection-instruments")
 
         self.assertEqual(200, response.status_code)
-        self.assertIn("SEFT collection instruments".encode(), response.data)
+        self.assertIn("Load Collection instruments for".encode(), response.data)
         self.assertIn("Upload SEFT files".encode(), response.data)
-        self.assertIn("Done".encode(), response.data)
+        self.assertIn("File types accepted are .xls and .xlsx".encode(), response.data)
+        self.assertIn("Upload".encode(), response.data)
 
     @requests_mock.mock()
-    def test_seft_loaded_sample_view_sample_ci_page_no_survey_permission(self, mock_request):
+    def test_seft_loaded_load_collection_instrument_page_no_survey_permission(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, json=self.seft_survey)
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)
         mock_request.get(url_ce_by_id, json=collection_exercise_details["collection_exercise"])
@@ -2115,11 +2116,11 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.get(url_link_sample, json=[sample_summary_id])
         mock_request.get(url_get_sample_summary, json=self.sample_summary)
 
-        response = self.client.get(f"/surveys/{short_name}/{period}/view-sample-ci?survey_mode=SEFT")
+        response = self.client.get(f"/surveys/{short_name}/{period}/load-collection-instruments")
 
         self.assertEqual(200, response.status_code)
-        self.assertIn("SEFT collection instruments".encode(), response.data)
-        self.assertIn("View SEFT files".encode(), response.data)
+        self.assertIn("Load Collection instruments for".encode(), response.data)
+        self.assertIn("SEFT collection instruments uploaded".encode(), response.data)
         self.assertIn("Done".encode(), response.data)
 
     @requests_mock.mock()

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -2023,7 +2023,7 @@ class TestCollectionExercise(ViewTestCase):
         self.assertNotIn("Upload sample file".encode(), response.data)
 
     @requests_mock.mock()
-    def test_seft_view_sample_ci_page_survey_permission(self, mock_request):
+    def test_seft_load_collection_instruments_survey_permission(self, mock_request):
         sign_in_with_permission(self, mock_request, user_permission_surveys_edit_json)
         mock_request.get(url_get_survey_by_short_name, json=self.seft_survey)
         mock_request.get(url_ces_by_survey, json=self.collection_exercises)
@@ -2040,12 +2040,12 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.get(url_link_sample, json=[""])
         mock_request.get(url_get_sample_summary, json="")
 
-        response = self.client.get(f"/surveys/{short_name}/{period}/view-sample-ci?survey_mode=SEFT")
+        response = self.client.get(f"/surveys/{short_name}/{period}/load-collection-instruments")
 
         self.assertEqual(200, response.status_code)
-        self.assertIn("SEFT collection instruments".encode(), response.data)
+        self.assertIn("Load Collection instruments for".encode(), response.data)
         self.assertIn("Upload SEFT files".encode(), response.data)
-        self.assertIn("Done".encode(), response.data)
+        self.assertIn("Upload".encode(), response.data)
 
     @requests_mock.mock()
     def test_eq_view_sample_ci_page_survey_permission(self, mock_request):
@@ -2095,7 +2095,8 @@ class TestCollectionExercise(ViewTestCase):
 
         self.assertEqual(200, response.status_code)
         self.assertIn("Load Collection instruments for".encode(), response.data)
-        self.assertIn("Upload SEFT files".encode(), response.data)
+        self.assertIn("Upload SEFT files".encode(), response.data)        
+        self.assertIn("Remove SEFT file".encode(), response.data)
         self.assertIn("File types accepted are .xls and .xlsx".encode(), response.data)
         self.assertIn("Upload".encode(), response.data)
 
@@ -2121,6 +2122,7 @@ class TestCollectionExercise(ViewTestCase):
         self.assertEqual(200, response.status_code)
         self.assertIn("Load Collection instruments for".encode(), response.data)
         self.assertIn("SEFT collection instruments uploaded".encode(), response.data)
+        self.assertNotIn("Remove SEFT file".encode(), response.data)
         self.assertIn("Done".encode(), response.data)
 
     @requests_mock.mock()

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -533,7 +533,7 @@ class TestCollectionExercise(ViewTestCase):
         # Then I can view SEFT collection instruments but not EQ
         self.assertEqual(response.status_code, 200)
         self.assertIn("SEFT collection instruments".encode(), response.data)
-        self.assertIn('id="view-add-upload-ci-seft">View</a>'.encode(), response.data)
+        self.assertIn('id="seft-upload-link">View</a>'.encode(), response.data)
         self.assertNotIn("EQ collection instruments".encode(), response.data)
         self.assertNotIn('id="view-add-upload-ci-eq">View</a>'.encode(), response.data)
 
@@ -559,7 +559,7 @@ class TestCollectionExercise(ViewTestCase):
         self.assertIn("SEFT collection instruments".encode(), response.data)
         self.assertIn("EQ collection instruments".encode(), response.data)
         self.assertIn('id="view-add-upload-ci-eq">View</a>'.encode(), response.data)
-        self.assertIn('id="view-add-upload-ci-seft">View</a>'.encode(), response.data)
+        self.assertIn('id="seft-upload-link">View</a>'.encode(), response.data)
 
     @requests_mock.mock()
     def test_collection_exercise_view_event_statuses(self, mock_request):
@@ -1805,7 +1805,7 @@ class TestCollectionExercise(ViewTestCase):
         mock_request.get(url_get_survey_by_short_name, json=updated_survey_info["survey"])
         mock_request.get(url_ces_by_survey, json=updated_survey_info["collection_exercises"])
         response = self.client.get(
-            f"/surveys/{short_name}/{period}/view-sample-ci?survey_mode=SEFT", follow_redirects=True
+            f"/surveys/{short_name}/{period}/load-collection-instruments", follow_redirects=True
         )
 
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
# What and why?
When clicking on the 'Upload' or 'View or upload' CI SEFT on the CE information page, an intermediary summary page is shown, this PR removes that page and takes the user directly to the load collection instrument page.
# How to test?
For a SEFT and an EQ and SEFT go through the seft upload journey on a collection exercise to ensure the intermediary page is no longer present and the user is taken directly to the load-collection-instruments page. The eQ journey should not have changed. 
# Jira
https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=1493&projectKey=RAS&view=detail&selectedIssue=RAS-682