### PR TITLE
Correct response chasing error with status check

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.40
+version: 3.1.41
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.40
+appVersion: 3.1.41

--- a/response_operations_ui/contexts/collection_exercise.py
+++ b/response_operations_ui/contexts/collection_exercise.py
@@ -30,7 +30,7 @@ def build_ce_context(ce_details: dict, has_edit_permission: bool, locked: bool) 
     collection_instruments = ce_details["collection_instruments"]
 
     response_chasing = (
-        _build_response_chasing(ce["id"], ce_details["survey"]["id"]) if ce["state"] in ("LIVE", "ENDED") else None
+        _build_response_chasing(ce["id"], ce_details["survey"]["id"]) if ce["state"] in ("Live", "Ended") else None
     )
     ci_table = _build_ci_table(
         collection_instruments,

--- a/tests/context/conftest.py
+++ b/tests/context/conftest.py
@@ -242,10 +242,3 @@ def ce_details_dynamic_event_deleted(ce_details_dynamic_event):
     ce_details_dynamic_event_deleted = ce_details_dynamic_event.copy()
     del ce_details_dynamic_event_deleted["events"]["reminder2"]
     return ce_details_dynamic_event_deleted
-
-
-@pytest.fixture()
-def ce_details_live(ce_details):
-    ce_details_live = ce_details.copy()
-    ce_details_live["collection_exercise"]["state"] = "LIVE"
-    return ce_details_live

--- a/tests/context/test_collection_exercise_context.py
+++ b/tests/context/test_collection_exercise_context.py
@@ -1,3 +1,5 @@
+import pytest
+
 from response_operations_ui.contexts.collection_exercise import build_ce_context
 
 SURVEY_ID = "c23bb1c1-5202-43bb-8357-7a07c844308f"
@@ -136,11 +138,13 @@ def test_not_locked_event_in_the_past(app, ce_details_event_in_the_past):
     assert "hyperlink" in context["action_dates"]["go_live"]
 
 
-def test_response_chasing(app, ce_details_live):
-    # Given the exercise is live
+@pytest.mark.parametrize("status", ["Live", "Ended"])
+def test_response_chasing(app, ce_details, status):
+    # Given the exercise is live/Ended
+    ce_details["collection_exercise"]["state"] = status
     # When build_ce_context is called
     with app.test_request_context():
-        context = build_ce_context(ce_details_live, True, True)
+        context = build_ce_context(ce_details, True, True)
 
     # Then response_chasing is populated correctly
     assert context["response_chasing"]["xslx_url"] == f"/surveys/response_chasing/xslx/{CE_ID}/{SURVEY_ID}"

--- a/tests/context/test_collection_exercise_context.py
+++ b/tests/context/test_collection_exercise_context.py
@@ -140,11 +140,12 @@ def test_not_locked_event_in_the_past(app, ce_details_event_in_the_past):
 
 @pytest.mark.parametrize("status", ["Live", "Ended"])
 def test_response_chasing(app, ce_details, status):
-    # Given the exercise is live/Ended
-    ce_details["collection_exercise"]["state"] = status
+    # Given the exercise is Live/Ended
+    ce_details_state_updated = ce_details.copy()
+    ce_details_state_updated["collection_exercise"]["state"] = status
     # When build_ce_context is called
     with app.test_request_context():
-        context = build_ce_context(ce_details, True, True)
+        context = build_ce_context(ce_details_state_updated, True, True)
 
     # Then response_chasing is populated correctly
     assert context["response_chasing"]["xslx_url"] == f"/surveys/response_chasing/xslx/{CE_ID}/{SURVEY_ID}"


### PR DESCRIPTION
# What and why?
In my last story I had to move response chasing, but I didn't change it, however what I hadn't picked up was there was data mutation on the dict here https://github.com/ONSdigital/response-operations-ui/blob/main/response_operations_ui/views/collection_exercise.py#L153. Basically doing this to the state element {"LIVE": "Live", "ENDED": "Ended"} Ironically we shouldn't be doing this but I am not going to unpick it now and just match it. 


# How to test?
Create a CE and put it in live/ended and make sure response chasing is there.
# Trello
