### PR TITLE
Add csrf token into eQ CI page

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.20
+version: 3.1.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.20
+appVersion: 3.1.21

--- a/response_operations_ui/templates/collection_exercise/ce-add-eq-ci.html
+++ b/response_operations_ui/templates/collection_exercise/ce-add-eq-ci.html
@@ -1,7 +1,7 @@
 <div id="ciAddForm" class=" ons-u-mt-l">
     <form id="form-add-ci" action="" class="form" method="post" enctype="multipart/form-data"
           xmlns="http://www.w3.org/1999/html">
-        {{ form.csrf_token }}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <div id="formtype">
             {{
                 onsInput({

--- a/response_operations_ui/templates/collection_exercise/ce-collection-instrument-eq-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-collection-instrument-eq-section.html
@@ -18,7 +18,6 @@ ons-u-mt-l">
                 })
             }}
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-            <input type="hidden" name="csrf_token" value="" />
             <input type="hidden" name="ce_id" value="{{ ce.id }}" /> 
             {% set selectAllText = "Select all" %}
             {% set unselectAllText = "Unselect all" %}


### PR DESCRIPTION
# What and why?
Currently the csrf_token is not appearing on the eQ CI upload page, this is because {{ form }} is not being passed and therefore is not in scope. Naturally this will cause the app to logout 
# How to test?
You will need to change your config WTF_CSRF_ENABLED to be true if testing in dev. Once this has been done try to upload a collection instrument for an eQ 
# Trello
