### PR TITLE
RAS-1105 Update email-validator

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -40,8 +40,8 @@ et_xmlfile = "*"
 Jinja2 = "*"
 MarkupSafe = "*"
 WTForms = "*"
-email_validator = "*"
 jwcrypto = "*"
+email-validator = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "50a525a8a63762e4754d21246794ef426b9bf2d08cda999a1aafc9a821d311c7"
+            "sha256": "2166771f5a376ed80909d111ee4e006a4cdf126170e9ef947a9c5851005151cf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -283,20 +283,20 @@
         },
         "dnspython": {
             "hashes": [
-                "sha256:6facdf76b73c742ccf2d07add296f178e629da60be23ce4b0a9c927b1e02c3a6",
-                "sha256:a0034815a59ba9ae888946be7ccca8f7c157b286f8455b379c692efb51022a15"
+                "sha256:5ef3b9680161f6fa89daf8ad451b5f1a33b18ae8a1c6778cdf4b43f08c0a6e50",
+                "sha256:e8f0f9c23a7b7cb99ded64e6c3a6f3e701d78f50c55e002b839dea7225cff7cc"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.5.0"
+            "version": "==2.6.1"
         },
         "email-validator": {
             "hashes": [
-                "sha256:a4b0bd1cf55f073b924258d19321b1f3aa74b4b5a71a42c305575dba920e1a44",
-                "sha256:c973053efbeddfef924dc0bd93f6e77a1ea7ee0fce935aea7103c7a3d6d2d637"
+                "sha256:200a70680ba08904be6d1eef729205cc0d687634399a5924d842533efb824b84",
+                "sha256:97d882d174e2a65732fb43bfce81a3a834cbc1bde8bf419e30ef5ea976370a05"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.1.0.post1"
+            "version": "==2.1.1"
         },
         "et-xmlfile": {
             "hashes": [

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.57
+version: 3.1.58
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.57
+appVersion: 3.1.58


### PR DESCRIPTION
# What and why?
There is a vulnerability in Dnspython 2.5.0 which is used by email-validator, update email-validator to 2.1.1 which update Dnspython to 2.6.0

# How to test?
Make sure tests pass and everything works as before
# Jira
