### PR TITLE
DAC Report - Reporting Units - Duplicate/non-descriptive page titles

### DIFF
--- a/response_operations_ui/templates/layouts/base.html
+++ b/response_operations_ui/templates/layouts/base.html
@@ -43,7 +43,7 @@
 %}
 {% endif %}
 {% set pageConfig = {
-    "title": page_title + " | Survey Data Collection" if page_title else "Survey Data Collection",
+    "title": page_title + " | Survey Data Collection | ONS" if page_title else "Survey Data Collection | ONS",
     "wide": true,
     "header": {
         "title": 'Survey Data Collection',

--- a/response_operations_ui/templates/reporting-unit-search/reporting-units.html
+++ b/response_operations_ui/templates/reporting-unit-search/reporting-units.html
@@ -3,7 +3,7 @@
 {% from "components/input/_macro.njk" import onsInput %}
 {% from "components/table/_macro.njk" import onsTable %}
 
-{% set page_title = "Reporting units" %}
+{% set page_title = total_business_count ~ " results found | Reporting units" %}
 
 {% block main %}
     <h1>Reporting units</h1>


### PR DESCRIPTION
# What and why?
This PR updates the reporting Unit search page to include the search results within the page title. This meets the requirements set out in the DAC report to avoid duplicate titles on the reporting unit and reporting unit search pages. 

The base template has also been updated to include the organisation (ONS) in the page titles as per the report. 

# How to test?
Deploy this PR and navigate to the reporting unit page. Search for reporting units and check that the title reflects the results found under different search scenarios. 
# Jira
[RAS-1367](https://jira.ons.gov.uk/browse/RAS-1367)