### PR TITLE
RAS-873 Show supplementary dataset ID in Rops collection exercise

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.35
+version: 3.1.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.35
+appVersion: 3.1.36

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -136,7 +136,12 @@ def view_collection_exercise(short_name, period):
     else:
         show_set_live_button = ce_state in "READY_FOR_REVIEW"
 
-    show_sds = True if ce_details["collection_exercise"]["supplementaryDatasetEntity"] else False
+    if ("supplementaryDatasetEntity" in ce_details["collection_exercise"]) and (
+        ce_details["collection_exercise"]["supplementaryDatasetEntity"]
+    ):
+        show_sds = True
+    else:
+        show_sds = False
 
     locked = ce_state in ("LIVE", "READY_FOR_LIVE", "EXECUTION_STARTED", "VALIDATED", "EXECUTED", "ENDED")
     processing = ce_state in ("EXECUTION_STARTED", "EXECUTED", "VALIDATED")

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -136,12 +136,7 @@ def view_collection_exercise(short_name, period):
     else:
         show_set_live_button = ce_state in "READY_FOR_REVIEW"
 
-    if ("supplementaryDatasetEntity" in ce_details["collection_exercise"]) and (
-        ce_details["collection_exercise"]["supplementaryDatasetEntity"]
-    ):
-        show_sds = True
-    else:
-        show_sds = False
+    show_sds = True if ce_details["collection_exercise"].get("supplementaryDatasetEntity") else False
 
     locked = ce_state in ("LIVE", "READY_FOR_LIVE", "EXECUTION_STARTED", "VALIDATED", "EXECUTED", "ENDED")
     processing = ce_state in ("EXECUTION_STARTED", "EXECUTED", "VALIDATED")

--- a/tests/test_data/collection_exercise/collection_exercise_details.json
+++ b/tests/test_data/collection_exercise/collection_exercise_details.json
@@ -15,8 +15,7 @@
     "state": "PUBLISHED",
     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
     "userDescription": "January 2017",
-    "validationErrors": null,
-    "supplementaryDatasetEntity": null
+    "validationErrors": null
   },
   "survey": {
     "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",

--- a/tests/test_data/collection_exercise/collection_exercise_details_eq_both_ref_date.json
+++ b/tests/test_data/collection_exercise/collection_exercise_details_eq_both_ref_date.json
@@ -16,8 +16,7 @@
     "state": "READY_FOR_REVIEW",
     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
     "userDescription": "January 2017",
-    "validationErrors": null,
-    "supplementaryDatasetEntity": null
+    "validationErrors": null
   },
   "survey": {
     "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",

--- a/tests/test_data/collection_exercise/collection_exercise_details_sample_init_state.json
+++ b/tests/test_data/collection_exercise/collection_exercise_details_sample_init_state.json
@@ -31,8 +31,7 @@
     "updated": null,
     "deleted": null,
     "validationErrors": null,
-    "events": [],
-    "supplementaryDatasetEntity": null
+    "events": []
   },
   "events": {},
   "collection_instruments": {},

--- a/tests/test_data/collection_exercise/formatted_collection_exercise_details.json
+++ b/tests/test_data/collection_exercise/formatted_collection_exercise_details.json
@@ -30,8 +30,7 @@
       "created": "2018-06-28T09:19:13.363Z",
       "updated": "2018-06-28T09:20:09.004Z",
       "deleted": null,
-      "validationErrors": null,
-      "supplementaryDatasetEntity": null
+      "validationErrors": null
     },
   "events":
     {

--- a/tests/test_data/collection_exercise/formatted_collection_exercise_details_failedvalidation.json
+++ b/tests/test_data/collection_exercise/formatted_collection_exercise_details_failedvalidation.json
@@ -30,8 +30,7 @@
       "created": "2018-06-28T09:19:13.363Z",
       "updated": "2018-06-28T09:20:09.004Z",
       "deleted": null,
-      "validationErrors": null,
-      "supplementaryDatasetEntity": null
+      "validationErrors": null
     },
   "events":
     {

--- a/tests/test_data/collection_exercise/formatted_collection_exercise_details_no_events.json
+++ b/tests/test_data/collection_exercise/formatted_collection_exercise_details_no_events.json
@@ -30,8 +30,7 @@
       "created": "2018-06-28T09:19:13.363Z",
       "updated": "2018-06-28T09:20:09.004Z",
       "deleted": null,
-      "validationErrors": null,
-      "supplementaryDatasetEntity": null
+      "validationErrors": null
     },
   "events":
     {

--- a/tests/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json
+++ b/tests/test_data/collection_exercise/formatted_collection_exercise_details_no_sample.json
@@ -30,8 +30,7 @@
       "created": "2018-06-28T09:19:13.363Z",
       "updated": "2018-06-28T09:20:09.004Z",
       "deleted": null,
-      "validationErrors": null,
-      "supplementaryDatasetEntity": null
+      "validationErrors": null
     },
   "events":
     {

--- a/tests/test_data/collection_exercise/formatted_new_collection_exercise_details.json
+++ b/tests/test_data/collection_exercise/formatted_new_collection_exercise_details.json
@@ -30,8 +30,7 @@
       "created": "2018-06-28T09:19:13.363Z",
       "updated": "2018-06-28T09:20:09.004Z",
       "deleted": null,
-      "validationErrors": null,
-      "supplementaryDatasetEntity": null
+      "validationErrors": null
     },
   "events":
     {

--- a/tests/test_data/collection_exercise/seft_collection_exercise_details.json
+++ b/tests/test_data/collection_exercise/seft_collection_exercise_details.json
@@ -30,8 +30,7 @@
       "created": "2018-06-28T09:19:13.363Z",
       "updated": "2018-06-28T09:20:09.004Z",
       "deleted": null,
-      "validationErrors": null,
-      "supplementaryDatasetEntity": null
+      "validationErrors": null
     },
   "events":
     {

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -231,7 +231,6 @@ class TestCollectionExercise(ViewTestCase):
                         "timestamp": "2018-03-16T00:00:00.000Z",
                     }
                 ],
-                "supplementaryDatasetEntity": None,
             }
         ]
         self.collection_exercise_events = [


### PR DESCRIPTION
# What and why?
Just updates to deal with updated return from collection exercise
# How to test?
Same as https://github.com/ONSdigital/response-operations-ui/pull/884

Deploy this PR to your environment
Ensure that https://github.com/ONSdigital/rm-collection-exercise-service/pull/318 is either merged or deploy it to your environment
Set up a collection exercise in Response Operations (only period ID is needed)
Place a pubsub message using and replacing your namespace, survey ID and period ID:
```
gcloud pubsub topics publish projects/ras-rm-dev/topics/supplementary-data-service-[your namespace] --message='{
    "survey_id": [your survey ID],
    "period_id": [your period ID],
    "form_types": [
       "0017",
       "0123",
       "0001"
      ],
    "title": "A dataset version 4 for survey 2012 period 2013",
    "sds_published_at": "2023-07-17T14:46:36Z",
    "total_reporting_units": 2,
    "schema_version": "v1.0.0",
    "sds_dataset_version": 4,
    "filename": "373d9a77-2ee5-4c1f-a6dd-8d07b0ea9793.json",
    "dataset_id": "b9a87999-fcc0-4085-979f-06390fb5dddd"
}'
```
Refresh the collection exercise in Response Operations, now a panel saying Pre-Populated data is available for this sample should appear at the top (in line with the design https://www.figma.com/file/uUb6GDGbgYVILiK5wP9wqi/CE-Reporting-period-page?type=design&node-id=2220-73919&mode=design)
# Trello
[RAS-873](https://jira.ons.gov.uk/browse/RAS-873)