### PR TITLE
Example how to pass thread_id to messages tab

### DIFF
--- a/response_operations_ui/views/messages.py
+++ b/response_operations_ui/views/messages.py
@@ -91,18 +91,7 @@ def view_conversation(thread_id):
         verify_permission("messages.edit")
         payload = {"is_closed": False}
         message_controllers.patch_thread(thread_id, payload)
-        thread_url = (
-            url_for(
-                "messages_bp.view_conversation",
-                thread_id=thread_id,
-                conversation_tab=conversation_tab,
-                page=page,
-                ru_ref_filter=ru_ref_filter,
-                business_id_filter=business_id_filter,
-            )
-            + "#latest-message"
-        )
-        flash(Markup(f"Conversation re-opened. <a href={thread_url}>View conversation</a>"))
+
         return redirect(
             url_for(
                 "messages_bp.view_select_survey",
@@ -110,6 +99,7 @@ def view_conversation(thread_id):
                 page=page,
                 ru_ref_filter=ru_ref_filter,
                 business_id_filter=business_id_filter,
+                thread_id=thread_id
             )
         )
 
@@ -143,18 +133,7 @@ def view_conversation(thread_id):
                 )
             else:
                 message_controllers.send_message(_get_message_json(form, thread_id=refined_thread[0]["thread_id"]))
-            thread_url = (
-                url_for(
-                    "messages_bp.view_conversation",
-                    thread_id=thread_id,
-                    page=page,
-                    conversation_tab=conversation_tab,
-                    ru_ref_filter=ru_ref_filter,
-                    business_id_filter=business_id_filter,
-                )
-                + "#latest-message"
-            )
-            flash(Markup(f"Message sent. <a href={thread_url}>View Message</a>"))
+           
             return redirect(
                 url_for(
                     "messages_bp.view_select_survey",
@@ -162,6 +141,7 @@ def view_conversation(thread_id):
                     conversation_tab=conversation_tab,
                     ru_ref_filter=ru_ref_filter,
                     business_id_filter=business_id_filter,
+                    thread_id=thread_id
                 )
             )
 
@@ -367,11 +347,11 @@ def mark_message_unread(message_id):
 @login_required
 def view_select_survey():
     return _view_select_survey(
-        request.args.get("conversation_tab"), request.args.get("ru_ref_filter"), request.args.get("business_id_filter")
+        request.args.get("conversation_tab"), request.args.get("ru_ref_filter"), request.args.get("business_id_filter"), request.args.get("thread_id")
     )
 
 
-def _view_select_survey(conversation_tab, ru_ref_filter, business_id_filter):
+def _view_select_survey(conversation_tab, ru_ref_filter, business_id_filter, thread_id):
     """
     Redirects to either a survey stored in the session under the 'messages_survey_selection'
     key or to the survey selection screen if the key isn't present in the session
@@ -410,6 +390,7 @@ def _view_select_survey(conversation_tab, ru_ref_filter, business_id_filter):
                 conversation_tab=conversation_tab,
                 ru_ref_filter=ru_ref_filter,
                 business_id_filter=business_id_filter,
+                thread_id=thread_id
             )
         )
 
@@ -480,6 +461,7 @@ def view_selected_survey(selected_survey):  # noqa: C901
     limit = request.args.get("limit", default=10, type=int)
     conversation_tab = request.args.get("conversation_tab", default="open")
     ru_ref_filter = request.args.get("ru_ref_filter", default="")
+    thread_id = request.args.get("thread_id")
     business_id_filter = request.args.get("business_id_filter", default="")
     category = "SURVEY"
 
@@ -548,6 +530,7 @@ def view_selected_survey(selected_survey):  # noqa: C901
             ru_ref_filter=ru_ref_filter,
             tab_titles=_get_tab_titles(tab_counts, ru_ref_filter),
             show_pagination=bool(tab_counts["current"] > limit),
+            thread_id=thread_id
         )
 
     except (TypeError, KeyError):
@@ -560,6 +543,7 @@ def view_selected_survey(selected_survey):  # noqa: C901
             displayed_short_name=displayed_short_name,
             response_error=True,
             tab_titles=_get_tab_titles(),
+            thread_id=thread_id
         )
 
 
@@ -605,19 +589,7 @@ def close_conversation(thread_id):
     if request.method == "POST":
         payload = {"is_closed": True}
         message_controllers.patch_thread(thread_id, payload)
-        thread_url = (
-            url_for(
-                "messages_bp.view_conversation",
-                thread_id=thread_id,
-                conversation_tab=conversation_tab,
-                page=page,
-                ru_ref_filter=ru_ref_filter,
-                business_id_filter=business_id_filter,
-            )
-            + "#latest-message"
-        )
 
-        flash(Markup(f"Conversation closed. <a href={thread_url}>View conversation</a>"))
         return redirect(
             url_for(
                 "messages_bp.view_select_survey",
@@ -625,6 +597,7 @@ def close_conversation(thread_id):
                 conversation_tab=conversation_tab,
                 ru_ref_filter=ru_ref_filter,
                 business_id_filter=business_id_filter,
+                thread_id=thread_id
             )
         )
 


### PR DESCRIPTION
# What and why?
Code need to pass the thread_id through
![image](https://github.com/ONSdigital/response-operations-ui/assets/14179817/6e354161-1042-437e-ba28-d327ee23239a)

# N.b
I haven't done all of them and naturally you then need to create the url and change the template to display it
# Jira
