### PR TITLE
Fix my account error summary

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.90
+version: 3.1.91
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.90
+appVersion: 3.1.91

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.89
+version: 3.1.90
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.89
+appVersion: 3.1.90

--- a/response_operations_ui/templates/radio-option-select-error-panel.html
+++ b/response_operations_ui/templates/radio-option-select-error-panel.html
@@ -21,7 +21,7 @@
             {% set errorTitle = 'There is 1 error on this page' %}
             {% call
                 onsPanel({
-                    "type": "error",
+                    "variant": "error",
                     "classes": "ons-u-mb-s",
                     "title": errorTitle
                 })


### PR DESCRIPTION
# What and why?
The error summary for the my account page was mislabelled. This PR fixes the summary and solves the focus order problem it caused, highlighted in the DAC report. 
# How to test?
Deploy this PR and check a correct error summary is generated at the top of the page instead of an info summary. 
# Jira
https://jira.ons.gov.uk/browse/RAS-1361