### PR TITLE
Potential fix for RAS-1147

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.80
+version: 3.1.81
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.80
+appVersion: 3.1.81

--- a/response_operations_ui/controllers/uaa_controller.py
+++ b/response_operations_ui/controllers/uaa_controller.py
@@ -469,8 +469,11 @@ def user_has_permission(permission: str, user_id=None) -> bool:
             return False
         user_id = session["user_id"]
 
-    if "permissions" not in session or datetime.fromisoformat(session["permissions"]["expiry"]) < datetime.now():
-        refresh_permissions(user_id)
+    try:
+        if "permissions" not in session or datetime.fromisoformat(session["permissions"]["expiry"]) < datetime.now():
+            refresh_permissions(user_id)
+    except ValueError:
+        session["permissions"]["expiry"] = datetime.isoformat(datetime.now() + timedelta(minutes=5))
 
     return any(permission in g["display"] for g in session["permissions"]["groups"])
 

--- a/tests/controllers/test_uaa_controller.py
+++ b/tests/controllers/test_uaa_controller.py
@@ -312,6 +312,4 @@ class TestUAAController(unittest.TestCase):
         with self.app.test_request_context():
             incorrect_date_format = str((datetime.now().strftime("%d/%m/%Y, %H:%M:%S")))
             session["permissions"] = {"groups": test_groups, "expiry": incorrect_date_format}
-            with self.assertRaises(ValueError) as e:
-                uaa_controller.user_has_permission("oauth.approvals", user_id)
-            self.assertEqual(e.exception.args[0], f"Invalid isoformat string: {incorrect_date_format!r}")
+            self.assertTrue(uaa_controller.user_has_permission("oauth.approvals", user_id))


### PR DESCRIPTION
# What and why?
After testing and deploying https://github.com/ONSdigital/response-operations-ui/pull/952 it was found that if a user was already logged in then their session with an incorrect iso date format would still persist. This would lead to the error that the original ticket was meant to fix. I have added a try to check the date is of isoformat and if it is not, then the except will deal with converting it into the correct format.

# How to test?

1. Deploy rOps version 3.1.78 to your dev env
2. Sign into rOps and navigate to surveys
3. Deploy version 3.1.79 and refresh rOps or move to another screen
4. An ValueError should appear with regards to an incorrect isoformat 
5. Deploy this branch
6. Refresh the screen, this error should no longer appear

Also run the unit tests

# Jira
https://jira.ons.gov.uk/browse/RAS-1147
