### PR TITLE
DAC Report - Surveys - Tables

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.96
+version: 3.1.97
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.96
+appVersion: 3.1.97

--- a/response_operations_ui/templates/surveys.html
+++ b/response_operations_ui/templates/surveys.html
@@ -43,16 +43,16 @@
             
         {% set surveyTableHeaders = [
         {
-            "value": "Survey title",
+            "value": "Survey title"
         },
         {
-            "value": "Survey ID",
+            "value": "Survey ID"
         },
         {
-            "value": "Survey mode",
+            "value": "Survey mode"
         },
         {
-            "value": "Legal basis",
+            "value": "Legal basis"
         }
         ] %}
     

--- a/response_operations_ui/templates/surveys.html
+++ b/response_operations_ui/templates/surveys.html
@@ -37,93 +37,68 @@
             </p>
           </div>
       {% endif %}
-  </div>
-  <div class="ons-grid">
-    <div class="ons-grid__col">
-      {% set surveyTableData = {
-          "table_class": 'table--dense',
-          "variants": ['sortable', 'compact', 'responsive'],
-          "sortBy": "Sort by",
-          "ariaAsc": "ascending",
-          "ariaDesc": "descending",
-          "id": 'tbl-surveys',
-          "ths": [
-                    {
-                        "value": "Survey title","ariaSort": "none"
-                    },
-                    {
-                        "value": "Survey ID","ariaSort": "none"
-                    },
-                    {
-                        "value": "Survey mode","ariaSort": "none"
-                    },
-                    {
-                        "value": "Legal basis","ariaSort": "none"
-                    } 
-                  ] if surveyEditPermission else 
-                  [
-                      {
-                          "value": "Survey title","ariaSort": "none"
-                      },
-                      {
-                          "value": "Survey ID","ariaSort": "none"
-                      },
-                      {
-                          "value": "Survey mode","ariaSort": "none"
-                      },
-                      {
-                          "value": "Legal basis","ariaSort": "none"
-                      }
-                  ]
-      } %}
+    </div>
+    <div class="ons-grid">
+        <div class="ons-grid__col">
+            
+        {% set surveyTableHeaders = [
+        {
+            "value": "Survey title", "ariaSort": "none"
+        },
+        {
+            "value": "Survey ID", "ariaSort": "none"
+        },
+        {
+            "value": "Survey mode", "ariaSort": "none"
+        },
+        {
+            "value": "Legal basis", "ariaSort": "none"
+        }
+        ] %}
+    
+        {% if surveyEditPermission %}
+            {% do surveyTableHeaders.append({"value": "Edit Survey"}) %}
+        {% endif %}
+        
+        {% set surveyTableData = {
+            "table_class": 'table--dense',
+            "variants": ['sortable', 'compact', 'responsive'],
+            "sortBy": "Sort by",
+            "ariaAsc": "ascending",
+            "ariaDesc": "descending",
+            "id": 'tbl-surveys',
+            "ths": surveyTableHeaders
+        } %}
         {% set surveyTableDataRows = [] %}
-
         {% for survey in survey_list %}
-            {% do surveyTableDataRows.append(
-            {
-                "tds": [
-                    {
-                        "value": '<a href="/surveys/' + survey.shortName.replace(' ', '') + '" name="survey-link-' + survey.shortName + '">' + survey.longName + '</a><a style="text-decoration: none">' + ' | ' + survey.shortName + '</a>',
-                        "data": "Survey Title"
-                    },
-                    {
-                        "value": survey.surveyRef,
-                        "data": "Survey ID"
-                    },
-                    {
-                        "value": survey.surveyMode.replace('_AND_', ' and '),
-                        "data": "Survey mode"
-                    },
-                    {
-                        "value": survey.legalBasis,
-                        "data": "Legal basis"
-                    },
-                    {
-                        "value": '<a href="' + url_for("surveys_bp.view_survey_details", short_name=survey.shortName) + '">Edit survey</a>',
-                        "class": "ons-u-ta-right",
-                        "dataSort": "2",
-                    } if surveyEditPermission else 
-                        [
-                            {
-                                "value": '<a href="/surveys/' + survey.shortName.replace(' ', '') + '" name="survey-link-' + survey.shortName + '">' + survey.longName + '</a>' + ' | ' + survey.shortName,
-                                "data": "Survey Title"
-                            },
-                            {
-                                "value": survey.surveyRef,
-                                "data": "Survey ID"
-                            },
-                            {
-                                "value": survey.surveyMode.replace('_AND_', ' and '),
-                                "data": "Survey mode"
-                            },
-                            {
-                                "value": survey.legalBasis,
-                                "data": "Legal basis"
-                            }
-                        ]
-                ]
-            }
-            ) %}
+            {% set surveyRow = [
+                {
+                    "value": '<a href="/surveys/' + survey.shortName.replace(' ', '') + '" name="survey-link-' + survey.shortName + '">' + survey.longName + '</a><a style="text-decoration: none">' + ' | ' + survey.shortName + '</a>',
+                    "data": "Survey Title"
+                },
+                {
+                    "value": survey.surveyRef,
+                    "data": "Survey ID"
+                },
+                {
+                    "value": survey.surveyMode.replace('_AND_', ' and '),
+                    "data": "Survey mode"
+                },
+                {
+                    "value": survey.legalBasis,
+                    "data": "Legal basis"
+                }
+            ] %}
+        
+            {% if surveyEditPermission %}
+                {% do surveyRow.append({
+                    "value": '<a href="' + url_for("surveys_bp.view_survey_details", short_name=survey.shortName) + '">Edit survey</a>',
+                    "class": "ons-u-ta-right",
+                    "dataSort": "2"
+                }) %}
+            {% endif %}
+
+            {% do surveyTableDataRows.append({"tds": surveyRow}) %}
         {% endfor %}
 
         {% do surveyTableData | setAttribute("trs", surveyTableDataRows) %}
@@ -131,6 +106,6 @@
         {{
             onsTable(surveyTableData)
         }}
+        </div>
     </div>
-  </div>
 {% endblock %}

--- a/response_operations_ui/templates/surveys.html
+++ b/response_operations_ui/templates/surveys.html
@@ -43,21 +43,21 @@
             
         {% set surveyTableHeaders = [
         {
-            "value": "Survey title", "ariaSort": "none"
+            "value": "Survey title",
         },
         {
-            "value": "Survey ID", "ariaSort": "none"
+            "value": "Survey ID",
         },
         {
-            "value": "Survey mode", "ariaSort": "none"
+            "value": "Survey mode",
         },
         {
-            "value": "Legal basis", "ariaSort": "none"
+            "value": "Legal basis",
         }
         ] %}
     
         {% if surveyEditPermission %}
-            {% do surveyTableHeaders.append({"value": "Edit Survey"}) %}
+            {% do surveyTableHeaders.append({"value": "Edit survey"}) %}
         {% endif %}
         
         {% set surveyTableData = {


### PR DESCRIPTION
# What and why?
This PR introduces a table header to the Edit Survey column to meet the DAC requirements and improve the navigation of the table for screen reader users. 

N.B. The design system does not currently allow individual columns to be sortable as it is applied in a macro to the entire table. Therefore a sort element is included with the header. 
https://github.com/ONSdigital/design-system/issues/2125

# How to test?
Deploy this PR and check there is now a table header on the Edit Survey column. 
# Jira
[RAS-1366](https://jira.ons.gov.uk/browse/RAS-1366)