### PR TITLE
Update sign in page error handling

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.95
+version: 3.1.96
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.95
+appVersion: 3.1.96

--- a/response_operations_ui/templates/sign_in.html
+++ b/response_operations_ui/templates/sign_in.html
@@ -75,9 +75,9 @@
                     "error": errorUN
                 })
             }}
-            {% if failed_authentication or form.password.errors | length > 0 %}
-                {% set errorPW = { "text": "Password is required", "id": 'password_error' } %}
-            {% endif %}
+        {% if failed_authentication or form.password.errors | length > 0 %}
+            {% set errorPW = { "text": "Password is required", "id": 'password_error' } %}
+        {% endif %}
             {{
                 onsPassword({
                     "id": "password",

--- a/response_operations_ui/templates/sign_in.html
+++ b/response_operations_ui/templates/sign_in.html
@@ -9,27 +9,45 @@
 {% set page_title = "Sign-In" %}
 
 {% block main %}
+{% set errorUN = { "text": "Email Address is required", "id": 'username_error' } %}
+{% set errorPW = { "text": "Password is required", "id": 'password_error' } %}
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
             {% for category, message in messages %}
                 {% if category == "failed_authentication" or category == "successful_signout" or category == "account_created" or category == "warn" %}
                     {% if category == "failed_authentication" %}
-                        {% set type = "error" %}
+                        {% set variant = "error" %}
                     {% elif category == "warn" %}
-                        {% set type = "warn" %}
+                        {% set variant = "warn" %}
                     {% else %}
-                        {% set type = "success" %}
+                        {% set variant = "success" %}
                     {% endif %}
                     {% call
                         onsPanel({
-                            "type": type,
+                            "variant": variant,
                             "classes": "ons-u-mb-s",
                             "title": message if category == "failed_authentication",
                             "iconType": "check" if category == "successful_signout" else null,
                         })
                     %}
                         {% if category == "failed_authentication" %}
-                            <p><a href="#username" id="try-again-link" class="ons-js-inpagelink">Please try again</a></p>
+                        {{
+                             onsList({
+                                "element": 'ol',
+                                "itemsList": [
+                                    {
+                                        "text": errorUN.text,
+                                        "url": '#username_error',
+                                        "variants": "inPageLink"
+                                    },
+                                    {
+                                        "text": errorPW.text,
+                                        "url": '#password_error',
+                                        "variants": "inPageLink"
+                                    },
+                                ]
+                            })
+                        }}
                         {% elif category == "warn" %}
                             <p id="signed-out-warning">{{ message }}</p>
                         {% else %}
@@ -42,47 +60,7 @@
     {% endwith %}
     <form method="post" class="form">
         {{ form.csrf_token }}
-        {% if form.errors %}
-            {% set errorData = [] %}
-            {% call
-                onsPanel({
-                    title: "This page has 1 error" if form.errors|length == 1 else "There are {{ form.errors|length }} errors on this page",
-                    type: "error"
-                })
-            %}
-                <p>These <strong>must be corrected</strong> to continue.</p>
-                {% for error in form.username.errors %}
-                    {% do errorData.append(
-                        {
-                            "text": error,
-                            "index": true,
-                            "url": "#username",
-                            "classes": "ons-js-inpagelink"
-                        }
-                    ) %}
-                {% endfor %}
-                {% for error in form.password.errors %}
-                    {% do errorData.append(
-                        {
-                            "text": error,
-                            "index": true,
-                            "url": "#password",
-                            "classes": "ons-js-inpagelink"
-                        }
-                    ) %}
-                {% endfor %}
-                {{
-                    onsList({
-                        "classes": "list--bare",
-                        "itemsList": errorData
-                    })
-                }}
-            {% endcall %}
-        {% endif %}
         <h2>Sign in</h2>
-        {% if failed_authentication or form.username.errors | length > 0 %}
-            {% set error = { "text": "Email address is required" } %}
-        {% endif %}
         {%- call onsFieldset({
             "legend": "Sign in",
             "legendClasses": "ons-u-vh"
@@ -98,13 +76,9 @@
                     "attributes": {
                         "required": true
                     },
-                    "error": error
+                    "error": errorUN
                 })
             }}
-
-            {% if failed_authentication or form.password.errors | length > 0 %}
-                {% set error = { "text": "Password is required" } %}
-            {% endif %}
 
             {{
                 onsPassword({
@@ -114,7 +88,7 @@
                         "text": "Password"
                     },
                     "showPasswordText": "Show password",
-                    "error": error
+                    "error": errorPW
                 })
             }}
         {%- endcall -%}

--- a/response_operations_ui/templates/sign_in.html
+++ b/response_operations_ui/templates/sign_in.html
@@ -55,7 +55,7 @@
         {{ form.csrf_token }}
         <h2>Sign in</h2>
         {% if failed_authentication or form.username.errors | length > 0 %}
-            {% set errorUN = { "text": "Email Address is required", "id": 'username_error' } %}
+            {% set usernameError = { "text": "Email Address is required", "id": 'username_error' } %}
         {% endif %}
         {%- call onsFieldset({
             "legend": "Sign in",
@@ -72,11 +72,11 @@
                     "attributes": {
                         "required": true
                     },
-                    "error": errorUN
+                    "error": usernameError
                 })
             }}
             {% if failed_authentication or form.password.errors | length > 0 %}
-                {% set errorPW = { "text": "Password is required", "id": 'password_error' } %}
+                {% set passwordError = { "text": "Password is required", "id": 'password_error' } %}
             {% endif %}
             {{
                 onsPassword({
@@ -86,7 +86,7 @@
                         "text": "Password"
                     },
                     "showPasswordText": "Show password",
-                    "error": errorPW
+                    "error": passwordError
                 })
             }}
         {%- endcall -%}

--- a/response_operations_ui/templates/sign_in.html
+++ b/response_operations_ui/templates/sign_in.html
@@ -9,8 +9,6 @@
 {% set page_title = "Sign-In" %}
 
 {% block main %}
-{% set errorUN = { "text": "Email Address is required", "id": 'username_error' } %}
-{% set errorPW = { "text": "Password is required", "id": 'password_error' } %}
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
             {% for category, message in messages %}
@@ -36,13 +34,8 @@
                                 "element": 'ol',
                                 "itemsList": [
                                     {
-                                        "text": errorUN.text,
+                                        "text": "Incorrect email or password",
                                         "url": '#username_error',
-                                        "variants": "inPageLink"
-                                    },
-                                    {
-                                        "text": errorPW.text,
-                                        "url": '#password_error',
                                         "variants": "inPageLink"
                                     },
                                 ]
@@ -65,6 +58,9 @@
             "legend": "Sign in",
             "legendClasses": "ons-u-vh"
         }) -%}
+        {% if failed_authentication or form.username.errors | length > 0 %}
+            {% set errorUN = { "text": "Email Address is required", "id": 'username_error' } %}
+        {% endif %}
             {{
                 onsInput({
                     "id": "username",
@@ -79,7 +75,9 @@
                     "error": errorUN
                 })
             }}
-
+            {% if failed_authentication or form.password.errors | length > 0 %}
+                {% set errorPW = { "text": "Password is required", "id": 'password_error' } %}
+            {% endif %}
             {{
                 onsPassword({
                     "id": "password",

--- a/response_operations_ui/templates/sign_in.html
+++ b/response_operations_ui/templates/sign_in.html
@@ -54,13 +54,13 @@
     <form method="post" class="form">
         {{ form.csrf_token }}
         <h2>Sign in</h2>
+        {% if failed_authentication or form.username.errors | length > 0 %}
+            {% set errorUN = { "text": "Email Address is required", "id": 'username_error' } %}
+        {% endif %}
         {%- call onsFieldset({
             "legend": "Sign in",
             "legendClasses": "ons-u-vh"
         }) -%}
-        {% if failed_authentication or form.username.errors | length > 0 %}
-            {% set errorUN = { "text": "Email Address is required", "id": 'username_error' } %}
-        {% endif %}
             {{
                 onsInput({
                     "id": "username",
@@ -75,9 +75,9 @@
                     "error": errorUN
                 })
             }}
-        {% if failed_authentication or form.password.errors | length > 0 %}
-            {% set errorPW = { "text": "Password is required", "id": 'password_error' } %}
-        {% endif %}
+            {% if failed_authentication or form.password.errors | length > 0 %}
+                {% set errorPW = { "text": "Password is required", "id": 'password_error' } %}
+            {% endif %}
             {{
                 onsPassword({
                     "id": "password",


### PR DESCRIPTION
# What and why?
This PR updates the error handling on the sign in page. It was identified in the DAC report that the error summary displayed a misleading please try again message. This has been updated with links to the specific errors. 
The error summary was also being displayed as an info summary which has been updated. 

# How to test?
Navigate to the sign in page and generate a sign in error. Check the resulting error summary and components meets the requirements on the DAC report. 

Check all other sign in page functionality remains unchanged. 

# Jira
[RAS-1364](https://jira.ons.gov.uk/browse/RAS-1364)