### PR TITLE
RAS-1111 Update ROPs to call new survey business end point

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.75
+version: 3.1.76
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.75
+appVersion: 3.1.76

--- a/response_operations_ui/views/reporting_units.py
+++ b/response_operations_ui/views/reporting_units.py
@@ -178,16 +178,7 @@ def view_reporting_unit_survey(ru_ref, survey_id):
     live_collection_exercises = [
         ce for ce in collection_exercises if parse_date(ce["scheduledStartDateTime"]) < datetime.now(timezone.utc)
     ]
-
-    # Get all respondents for the given ru
-    respondent_party_ids = [respondent["partyId"] for respondent in reporting_unit.get("associations")]
-    respondents = party_controller.get_respondent_by_party_ids(respondent_party_ids)
-
-    survey_respondents = [
-        party_controller.add_enrolment_status_for_respondent(respondent, ru_ref, survey_id)
-        for respondent in respondents
-        if survey_id in party_controller.survey_ids_for_respondent(respondent, ru_ref)
-    ]
+    enrolled_respondents = party_controller.get_respondents_by_survey_and_business_id(survey_id, reporting_unit["id"])
 
     survey_collection_exercises = sorted(
         [collection_exercise for collection_exercise in live_collection_exercises],
@@ -237,9 +228,7 @@ def view_reporting_unit_survey(ru_ref, survey_id):
         collection_exercises_with_details,
         reporting_unit,
         survey_details,
-        survey_respondents,
-        case,
-        unused_iac,
+        enrolled_respondents,
         permissions,
     )
 
@@ -247,7 +236,6 @@ def view_reporting_unit_survey(ru_ref, survey_id):
         "reporting-unit-survey.html",
         ru=reporting_unit,
         survey=survey_details,
-        respondents=survey_respondents,
         collection_exercises=collection_exercises_with_details,
         iac=unused_iac,
         enrolment_code_hyperlink=enrolment_code_hyperlink,

--- a/tests/context/conftest.py
+++ b/tests/context/conftest.py
@@ -332,22 +332,17 @@ def survey_details(ce_details):
 def survey_respondents():
     return [
         {
-            "associations": [
-                {
-                    "businessRespondentStatus": "ACTIVE",
-                    "enrolments": [{"enrolmentStatus": "ENABLED", "surveyId": "02b9c366-7397-42f7-942a-76dc5876d86d"}],
-                    "partyId": "a5348157-feb4-4bad-9614-fc76e2bfea94",
-                    "sampleUnitRef": "49900000001",
-                }
-            ],
-            "emailAddress": "example@example.com",
-            "firstName": "john",
-            "id": "bf19a18f-fe15-4005-b698-fdd36f35f940",
-            "lastName": "doe",
-            "sampleUnitType": "BI",
-            "status": "ACTIVE",
-            "telephone": "07772257772",
-            "enrolmentStatus": "ENABLED",
+            "enrolment_status": "ENABLED",
+            "respondent": {
+                "emailAddress": "example@example.com",
+                "firstName": "john",
+                "id": "bf19a18f-fe15-4005-b698-fdd36f35f940",
+                "lastName": "doe",
+                "sampleUnitType": "BI",
+                "status": "ACTIVE",
+                "telephone": "07772257772",
+                "enrolmentStatus": "ENABLED",
+            },
         }
     ]
 
@@ -362,21 +357,21 @@ def multiple_survey_respondents(survey_respondents):
 @pytest.fixture
 def suspended_survey_respondents(survey_respondents):
     suspended_survey_respondents = survey_respondents.copy()
-    suspended_survey_respondents[0]["status"] = "SUSPENDED"
+    suspended_survey_respondents[0]["respondent"]["status"] = "SUSPENDED"
     return suspended_survey_respondents
 
 
 @pytest.fixture
 def pending_enrolment_survey_respondents(survey_respondents):
     pending_enrolment_survey_respondents = survey_respondents.copy()
-    pending_enrolment_survey_respondents[0]["enrolmentStatus"] = "PENDING"
+    pending_enrolment_survey_respondents[0]["enrolment_status"] = "PENDING"
     return pending_enrolment_survey_respondents
 
 
 @pytest.fixture
 def disabled_enrolment_survey_respondents(survey_respondents):
     disabled_enrolment_survey_respondents = survey_respondents.copy()
-    disabled_enrolment_survey_respondents[0]["enrolmentStatus"] = "DISABLED"
+    disabled_enrolment_survey_respondents[0]["enrolment_status"] = "DISABLED"
     return disabled_enrolment_survey_respondents
 
 

--- a/tests/context/test_reporting_units_context.py
+++ b/tests/context/test_reporting_units_context.py
@@ -18,8 +18,6 @@ def test_has_both_edit_permission(
             reporting_unit,
             survey_details,
             survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
         hyperlink = get_ru_context(context, "collection_exercise_section", 0, "status")["hyperlink_text"]
@@ -44,8 +42,6 @@ def test_no_reporting_units_edit_permission(
             reporting_unit,
             survey_details,
             survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": False, "messages_edit": True},
         )
         hyperlink = get_ru_context(context, "collection_exercise_section", 0, "status")["hyperlink_text"]
@@ -68,8 +64,6 @@ def test_no_messages_edit_permission(
             reporting_unit,
             survey_details,
             survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": False},
         )
 
@@ -85,8 +79,6 @@ def test_collection_exercise_in_progress(
             reporting_unit,
             survey_details,
             survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
         collection_exercise_status = get_ru_context(context, "collection_exercise_section", 0, "status_class")
@@ -103,8 +95,6 @@ def test_collection_exercise_completed(
             reporting_unit,
             survey_details,
             survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
         collection_exercise_status = get_ru_context(context, "collection_exercise_section", 0, "status_class")
@@ -121,8 +111,6 @@ def test_collection_exercise_no_longer_required(
             reporting_unit,
             survey_details,
             survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
         collection_exercise_status = get_ru_context(context, "collection_exercise_section", 0, "status_class")
@@ -139,8 +127,6 @@ def test_collection_exercise_error(
             reporting_unit,
             survey_details,
             survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
         collection_exercise_status = get_ru_context(context, "collection_exercise_section", 0, "status_class")
@@ -163,8 +149,6 @@ def test_respondent_active(
             reporting_unit,
             survey_details,
             survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
         respondent_status = get_ru_context(context, "respondents_section", 0, "account_status_class")
@@ -187,8 +171,6 @@ def test_respondent_suspended(
             reporting_unit,
             survey_details,
             suspended_survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
         respondent_status = get_ru_context(context, "respondents_section", 0, "account_status_class")
@@ -211,8 +193,6 @@ def test_respondent_enrolment_enabled(
             reporting_unit,
             survey_details,
             survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
         enrolment_status = get_ru_context(context, "respondents_section", 0, "enrolment_status_class")
@@ -235,8 +215,6 @@ def test_respondent_enrolment_pending(
             reporting_unit,
             survey_details,
             pending_enrolment_survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
         enrolment_status = get_ru_context(context, "respondents_section", 0, "enrolment_status_class")
@@ -259,8 +237,6 @@ def test_respondent_enrolment_disabled(
             reporting_unit,
             survey_details,
             disabled_enrolment_survey_respondents,
-            case,
-            "",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
         enrolment_status = get_ru_context(context, "respondents_section", 0, "enrolment_status_class")
@@ -283,8 +259,6 @@ def test_multiple_collection_exercises_and_respondents(
             multiple_reporting_units,
             survey_details,
             multiple_survey_respondents,
-            case,
-            "99yk5r3yjycn",
             {"reporting_unit_edit": True, "messages_edit": True},
         )
 

--- a/tests/test_data/party/enrolled_respondents.json
+++ b/tests/test_data/party/enrolled_respondents.json
@@ -1,0 +1,13 @@
+[
+            {   "enrolment_status": "ENABLED",
+                "respondent": {
+                    "emailAddress": "Jacky.Turner@email.com",
+                    "firstName": "Jacky",
+                    "lastName": "Turner",
+                    "telephone": "7971161859",
+                    "id": "cd592e0f-8d07-407b-b75d-e01fbdae8233",
+                    "sampleUnitType": "BI",
+                    "status": "ACTIVE"
+                }
+            }
+        ]

--- a/tests/views/test_reporting_units.py
+++ b/tests/views/test_reporting_units.py
@@ -38,7 +38,9 @@ url_get_cases_by_business_party_id = f"{TestingConfig.CASE_URL}/cases/partyid/{b
 
 url_get_collection_exercise_by_id = f"{TestingConfig.COLLECTION_EXERCISE_URL}/collectionexercises"
 url_get_business_attributes = f"{TestingConfig.PARTY_URL}/party-api/v1/businesses/id/{business_party_id}/attributes"
-
+url_get_respondents_by_survey_and_business_id = (
+    f"{TestingConfig.PARTY_URL}/party-api/v1/respondents/survey_id/{survey_id}/business_id/{business_party_id}"
+)
 url_get_survey_by_id = f"{TestingConfig.SURVEY_URL}/surveys/{survey_id}"
 url_get_respondent_party_by_party_id = f"{TestingConfig.PARTY_URL}/party-api/v1/respondents/id/{respondent_party_id}"
 url_get_respondent_party_by_list = f"{TestingConfig.PARTY_URL}/party-api/v1/respondents?id={respondent_party_id}"
@@ -82,6 +84,8 @@ with open(f"{project_root}/test_data/party/respondent_party.json") as fp:
     respondent_party = json.load(fp)
 with open(f"{project_root}/test_data/party/respondent_party_list.json") as fp:
     respondent_party_list = json.load(fp)
+with open(f"{project_root}/test_data/party/enrolled_respondents.json") as fp:
+    enrolled_respondents = json.load(fp)
 with open(f"{project_root}/test_data/iac/iac.json") as fp:
     iac = json.load(fp)
 with open(f"{project_root}/test_data/iac/iac_inactive.json") as fp:
@@ -259,7 +263,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
         mock_request.get(url_get_business_attributes, json=business_attributes)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
+        mock_request.get(url_get_respondents_by_survey_and_business_id, json=enrolled_respondents)
         mock_request.get(f"{url_get_iac}/{iac_1}", json=iac)
         mock_request.get(f"{url_get_iac}/{iac_2}", json=iac)
         mock_request.get(url_permission_url, json=user_permission_reporting_unit_edit_json, status_code=200)
@@ -286,7 +290,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
         mock_request.get(url_get_business_attributes, json=business_attributes)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
+        mock_request.get(url_get_respondents_by_survey_and_business_id, json=enrolled_respondents)
         mock_request.get(f"{url_get_iac}/{iac_1}", json=iac)
         mock_request.get(f"{url_get_iac}/{iac_2}", json=iac)
         mock_request.get(url_permission_url, json=user_permission_reporting_unit_edit_json, status_code=200)
@@ -309,6 +313,7 @@ class TestReportingUnits(ViewTestCase):
         self.client.post("/sign-in", follow_redirects=True, data={"username": "user", "password": "pass"})
         mock_request.get(url_get_business_by_ru_ref, json=business_reporting_unit_no_enrolments)
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
+        mock_request.get(url_get_respondents_by_survey_and_business_id, json=enrolled_respondents)
         mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
         mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
         mock_request.get(url_get_business_attributes, json=business_attributes)
@@ -343,10 +348,9 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_cases_by_business_party_id, json=cases_list)
         mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
         mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
-        mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
+        mock_request.get(url_get_respondents_by_survey_and_business_id, json=enrolled_respondents)
         mock_request.get(url_get_business_attributes, json=business_attributes)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f"{url_get_iac}/{iac_1}", json=iac)
         mock_request.get(f"{url_get_iac}/{iac_2}", json=iac)
         mock_request.get(url_permission_url, json=user_permission_admin_json, status_code=200)
@@ -367,6 +371,8 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_1}", json=collection_exercise)
         mock_request.get(f"{url_get_collection_exercise_by_id}/{collection_exercise_id_2}", json=collection_exercise_2)
         mock_request.get(url_get_business_attributes, json=business_attributes)
+        mock_request.get(url_get_respondents_by_survey_and_business_id, json=enrolled_respondents)
+
         mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
         mock_request.get(f"{url_get_iac}/{iac_1}", status_code=500)
 
@@ -810,7 +816,7 @@ class TestReportingUnits(ViewTestCase):
         mock_request.get(url_get_respondent_party_by_party_id, json=respondent_party)
         mock_request.get(url_get_business_attributes, json=business_attributes)
         mock_request.get(url_get_survey_by_id, json=survey)
-        mock_request.get(url_get_respondent_party_by_list, json=respondent_party_list)
+        mock_request.get(url_get_respondents_by_survey_and_business_id, json=enrolled_respondents)
         mock_request.get(f"{url_get_iac}/{iac_1}", json=iac)
         mock_request.get(f"{url_get_iac}/{iac_2}", json=iac)
         mock_request.get(url_permission_url, json=user_permission_admin_json, status_code=200)


### PR DESCRIPTION
# What and why?
Updates the call in view_reporting_unit_survey to use the new party service endpoint to find respondents by survey_id and business_id. There is also a small amount of refactoring and removal as well. view_reporting_unit_survey still needs a fair amount of work, so I have left it largely untouched bar the change in this PR

# How to test?
Deploy this PR and seed the db with data. Go to ROPs and search for a Reporting unit, drill down to the survey page of a business and confirm it still works and displays the correct information for respondents
<img width="1203" alt="image" src="https://github.com/ONSdigital/response-operations-ui/assets/14179817/5b57a8fa-1af7-4618-9e9c-dbce33f6881d">
Basically the PR is updating the Respondents section of the image above to call from a different endpoint. It is worth adding some more respondents, changing their state, sending a message and doing anything else you can think of
# Jira
