### PR TITLE
Fix broken details element

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.5
+version: 3.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.5
+appVersion: 3.1.6

--- a/response_operations_ui/templates/create-collection-exercise.html
+++ b/response_operations_ui/templates/create-collection-exercise.html
@@ -84,12 +84,8 @@
                 {{
                     onsDetails({
                         "id": "periodDetails",
-                        "itemsList": [
-                            {
-                                "title": "What is a Period ID",
-                                "content": "<p>The period ID is a two, four or six digit number that represents the month or year that a survey runs until.</p><p>'202212' or '2212' would represent December 2022.</p><p>'22' would represent the year 2022.</p>"
-                            }
-                        ]
+                        "title": "What is a Period ID?",
+                        "content": "<p>The period ID is a two, four or six digit number that represents the month or year that a survey runs until.</p><p>'202212' or '2212' would represent December 2022.</p><p>'22' would represent the year 2022.</p>"
                     })
                 }}
             </div>


### PR DESCRIPTION
# What and why?

The 'what is the period ID' part of the create-collection-exercise page was broken and just showing an arrow with no text.  This PR fixes it so it shows the title and help text

# How to test?

# Trello
