### PR TITLE
RAS-272 Outputting the response chasing report as a csv as well as xlsx

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.37
+version: 3.1.38
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.37
+appVersion: 3.1.38

--- a/response_operations_ui/controllers/collection_exercise_controllers.py
+++ b/response_operations_ui/controllers/collection_exercise_controllers.py
@@ -12,14 +12,17 @@ from response_operations_ui.exceptions.exceptions import ApiError
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def download_report(collection_exercise_id, survey_id):
+def download_report(document_type, collection_exercise_id, survey_id):
     logger.info(
-        "Downloading response chasing report", collection_exercise_id=collection_exercise_id, survey_id=survey_id
+        "Downloading response chasing report",
+        document_type=document_type,
+        collection_exercise_id=collection_exercise_id,
+        survey_id=survey_id,
     )
 
     url = (
         f"{app.config['REPORT_URL']}"
-        f"/reporting-api/v1/response-chasing/download-report/{collection_exercise_id}/{survey_id}"
+        f"/reporting-api/v1/response-chasing/download-report/{document_type}/{collection_exercise_id}/{survey_id}"
     )
 
     response = requests.get(url)
@@ -32,11 +35,6 @@ def download_report(collection_exercise_id, survey_id):
         )
         raise ApiError(response)
 
-    logger.info(
-        "Successfully downloaded response chasing report",
-        collection_exercise_id=collection_exercise_id,
-        survey_id=survey_id,
-    )
     return response
 
 

--- a/response_operations_ui/templates/collection_exercise/ce-header-section.html
+++ b/response_operations_ui/templates/collection_exercise/ce-header-section.html
@@ -27,31 +27,44 @@
 {% else %}
     {% set class = 'ons-status ons-status--info' %}
 {% endif %}
+
+{% set metaDataList = [{
+    "term": "Status:",
+    "descriptions": [{
+        "description": '<span class="'+ class + '">'+ ce.state + status_event +'</span>',
+        "id": "ce_status"
+    }]
+}] %}
+
+{% if response_chasing %}
+    {% do metaDataList.append({
+        "term": "Report:",
+        "descriptions": [{
+            "description":
+                onsButton({
+                    "text": 'Save report as xslx',
+                    "url": response_chasing.xslx_url,
+                    "variants": ['download', 'small', 'secondary'],
+                    "removeDownloadAttribute": true
+                })
+                +
+                onsButton({
+                    "text": 'Save report as csv',
+                    "url": response_chasing.csv_url,
+                    "variants": ['download', 'small', 'secondary'],
+                    "removeDownloadAttribute": true
+                }),
+            "id": "ce_status"
+        }]
+    })%}
+{% endif %}
+
 {{
     onsMetadata({
         "metadataLabel": survey.longName + "information",
         "termCol": "1",
         "descriptionCol": "11",
-        "itemsList": [
-            {
-                "term": "Status:",
-                "descriptions": [
-                    {
-                        "description": '<span class="'+ class + '">'+ ce.state + status_event +'</span>',
-                        "id": "ce_status"
-                    }
-                ]
-            },
-            {
-                "term": "Report:" if ce.state|upper == "LIVE",
-                "descriptions": [
-                    {
-                        "description": '<a href="' + url_for('collection_exercise_bp.response_chasing', ce_id=ce.id, survey_id=survey.id) + '"><svg class="ons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/><path d="M0 0h24v24H0z" fill="none"/></svg> Download response report</a>' if (ce.state|upper == "LIVE" or ce.state|upper == "ENDED"),
-                        "id": "ce_status"
-                    }
-                ]
-            }
-        ]
+        "itemsList": metaDataList
     })
 }}
 {% if show_set_live_button %}

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -181,7 +181,7 @@ def view_collection_exercise(short_name, period):
     response_chasing_context = (
         _build_response_chasing_context(ce_details["collection_exercise"]["id"], ce_details["survey"]["id"])
         if ce_state in ("LIVE", "ENDED")
-        else None,
+        else None
     )
 
     return render_template(


### PR DESCRIPTION
# What and why?
Add csv download option to response chase report. 
# How to test?
You will need this PR and the one for [reporting](https://github.com/ONSdigital/rm-reporting/pull/106) run locally or on GCP.  You will also need to seed some data or run the acceptance tests (if using acceptance, make sure you put enrol some extra respondents, as one user in one business is not overall reliable to test the functionality) Once you have done this make sure the report works as expected
# Trello
