### PR TITLE
RAS-1088 Implement 48 hour grace period for survey change of status

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.54
+version: 3.1.55
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.54
+appVersion: 3.1.55

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -233,7 +233,7 @@ spec:
             value: "{{- if .Values.test.enabled -}}True{{- else -}}False{{- end -}}"
           - name: WTF_CSRF_ENABLED
             value: "{{- if .Values.test.enabled -}}False{{- else -}}True{{- end -}}"
-          - COMPLETE_TO_NOT_STARTED_WAIT_TIME
+          - name: COMPLETE_TO_NOT_STARTED_WAIT_TIME
             value: "{{ .Values.admin.completeToNotStartedWaitTime }}"
           resources:
             {{ toYaml .Values.resources | nindent 12 }}

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -233,5 +233,7 @@ spec:
             value: "{{- if .Values.test.enabled -}}True{{- else -}}False{{- end -}}"
           - name: WTF_CSRF_ENABLED
             value: "{{- if .Values.test.enabled -}}False{{- else -}}True{{- end -}}"
+          - COMPLETE_TO_NOT_STARTED_WAIT_TIME
+            value: "{{ .Values.admin.completeToNotStartedWaitTime }}"
           resources:
             {{ toYaml .Values.resources | nindent 12 }}

--- a/_infra/helm/response-operations-ui/values.yaml
+++ b/_infra/helm/response-operations-ui/values.yaml
@@ -7,7 +7,7 @@ sendEmailToGovNotify: false
 admin:
   createAccountEmailExpiry: "2419200"
   updateAccountEmailExpiry: "259200"
-  completeToNotStartedWaitTime: "259200"
+  completeToNotStartedWaitTime: "172800"
 
 analytics:
   enabled: false

--- a/_infra/helm/response-operations-ui/values.yaml
+++ b/_infra/helm/response-operations-ui/values.yaml
@@ -7,6 +7,7 @@ sendEmailToGovNotify: false
 admin:
   createAccountEmailExpiry: "2419200"
   updateAccountEmailExpiry: "259200"
+  completeToNotStartedWaitTime: "259200"
 
 analytics:
   enabled: false

--- a/_infra/helm/response-operations-ui/values.yaml
+++ b/_infra/helm/response-operations-ui/values.yaml
@@ -7,7 +7,7 @@ sendEmailToGovNotify: false
 admin:
   createAccountEmailExpiry: "2419200"
   updateAccountEmailExpiry: "259200"
-  completeToNotStartedWaitTime: "172800"
+  completeToNotStartedWaitTime: "1200"
 
 analytics:
   enabled: false

--- a/config.py
+++ b/config.py
@@ -97,6 +97,8 @@ class Config(object):
     CREATE_ACCOUNT_EMAIL_TOKEN_EXPIRY = int(os.getenv("CREATE_ACCOUNT_EMAIL_TOKEN_EXPIRY", "2419200"))
     # 3 days in seconds
     UPDATE_ACCOUNT_EMAIL_TOKEN_EXPIRY = int(os.getenv("UPDATE_ACCOUNT_EMAIL_TOKEN_EXPIRY", "259200"))
+    # 48 hours in seconds
+    COMPLETE_TO_NOT_STARTED_WAIT_TIME = int(os.getenv("COMPLETE_TO_NOT_STARTED_WAIT_TIME", "172800"))
 
     TEST_MODE = strtobool(os.getenv("TEST_MODE", "False"))
     WTF_CSRF_ENABLED = strtobool(os.getenv("WTF_CSRF_ENABLED", "True"))
@@ -144,6 +146,8 @@ class DevelopmentConfig(Config):
     # 3 days in seconds
     UPDATE_ACCOUNT_EMAIL_TOKEN_EXPIRY = int(os.getenv("UPDATE_ACCOUNT_EMAIL_TOKEN_EXPIRY", "259200"))
     WTF_CSRF_ENABLED = strtobool(os.getenv("WTF_CSRF_ENABLED", "False"))
+    # 12 hours in seconds
+    COMPLETE_TO_NOT_STARTED_WAIT_TIME = int(os.getenv("COMPLETE_TO_NOT_STARTED_WAIT_TIME", "43200"))
 
 
 class TestingConfig(DevelopmentConfig):
@@ -176,3 +180,5 @@ Z5VVFymXN2n+A6UeWAnuO8/E1inhk99dBzKEGdw=
     SECRET_KEY = "sekrit!"
     SECURITY_USER_NAME = "admin"
     SECURITY_USER_PASSWORD = "secret"
+    # 12 hours in seconds
+    COMPLETE_TO_NOT_STARTED_WAIT_TIME = int(os.getenv("COMPLETE_TO_NOT_STARTED_WAIT_TIME", "43200"))

--- a/config.py
+++ b/config.py
@@ -98,6 +98,8 @@ class Config(object):
     # 3 days in seconds
     UPDATE_ACCOUNT_EMAIL_TOKEN_EXPIRY = int(os.getenv("UPDATE_ACCOUNT_EMAIL_TOKEN_EXPIRY", "259200"))
     # 48 hours in seconds
+    # Grace period for changing the survey status from complete to not started to ensure that when an eQ status is
+    # changed, the respondent will be provided with an empty survey
     COMPLETE_TO_NOT_STARTED_WAIT_TIME = int(os.getenv("COMPLETE_TO_NOT_STARTED_WAIT_TIME", "172800"))
 
     TEST_MODE = strtobool(os.getenv("TEST_MODE", "False"))
@@ -146,8 +148,8 @@ class DevelopmentConfig(Config):
     # 3 days in seconds
     UPDATE_ACCOUNT_EMAIL_TOKEN_EXPIRY = int(os.getenv("UPDATE_ACCOUNT_EMAIL_TOKEN_EXPIRY", "259200"))
     WTF_CSRF_ENABLED = strtobool(os.getenv("WTF_CSRF_ENABLED", "False"))
-    # 12 hours in seconds
-    COMPLETE_TO_NOT_STARTED_WAIT_TIME = int(os.getenv("COMPLETE_TO_NOT_STARTED_WAIT_TIME", "43200"))
+    # 5 minutes in seconds
+    COMPLETE_TO_NOT_STARTED_WAIT_TIME = int(os.getenv("COMPLETE_TO_NOT_STARTED_WAIT_TIME", "300"))
 
 
 class TestingConfig(DevelopmentConfig):
@@ -180,5 +182,5 @@ Z5VVFymXN2n+A6UeWAnuO8/E1inhk99dBzKEGdw=
     SECRET_KEY = "sekrit!"
     SECURITY_USER_NAME = "admin"
     SECURITY_USER_PASSWORD = "secret"
-    # 12 hours in seconds
-    COMPLETE_TO_NOT_STARTED_WAIT_TIME = int(os.getenv("COMPLETE_TO_NOT_STARTED_WAIT_TIME", "43200"))
+    # 5 minutes in seconds
+    COMPLETE_TO_NOT_STARTED_WAIT_TIME = int(os.getenv("COMPLETE_TO_NOT_STARTED_WAIT_TIME", "300"))

--- a/response_operations_ui/contexts/case.py
+++ b/response_operations_ui/contexts/case.py
@@ -12,7 +12,7 @@ def build_response_status_context(
     allowed_transitions_for_case: dict,
     survey_id: str,
     has_reporting_unit_permission: bool,
-    timestamp: datetime = None,
+    case_completed_time: datetime = None,
 ) -> dict:
     if has_reporting_unit_permission and allowed_transitions_for_case:
         change_response_status = {
@@ -23,7 +23,7 @@ def build_response_status_context(
                 case_group_id=case_group_id,
                 period=ce_period,
             ),
-            "radios": _generate_radios(allowed_transitions_for_case, timestamp),
+            "radios": _generate_radios(allowed_transitions_for_case, case_completed_time),
             "cancel_link": url_for("reporting_unit_bp.view_reporting_unit_survey", ru_ref=ru_ref, survey_id=survey_id),
         }
     else:
@@ -31,16 +31,16 @@ def build_response_status_context(
     return {"change_response_status": change_response_status}
 
 
-def _generate_radios(allowed_transitions_for_case: dict, timestamp: datetime) -> list:
-    complete_to_not_started_wait_time = app.config["COMPLETE_TO_NOT_STARTED_WAIT_TIME"]
-    radios = [
-        {"id": f"state-{index + 1}", "label": {"text": status}, "value": event}
-        for index, (event, status) in enumerate(allowed_transitions_for_case.items())
-    ]
-    if timestamp:
-        for radio in radios:
+def _generate_radios(allowed_transitions_for_case: dict, case_completed_time: datetime) -> list:
+    radios = []
+    for index, (event, status) in enumerate(allowed_transitions_for_case.items()):
+        radio = {"id": f"state-{index + 1}", "label": {"text": status}, "value": event}
+        if case_completed_time:
+            complete_to_not_started_wait_time = app.config["COMPLETE_TO_NOT_STARTED_WAIT_TIME"]
             if (radio["value"] == "COMPLETED_TO_NOTSTARTED") and (
-                (datetime.now() - timestamp) < timedelta(seconds=complete_to_not_started_wait_time)
+                (datetime.now() - case_completed_time) < timedelta(seconds=complete_to_not_started_wait_time)
             ):
                 radio["attributes"] = {"disabled": "true"}
+        radios.append(radio)
+
     return radios

--- a/response_operations_ui/contexts/case.py
+++ b/response_operations_ui/contexts/case.py
@@ -37,9 +37,10 @@ def _generate_radios(allowed_transitions_for_case: dict, timestamp: datetime) ->
         {"id": f"state-{index + 1}", "label": {"text": status}, "value": event}
         for index, (event, status) in enumerate(allowed_transitions_for_case.items())
     ]
-    for radio in radios:
-        if (radio["value"] == "COMPLETED_TO_NOTSTARTED") and (
-            (datetime.now() - timestamp) < timedelta(seconds=complete_to_not_started_wait_time)
-        ):
-            radio["attributes"] = {"disabled": "true"}
+    if timestamp:
+        for radio in radios:
+            if (radio["value"] == "COMPLETED_TO_NOTSTARTED") and (
+                (datetime.now() - timestamp) < timedelta(seconds=complete_to_not_started_wait_time)
+            ):
+                radio["attributes"] = {"disabled": "true"}
     return radios

--- a/response_operations_ui/contexts/case.py
+++ b/response_operations_ui/contexts/case.py
@@ -41,6 +41,9 @@ def _generate_radios(allowed_transitions_for_case: dict, case_completed_time: da
                 (datetime.now() - case_completed_time) < timedelta(seconds=complete_to_not_started_wait_time)
             ):
                 radio["attributes"] = {"disabled": "true"}
+                radio["label"][
+                    "description"
+                ] = "Status can only be changed after 48 hours have passed since the submission"
         radios.append(radio)
 
     return radios

--- a/response_operations_ui/contexts/case.py
+++ b/response_operations_ui/contexts/case.py
@@ -35,11 +35,9 @@ def _generate_radios(allowed_transitions_for_case: dict, case_completed_time: da
     radios = []
     for index, (event, status) in enumerate(allowed_transitions_for_case.items()):
         radio = {"id": f"state-{index + 1}", "label": {"text": status}, "value": event}
-        if case_completed_time:
+        if event == "COMPLETED_TO_NOTSTARTED" and case_completed_time:
             complete_to_not_started_wait_time = app.config["COMPLETE_TO_NOT_STARTED_WAIT_TIME"]
-            if (radio["value"] == "COMPLETED_TO_NOTSTARTED") and (
-                (datetime.now() - case_completed_time) < timedelta(seconds=complete_to_not_started_wait_time)
-            ):
+            if (datetime.now() - case_completed_time) < timedelta(seconds=complete_to_not_started_wait_time):
                 radio["attributes"] = {"disabled": "true"}
                 radio["label"][
                     "description"

--- a/response_operations_ui/contexts/case.py
+++ b/response_operations_ui/contexts/case.py
@@ -1,3 +1,6 @@
+from datetime import datetime, timedelta
+
+from flask import current_app as app
 from flask import url_for
 
 
@@ -9,8 +12,9 @@ def build_response_status_context(
     allowed_transitions_for_case: dict,
     survey_id: str,
     has_reporting_unit_permission: bool,
+    timestamp: datetime = None,
 ) -> dict:
-    if has_reporting_unit_permission:
+    if has_reporting_unit_permission and allowed_transitions_for_case:
         change_response_status = {
             "url": url_for(
                 "case_bp.update_response_status",
@@ -19,7 +23,7 @@ def build_response_status_context(
                 case_group_id=case_group_id,
                 period=ce_period,
             ),
-            "radios": _generate_radios(allowed_transitions_for_case),
+            "radios": _generate_radios(allowed_transitions_for_case, timestamp),
             "cancel_link": url_for("reporting_unit_bp.view_reporting_unit_survey", ru_ref=ru_ref, survey_id=survey_id),
         }
     else:
@@ -27,9 +31,15 @@ def build_response_status_context(
     return {"change_response_status": change_response_status}
 
 
-def _generate_radios(allowed_transitions_for_case: dict) -> list:
+def _generate_radios(allowed_transitions_for_case: dict, timestamp: datetime) -> list:
+    complete_to_not_started_wait_time = app.config["COMPLETE_TO_NOT_STARTED_WAIT_TIME"]
     radios = [
         {"id": f"state-{index + 1}", "label": {"text": status}, "value": event}
         for index, (event, status) in enumerate(allowed_transitions_for_case.items())
     ]
+    for radio in radios:
+        if (radio["value"] == "COMPLETED_TO_NOTSTARTED") and (
+            (datetime.now() - timestamp) < timedelta(seconds=complete_to_not_started_wait_time)
+        ):
+            radio["attributes"] = {"disabled": "true"}
     return radios

--- a/response_operations_ui/views/case.py
+++ b/response_operations_ui/views/case.py
@@ -139,8 +139,7 @@ def update_response_status(ru_ref):
 
 def get_timestamp_for_completed_case_event(case_id):
     case_events = get_case_events_by_case_id(case_id, COMPLETED_CASE_EVENTS)
-    last_index = len(case_events) - 1
-    timestamp = case_events[last_index]["createdDateTime"].replace("T", " ").split(".")[0]
+    timestamp = case_events[0]["createdDateTime"].replace("T", " ").split(".")[0]
 
     return get_formatted_date(timestamp), datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
 

--- a/response_operations_ui/views/case.py
+++ b/response_operations_ui/views/case.py
@@ -60,9 +60,7 @@ def get_response_statuses(ru_ref, error=None):
     case_group_status = case_group["caseGroupStatus"]
     case_id = get_case_by_case_group_id(case_group["id"]).get("id")
     is_case_complete = case_group_status in COMPLETE_STATE
-    completed_timestamp, unformatted_timestamp = (
-        get_timestamp_for_completed_case_event(case_id) if is_case_complete else (None, None)
-    )
+    case_completed_timestamp = get_timestamp_for_completed_case_event(case_id) if is_case_complete else None
 
     if is_case_complete:
         case_events = get_case_events_by_case_id(case_id=case_id)
@@ -88,7 +86,7 @@ def get_response_statuses(ru_ref, error=None):
         allowed_transitions_for_case,
         survey["id"],
         has_reporting_unit_permission,
-        unformatted_timestamp,
+        datetime.strptime(case_completed_timestamp, "%Y-%m-%d %H:%M:%S") if case_completed_timestamp else None,
     )
 
     return render_template(
@@ -105,7 +103,7 @@ def get_response_statuses(ru_ref, error=None):
         case_group_id=case_group["id"],
         error=error,
         is_case_complete=is_case_complete,
-        completed_timestamp=completed_timestamp,
+        completed_timestamp=get_formatted_date(case_completed_timestamp) if case_completed_timestamp else None,
         completed_respondent=completed_respondent,
         context=context,
     )
@@ -141,7 +139,7 @@ def get_timestamp_for_completed_case_event(case_id):
     case_events = get_case_events_by_case_id(case_id, COMPLETED_CASE_EVENTS)
     timestamp = case_events[0]["createdDateTime"].replace("T", " ").split(".")[0]
 
-    return get_formatted_date(timestamp), datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
+    return timestamp
 
 
 def get_case_event_for_seft_or_eq(case_events):

--- a/response_operations_ui/views/case.py
+++ b/response_operations_ui/views/case.py
@@ -64,6 +64,11 @@ def get_response_statuses(ru_ref, error=None):
         get_timestamp_for_completed_case_event(case_id) if is_case_complete else (None, None)
     )
 
+    if is_case_complete:
+        case_events = get_case_events_by_case_id(case_id=case_id)
+        case_event = get_case_event_for_seft_or_eq(case_events)
+        completed_respondent = get_user_from_case_events(case_event)
+
     # Using a list filter to return only the status we actually require. This is then used
     # to create the dictionary with only the required allowed transitions for certain case events
     allowed_transitions_filtered = list(filter(lambda statuses: statuses != case_group_status, ALLOWED_TRANSITIONS))
@@ -73,11 +78,6 @@ def get_response_statuses(ru_ref, error=None):
         for event, status in possible_transitions_for_case.items()
         if status in allowed_transitions_filtered
     }
-
-    if is_case_complete:
-        case_events = get_case_events_by_case_id(case_id=case_id)
-        case_event = get_case_event_for_seft_or_eq(case_events)
-        completed_respondent = get_user_from_case_events(case_event)
 
     has_reporting_unit_permission = user_has_permission("reportingunits.edit")
     context = build_response_status_context(

--- a/tests/context/conftest.py
+++ b/tests/context/conftest.py
@@ -528,6 +528,9 @@ def expected_response_status_context_for_complete_case_status_change_disabled(
     expected_response_status_context_for_complete_case["change_response_status"]["radios"][0]["attributes"] = {
         "disabled": "true"
     }
+    expected_response_status_context_for_complete_case["change_response_status"]["radios"][0]["label"][
+        "description"
+    ] = "Status can only be changed after 48 hours have passed since the submission"
     return expected_response_status_context_for_complete_case_after_48_hours
 
 

--- a/tests/context/conftest.py
+++ b/tests/context/conftest.py
@@ -414,7 +414,7 @@ def unused_iac():
 
 
 @pytest.fixture
-def expected_ru_context_with_all_permissions():
+def expected_ru_context():
     return {
         "collection_exercise_section": [
             {
@@ -471,8 +471,8 @@ def expected_ru_context_with_all_permissions():
 
 
 @pytest.fixture
-def expected_ru_context_with_multiple_ces_and_respondents(expected_ru_context_with_all_permissions):
-    expected_ru_context_with_multiple_ces_and_respondents = expected_ru_context_with_all_permissions.copy()
+def expected_ru_context_with_multiple_ces_and_respondents(expected_ru_context):
+    expected_ru_context_with_multiple_ces_and_respondents = expected_ru_context.copy()
     expected_ru_context_with_multiple_ces_and_respondents["collection_exercise_section"].append(
         {
             "hyperlink": "/case/49900000001/response-status?survey=MWSS&period=021123",
@@ -492,7 +492,7 @@ def expected_ru_context_with_multiple_ces_and_respondents(expected_ru_context_wi
         }
     )
     expected_ru_context_with_multiple_ces_and_respondents["respondents_section"].append(
-        expected_ru_context_with_all_permissions["respondents_section"][0]
+        expected_ru_context["respondents_section"][0]
     )
     expected_ru_context_with_multiple_ces_and_respondents["respondents_section"][0].pop("enrolment_code_hyperlink")
     expected_ru_context_with_multiple_ces_and_respondents["respondents_section"][0].pop("enrolment_code_hyperlink_text")
@@ -501,7 +501,7 @@ def expected_ru_context_with_multiple_ces_and_respondents(expected_ru_context_wi
 
 
 @pytest.fixture
-def expected_response_status_context_for_complete_case_with_all_permissions():
+def expected_response_status_context_for_complete_case():
     return {
         "change_response_status": {
             "cancel_link": "/reporting-units/49900000001/surveys/02b9c366-7397-42f7-942a-76dc5876d86d",
@@ -510,7 +510,6 @@ def expected_response_status_context_for_complete_case_with_all_permissions():
                     "id": "state-1",
                     "label": {"text": "Not started"},
                     "value": "COMPLETED_TO_NOTSTARTED",
-                    "attributes": {"disabled": "true"},
                 }
             ],
             "url": "/case/49900000001/response-status?survey=QBS&"
@@ -520,15 +519,15 @@ def expected_response_status_context_for_complete_case_with_all_permissions():
 
 
 @pytest.fixture
-def expected_response_status_context_for_complete_case_after_48_hours(
-    expected_response_status_context_for_complete_case_with_all_permissions,
+def expected_response_status_context_for_complete_case_status_change_disabled(
+    expected_response_status_context_for_complete_case,
 ):
     expected_response_status_context_for_complete_case_after_48_hours = (
-        expected_response_status_context_for_complete_case_with_all_permissions.copy()
+        expected_response_status_context_for_complete_case.copy()
     )
-    expected_response_status_context_for_complete_case_with_all_permissions["change_response_status"]["radios"][0].pop(
-        "attributes"
-    )
+    expected_response_status_context_for_complete_case["change_response_status"]["radios"][0]["attributes"] = {
+        "disabled": "true"
+    }
     return expected_response_status_context_for_complete_case_after_48_hours
 
 
@@ -539,11 +538,9 @@ def expected_response_status_context_with_no_permissions():
 
 @pytest.fixture
 def expected_response_status_context_transitions_for_incomplete_case(
-    expected_response_status_context_for_complete_case_with_all_permissions,
+    expected_response_status_context_for_complete_case,
 ):
-    expected_case_context_transitions_from_not_started = (
-        expected_response_status_context_for_complete_case_with_all_permissions.copy()
-    )
+    expected_case_context_transitions_from_not_started = expected_response_status_context_for_complete_case.copy()
     expected_case_context_transitions_from_not_started["change_response_status"]["radios"] = [
         {"id": "state-1", "label": {"text": "Completed by phone"}, "value": "COMPLETED_BY_PHONE"},
         {"id": "state-2", "label": {"text": "No longer required"}, "value": "NO_LONGER_REQUIRED"},

--- a/tests/context/conftest.py
+++ b/tests/context/conftest.py
@@ -505,11 +505,31 @@ def expected_response_status_context_for_complete_case_with_all_permissions():
     return {
         "change_response_status": {
             "cancel_link": "/reporting-units/49900000001/surveys/02b9c366-7397-42f7-942a-76dc5876d86d",
-            "radios": [{"id": "state-1", "label": {"text": "Not started"}, "value": "COMPLETED_TO_NOTSTARTED"}],
+            "radios": [
+                {
+                    "id": "state-1",
+                    "label": {"text": "Not started"},
+                    "value": "COMPLETED_TO_NOTSTARTED",
+                    "attributes": {"disabled": "true"},
+                }
+            ],
             "url": "/case/49900000001/response-status?survey=QBS&"
             + "case_group_id=6fef0397-f07b-4d65-8988-931cec23057f&period=1912",
         }
     }
+
+
+@pytest.fixture
+def expected_response_status_context_for_complete_case_after_48_hours(
+    expected_response_status_context_for_complete_case_with_all_permissions,
+):
+    expected_response_status_context_for_complete_case_after_48_hours = (
+        expected_response_status_context_for_complete_case_with_all_permissions.copy()
+    )
+    expected_response_status_context_for_complete_case_with_all_permissions["change_response_status"]["radios"][0].pop(
+        "attributes"
+    )
+    return expected_response_status_context_for_complete_case_after_48_hours
 
 
 @pytest.fixture

--- a/tests/context/test_case_context.py
+++ b/tests/context/test_case_context.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from response_operations_ui.contexts.case import build_response_status_context
 
 
@@ -20,6 +22,7 @@ def test_response_status_context_with_permissions(
             transitions_for_complete_case,
             survey_id,
             True,
+            datetime.now(),
         )
     assert context == expected_response_status_context_for_complete_case_with_all_permissions
 
@@ -93,6 +96,7 @@ def test_transitions_from_completed_by_phone(
             transitions_for_complete_case,
             survey_id,
             True,
+            datetime.now(),
         )
         radios = get_response_status_context(context, "change_response_status", "radios")
 
@@ -121,6 +125,7 @@ def test_transitions_from_no_longer_required(
             transitions_for_complete_case,
             survey_id,
             True,
+            datetime.now(),
         )
         radios = get_response_status_context(context, "change_response_status", "radios")
 
@@ -176,6 +181,64 @@ def test_transitions_from_complete(
             transitions_for_complete_case,
             survey_id,
             True,
+            datetime.now(),
+        )
+        radios = get_response_status_context(context, "change_response_status", "radios")
+
+    assert (
+        expected_response_status_context_for_complete_case_with_all_permissions["change_response_status"]["radios"]
+        == radios
+    )
+
+
+def test_transitions_from_complete_after_48_hours(
+    app,
+    transitions_for_complete_case,
+    expected_response_status_context_for_complete_case_after_48_hours,
+    ru_ref,
+    survey_short_name,
+    case_group_id,
+    ce_period,
+    survey_id,
+):
+    with app.test_request_context():
+        context = build_response_status_context(
+            ru_ref,
+            survey_short_name,
+            case_group_id,
+            ce_period,
+            transitions_for_complete_case,
+            survey_id,
+            True,
+            datetime.now() - timedelta(days=3),
+        )
+        radios = get_response_status_context(context, "change_response_status", "radios")
+
+    assert (
+        expected_response_status_context_for_complete_case_after_48_hours["change_response_status"]["radios"] == radios
+    )
+
+
+def test_transitions_from_complete_within_48_hours(
+    app,
+    transitions_for_complete_case,
+    expected_response_status_context_for_complete_case_with_all_permissions,
+    ru_ref,
+    survey_short_name,
+    case_group_id,
+    ce_period,
+    survey_id,
+):
+    with app.test_request_context():
+        context = build_response_status_context(
+            ru_ref,
+            survey_short_name,
+            case_group_id,
+            ce_period,
+            transitions_for_complete_case,
+            survey_id,
+            True,
+            datetime.now(),
         )
         radios = get_response_status_context(context, "change_response_status", "radios")
 

--- a/tests/context/test_case_context.py
+++ b/tests/context/test_case_context.py
@@ -6,7 +6,7 @@ from response_operations_ui.contexts.case import build_response_status_context
 def test_response_status_context_with_permissions(
     app,
     transitions_for_complete_case,
-    expected_response_status_context_for_complete_case_with_all_permissions,
+    expected_response_status_context_for_complete_case,
     ru_ref,
     survey_short_name,
     case_group_id,
@@ -22,9 +22,9 @@ def test_response_status_context_with_permissions(
             transitions_for_complete_case,
             survey_id,
             True,
-            datetime.now(),
+            datetime.now() - timedelta(seconds=300),
         )
-    assert context == expected_response_status_context_for_complete_case_with_all_permissions
+    assert context == expected_response_status_context_for_complete_case
 
 
 def test_response_status_context_without_permissions(
@@ -70,7 +70,7 @@ def test_transitions_from_not_started(
             survey_id,
             True,
         )
-        radios = get_response_status_context(context, "change_response_status", "radios")
+        radios = get_response_status_context_element(context, "change_response_status", "radios")
 
     assert (
         expected_response_status_context_transitions_for_incomplete_case["change_response_status"]["radios"] == radios
@@ -80,7 +80,7 @@ def test_transitions_from_not_started(
 def test_transitions_from_completed_by_phone(
     app,
     transitions_for_complete_case,
-    expected_response_status_context_for_complete_case_with_all_permissions,
+    expected_response_status_context_for_complete_case,
     ru_ref,
     survey_short_name,
     case_group_id,
@@ -96,20 +96,17 @@ def test_transitions_from_completed_by_phone(
             transitions_for_complete_case,
             survey_id,
             True,
-            datetime.now(),
+            datetime.now() - timedelta(seconds=300),
         )
-        radios = get_response_status_context(context, "change_response_status", "radios")
+        radios = get_response_status_context_element(context, "change_response_status", "radios")
 
-    assert (
-        expected_response_status_context_for_complete_case_with_all_permissions["change_response_status"]["radios"]
-        == radios
-    )
+    assert expected_response_status_context_for_complete_case["change_response_status"]["radios"] == radios
 
 
 def test_transitions_from_no_longer_required(
     app,
     transitions_for_complete_case,
-    expected_response_status_context_for_complete_case_with_all_permissions,
+    expected_response_status_context_for_complete_case,
     ru_ref,
     survey_short_name,
     case_group_id,
@@ -125,14 +122,11 @@ def test_transitions_from_no_longer_required(
             transitions_for_complete_case,
             survey_id,
             True,
-            datetime.now(),
+            datetime.now() - timedelta(seconds=300),
         )
-        radios = get_response_status_context(context, "change_response_status", "radios")
+        radios = get_response_status_context_element(context, "change_response_status", "radios")
 
-    assert (
-        expected_response_status_context_for_complete_case_with_all_permissions["change_response_status"]["radios"]
-        == radios
-    )
+    assert expected_response_status_context_for_complete_case["change_response_status"]["radios"] == radios
 
 
 def test_transitions_from_in_progress(
@@ -155,7 +149,7 @@ def test_transitions_from_in_progress(
             survey_id,
             True,
         )
-        radios = get_response_status_context(context, "change_response_status", "radios")
+        radios = get_response_status_context_element(context, "change_response_status", "radios")
 
     assert (
         expected_response_status_context_transitions_for_incomplete_case["change_response_status"]["radios"] == radios
@@ -165,7 +159,59 @@ def test_transitions_from_in_progress(
 def test_transitions_from_complete(
     app,
     transitions_for_complete_case,
-    expected_response_status_context_for_complete_case_with_all_permissions,
+    expected_response_status_context_for_complete_case,
+    ru_ref,
+    survey_short_name,
+    case_group_id,
+    ce_period,
+    survey_id,
+):
+    with app.test_request_context():
+        context = build_response_status_context(
+            ru_ref,
+            survey_short_name,
+            case_group_id,
+            ce_period,
+            transitions_for_complete_case,
+            survey_id,
+            True,
+            datetime.now() - timedelta(seconds=300),
+        )
+        radios = get_response_status_context_element(context, "change_response_status", "radios")
+
+    assert expected_response_status_context_for_complete_case["change_response_status"]["radios"] == radios
+
+
+def test_transitions_from_complete_case_enabled(
+    app,
+    transitions_for_complete_case,
+    expected_response_status_context_for_complete_case,
+    ru_ref,
+    survey_short_name,
+    case_group_id,
+    ce_period,
+    survey_id,
+):
+    with app.test_request_context():
+        context = build_response_status_context(
+            ru_ref,
+            survey_short_name,
+            case_group_id,
+            ce_period,
+            transitions_for_complete_case,
+            survey_id,
+            True,
+            datetime.now() - timedelta(seconds=300),
+        )
+        radios = get_response_status_context_element(context, "change_response_status", "radios")
+
+    assert expected_response_status_context_for_complete_case["change_response_status"]["radios"] == radios
+
+
+def test_transitions_from_complete_case_disabled(
+    app,
+    transitions_for_complete_case,
+    expected_response_status_context_for_complete_case_status_change_disabled,
     ru_ref,
     survey_short_name,
     case_group_id,
@@ -183,70 +229,13 @@ def test_transitions_from_complete(
             True,
             datetime.now(),
         )
-        radios = get_response_status_context(context, "change_response_status", "radios")
+        radios = get_response_status_context_element(context, "change_response_status", "radios")
 
     assert (
-        expected_response_status_context_for_complete_case_with_all_permissions["change_response_status"]["radios"]
+        expected_response_status_context_for_complete_case_status_change_disabled["change_response_status"]["radios"]
         == radios
     )
 
 
-def test_transitions_from_complete_after_48_hours(
-    app,
-    transitions_for_complete_case,
-    expected_response_status_context_for_complete_case_after_48_hours,
-    ru_ref,
-    survey_short_name,
-    case_group_id,
-    ce_period,
-    survey_id,
-):
-    with app.test_request_context():
-        context = build_response_status_context(
-            ru_ref,
-            survey_short_name,
-            case_group_id,
-            ce_period,
-            transitions_for_complete_case,
-            survey_id,
-            True,
-            datetime.now() - timedelta(days=3),
-        )
-        radios = get_response_status_context(context, "change_response_status", "radios")
-
-    assert (
-        expected_response_status_context_for_complete_case_after_48_hours["change_response_status"]["radios"] == radios
-    )
-
-
-def test_transitions_from_complete_within_48_hours(
-    app,
-    transitions_for_complete_case,
-    expected_response_status_context_for_complete_case_with_all_permissions,
-    ru_ref,
-    survey_short_name,
-    case_group_id,
-    ce_period,
-    survey_id,
-):
-    with app.test_request_context():
-        context = build_response_status_context(
-            ru_ref,
-            survey_short_name,
-            case_group_id,
-            ce_period,
-            transitions_for_complete_case,
-            survey_id,
-            True,
-            datetime.now(),
-        )
-        radios = get_response_status_context(context, "change_response_status", "radios")
-
-    assert (
-        expected_response_status_context_for_complete_case_with_all_permissions["change_response_status"]["radios"]
-        == radios
-    )
-
-
-def get_response_status_context(context, section, element):
+def get_response_status_context_element(context, section, element):
     return context[section][element]

--- a/tests/context/test_reporting_units_context.py
+++ b/tests/context/test_reporting_units_context.py
@@ -10,7 +10,7 @@ def test_has_both_edit_permission(
     survey_details,
     survey_respondents,
     case,
-    expected_ru_context_with_all_permissions,
+    expected_ru_context,
 ):
     with app.test_request_context():
         context = build_reporting_units_context(
@@ -25,7 +25,7 @@ def test_has_both_edit_permission(
         hyperlink = get_ru_context(context, "collection_exercise_section", 0, "status")["hyperlink_text"]
         message = get_ru_context(context, "respondents_section", 0, "message")
 
-    assert context == expected_ru_context_with_all_permissions
+    assert context == expected_ru_context
     assert "Change" in hyperlink
     assert message[0]["value"] == "49900000001"
 
@@ -155,7 +155,7 @@ def test_respondent_active(
     survey_details,
     survey_respondents,
     case,
-    expected_ru_context_with_all_permissions,
+    expected_ru_context,
 ):
     with app.test_request_context():
         context = build_reporting_units_context(
@@ -179,7 +179,7 @@ def test_respondent_suspended(
     survey_details,
     suspended_survey_respondents,
     case,
-    expected_ru_context_with_all_permissions,
+    expected_ru_context,
 ):
     with app.test_request_context():
         context = build_reporting_units_context(
@@ -203,7 +203,7 @@ def test_respondent_enrolment_enabled(
     survey_details,
     survey_respondents,
     case,
-    expected_ru_context_with_all_permissions,
+    expected_ru_context,
 ):
     with app.test_request_context():
         context = build_reporting_units_context(
@@ -227,7 +227,7 @@ def test_respondent_enrolment_pending(
     survey_details,
     pending_enrolment_survey_respondents,
     case,
-    expected_ru_context_with_all_permissions,
+    expected_ru_context,
 ):
     with app.test_request_context():
         context = build_reporting_units_context(
@@ -251,7 +251,7 @@ def test_respondent_enrolment_disabled(
     survey_details,
     disabled_enrolment_survey_respondents,
     case,
-    expected_ru_context_with_all_permissions,
+    expected_ru_context,
 ):
     with app.test_request_context():
         context = build_reporting_units_context(

--- a/tests/test_data/case/case_events.json
+++ b/tests/test_data/case/case_events.json
@@ -3,14 +3,14 @@
     "category": "COLLECTION_INSTRUMENT_DOWNLOADED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2017-02-22T14:16:50Z",
+    "createdDateTime": "2017-02-22 14:16:50.000Z",
     "metadata": {"partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"}
   },
   {
     "category": "OFFLINE_RESPONSE_PROCESSED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-02-22T14:16:50Z",
+    "createdDateTime": "2018-02-22 14:16:50.000Z",
     "metadata": {"partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"}
 
   },
@@ -18,21 +18,21 @@
     "category": "COMPLETED_BY_PHONE",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-04-22T15:16:50Z",
+    "createdDateTime": "2018-04-22 15:16:50.000Z",
     "metadata": {"partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"}
   },
   {
    "category":"COMPLETED_TO_NOTSTARTED",
    "subCategory":null,
    "createdBy":"SYSTEM",
-   "createdDateTime":"2018-04-22T15:16:50Z",
+   "createdDateTime":"2018-04-22 15:16:50.000Z",
    "metadata":{"partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"}
   },
   {
    "category":"NO_LONGER_REQUIRED",
    "subCategory":null,
    "createdBy":"SYSTEM",
-   "createdDateTime":"2018-04-22T15:16:50Z",
+   "createdDateTime":"2018-04-22 15:16:50.000Z",
    "metadata":{"partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"}
   }
 ]

--- a/tests/test_data/case/case_events.json
+++ b/tests/test_data/case/case_events.json
@@ -3,14 +3,14 @@
     "category": "COLLECTION_INSTRUMENT_DOWNLOADED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2017-02-22 14:16:50.000Z",
+    "createdDateTime": "2017-02-22T14:16:50.000Z",
     "metadata": {"partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"}
   },
   {
     "category": "OFFLINE_RESPONSE_PROCESSED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-02-22 14:16:50.000Z",
+    "createdDateTime": "2018-02-22T14:16:50.000Z",
     "metadata": {"partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"}
 
   },
@@ -18,21 +18,21 @@
     "category": "COMPLETED_BY_PHONE",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-04-22 15:16:50.000Z",
+    "createdDateTime": "2018-04-22T15:16:50.000Z",
     "metadata": {"partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"}
   },
   {
    "category":"COMPLETED_TO_NOTSTARTED",
    "subCategory":null,
    "createdBy":"SYSTEM",
-   "createdDateTime":"2018-04-22 15:16:50.000Z",
+   "createdDateTime":"2018-04-22T15:16:50.000Z",
    "metadata":{"partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"}
   },
   {
    "category":"NO_LONGER_REQUIRED",
    "subCategory":null,
    "createdBy":"SYSTEM",
-   "createdDateTime":"2018-04-22 15:16:50.000Z",
+   "createdDateTime":"2018-04-22T15:16:50.000Z",
    "metadata":{"partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"}
   }
 ]

--- a/tests/test_data/case/case_events_without_metadata.json
+++ b/tests/test_data/case/case_events_without_metadata.json
@@ -3,14 +3,14 @@
     "category": "COLLECTION_INSTRUMENT_DOWNLOADED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2017-02-22T14:16:50Z",
+    "createdDateTime": "2017-02-22 14:16:50.000Z",
     "metadata": {}
   },
   {
     "category": "OFFLINE_RESPONSE_PROCESSED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-02-22T14:16:50Z",
+    "createdDateTime": "2018-02-22 14:16:50.000Z",
     "metadata": {}
 
   },
@@ -18,7 +18,7 @@
     "category": "COMPLETED_BY_PHONE",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-04-22T15:16:50Z",
+    "createdDateTime": "2018-04-22 15:16:50.000Z",
     "metadata": {}
 
   }

--- a/tests/test_data/case/case_events_without_metadata.json
+++ b/tests/test_data/case/case_events_without_metadata.json
@@ -3,14 +3,14 @@
     "category": "COLLECTION_INSTRUMENT_DOWNLOADED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2017-02-22 14:16:50.000Z",
+    "createdDateTime": "2017-02-22T14:16:50.000Z",
     "metadata": {}
   },
   {
     "category": "OFFLINE_RESPONSE_PROCESSED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-02-22 14:16:50.000Z",
+    "createdDateTime": "2018-02-22T14:16:50.000Z",
     "metadata": {}
 
   },
@@ -18,7 +18,7 @@
     "category": "COMPLETED_BY_PHONE",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-04-22 15:16:50.000Z",
+    "createdDateTime": "2018-04-22T15:16:50.000Z",
     "metadata": {}
 
   }

--- a/tests/test_data/case/case_events_without_partyId_in_metadata.json
+++ b/tests/test_data/case/case_events_without_partyId_in_metadata.json
@@ -3,14 +3,14 @@
     "category": "COLLECTION_INSTRUMENT_DOWNLOADED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2017-02-22T14:16:50Z",
+    "createdDateTime": "2017-02-22 14:16:50.000Z",
     "metadata": {"user": "information"}
   },
   {
     "category": "OFFLINE_RESPONSE_PROCESSED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-02-22T14:16:50Z",
+    "createdDateTime": "2018-02-22 14:16:50.000Z",
     "metadata": {"user": "information"}
 
   },
@@ -18,7 +18,7 @@
     "category": "COMPLETED_BY_PHONE",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-04-22T15:16:50Z",
+    "createdDateTime": "2018-04-22 15:16:50.000Z",
     "metadata": {"user": "information"}
 
   }

--- a/tests/test_data/case/case_events_without_partyId_in_metadata.json
+++ b/tests/test_data/case/case_events_without_partyId_in_metadata.json
@@ -3,14 +3,14 @@
     "category": "COLLECTION_INSTRUMENT_DOWNLOADED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2017-02-22 14:16:50.000Z",
+    "createdDateTime": "2017-02-22T14:16:50.000Z",
     "metadata": {"user": "information"}
   },
   {
     "category": "OFFLINE_RESPONSE_PROCESSED",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-02-22 14:16:50.000Z",
+    "createdDateTime": "2018-02-22T14:16:50.000Z",
     "metadata": {"user": "information"}
 
   },
@@ -18,7 +18,7 @@
     "category": "COMPLETED_BY_PHONE",
     "subCategory": null,
     "createdBy": "SYSTEM",
-    "createdDateTime": "2018-04-22 15:16:50.000Z",
+    "createdDateTime": "2018-04-22T15:16:50.000Z",
     "metadata": {"user": "information"}
 
   }


### PR DESCRIPTION
# What and why?
Adds a 48 hour grace period to the survey status change (from complete to not started) 
# How to test?
- deploy this pr into your environment
- run the acceptance tests
- complete the survey in frontstage
- go to `/case/49900000001/response-status?survey=QBS&period=1912`
- make sure the radio to reset to Not Started is disabled
- go to the caseevent table in the case db and edit the date of the response (`OFFLINE_RESPONSE_PROCESSED`) to have happened at lease 48 hours ago
- refresh `/case/49900000001/response-status?survey=QBS&period=1912`
- make sure the radio is now enabled and you can reset the status
# Jira
[RAS-1086](https://jira.ons.gov.uk/browse/RAS-1086)