### PR TITLE
RAS-728 Ready for live button not appearing

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.24
+version: 3.1.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.24
+appVersion: 3.1.25

--- a/response_operations_ui/controllers/collection_instrument_controllers.py
+++ b/response_operations_ui/controllers/collection_instrument_controllers.py
@@ -130,8 +130,8 @@ def link_collection_instrument_to_survey(survey_uuid, eq_id, form_type):
     )
 
 
-def update_collection_exercise_instruments(cis_selected, ce_id):
-    """Links a collection instrument to a collection exercise
+def update_collection_exercise_eq_instruments(cis_selected, ce_id):
+    """Links a collection instrument to an eQ collection exercise
 
     :param ce_id: A uuid of a collection exercise
     :type ce_id: str
@@ -143,7 +143,7 @@ def update_collection_exercise_instruments(cis_selected, ce_id):
     url = (
         f'{app.config["COLLECTION_INSTRUMENT_URL"]}'
         f"/collection-instrument-api/1.0.2"
-        f"/update_collection_exercise_instruments/{ce_id}"
+        f"/update-eq-instruments/{ce_id}"
     )
     payload = {
         "instruments": cis_selected,

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -336,7 +336,7 @@ def _select_eq_collection_instrument(short_name, period):
 
     if "EQ" in ce_details["survey"]["surveyMode"]:
         ce_id = ce_details["collection_exercise"]["id"]
-        response = collection_instrument_controllers.update_collection_exercise_instruments(cis_selected, ce_id)
+        response = collection_instrument_controllers.update_collection_exercise_eq_instruments(cis_selected, ce_id)
 
         if response[0] != 200:
             if cis_selected:

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -126,9 +126,7 @@ url_collection_instrument = f"{collection_instrument_root}/upload/{collection_ex
 url_collection_instrument_unlink = (
     f"{collection_instrument_root}/unlink-exercise/{collection_instrument_id}/{collection_exercise_id}"
 )
-url_collection_instrument_multi_select = (
-    f"{collection_instrument_root}/update_collection_exercise_instruments/{collection_exercise_id}"
-)
+url_collection_instrument_multi_select = f"{collection_instrument_root}/update-eq-instruments/{collection_exercise_id}"
 
 url_post_instrument_link = f"{TestingConfig.COLLECTION_INSTRUMENT_URL}/collection-instrument-api/1.0.2/upload"
 url_get_collection_instrument = f"{collection_instrument_root}/collectioninstrument"


### PR DESCRIPTION
# What and why?
This PR updates the name of the end point it is calling
# How to test?
Test with https://github.com/ONSdigital/rm-collection-exercise-service/pull/312 and https://github.com/ONSdigital/ras-collection-instrument/pull/307 (description on collection instrument)
# Trello
