### PR TITLE
Remove survey edit table header

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.19
+version: 3.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.19
+appVersion: 3.1.20

--- a/response_operations_ui/templates/surveys.html
+++ b/response_operations_ui/templates/surveys.html
@@ -48,21 +48,19 @@
           "ariaDesc": "descending",
           "id": 'tbl-surveys',
           "ths": [
-              {
-                  "value": "Survey title","ariaSort": "none"
-              },
-              {
-                  "value": "Survey ID","ariaSort": "none"
-              },
-              {
-                  "value": "Survey mode","ariaSort": "none"
-              },
-              {
-                  "value": "Legal basis","ariaSort": "none"
-              },
-              {
-                  "value": "Edit survey", "ariaSort": "none"
-              } if surveyEditPermission else 
+                    {
+                        "value": "Survey title","ariaSort": "none"
+                    },
+                    {
+                        "value": "Survey ID","ariaSort": "none"
+                    },
+                    {
+                        "value": "Survey mode","ariaSort": "none"
+                    },
+                    {
+                        "value": "Legal basis","ariaSort": "none"
+                    } 
+                  ] if surveyEditPermission else 
                   [
                       {
                           "value": "Survey title","ariaSort": "none"
@@ -77,7 +75,6 @@
                           "value": "Legal basis","ariaSort": "none"
                       }
                   ]
-          ]
       } %}
         {% set surveyTableDataRows = [] %}
 


### PR DESCRIPTION
# What and why?
This PR removes the table header (survey edit) from the surveys table.
# How to test?
Check the surveys table displays correctly without the survey edit table header. Check both with and without survey edit permissions. 
# Jira
https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=1493&projectKey=RAS&view=detail&selectedIssue=RAS-722
