### PR TITLE
RAS-1546 Create new 'Collection instruments step 2 of 2' page

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.100
+version: 3.1.101
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.100
+appVersion: 3.1.101

--- a/response_operations_ui/templates/collection_exercise/view-sample-ci-summary.html
+++ b/response_operations_ui/templates/collection_exercise/view-sample-ci-summary.html
@@ -1,0 +1,42 @@
+{% extends "layouts/base.html" %}
+{% from "components/table/_macro.njk" import onsTable %}
+
+{% set  formTypeCIVersionTable = {
+    "id": "form-type-ci-version",
+    "ths": [{
+        "value": "EQ form type"
+    },
+    {
+        "value": "CIR version"
+    }]
+}%}
+
+{% set formTypeCIVersionTableDataRows = [] %}
+
+{% for collection_instrument in collection_instruments %}
+    {% do formTypeCIVersionTableDataRows.append(
+        {
+            "tds": [
+                {
+                    "value": collection_instrument["classifiers"]["form_type"]
+                },
+                {
+                  "value": "Nothing selected",
+                  "tdClasses": "ons-u-ta-centre"
+                }, 
+                {
+                  "value": '<a href="">Choose a version</a>',
+                  "tdClasses": "ons-u-ta-right"
+                }
+              ] 
+          }
+      )
+    %}
+    {% endfor %}
+    {% do formTypeCIVersionTable | setAttribute("trs", formTypeCIVersionTableDataRows) %}
+
+{% block main %}
+    <h1 class="ons-u-fs-xl" >Collection instruments step 2 of 2</h1>
+    <h3 class="ons-u-fs-m">Choose a CIR version for each eQ form type</h3>
+    {{ onsTable(formTypeCIVersionTable) }}
+{% endblock %}

--- a/response_operations_ui/templates/collection_exercise/view-sample-ci-summary.html
+++ b/response_operations_ui/templates/collection_exercise/view-sample-ci-summary.html
@@ -4,7 +4,7 @@
 {% set  formTypeCIVersionTable = {
     "id": "form-type-ci-version",
     "ths": [{
-        "value": "EQ form type"
+        "value": "EQ formtype"
     },
     {
         "value": "CIR version"
@@ -37,6 +37,6 @@
 
 {% block main %}
     <h1 class="ons-u-fs-xl" >Collection instruments step 2 of 2</h1>
-    <h3 class="ons-u-fs-m">Choose a CIR version for each eQ form type</h3>
+    <h3 class="ons-u-fs-m">Choose a CIR version for each EQ formtype</h3>
     {{ onsTable(formTypeCIVersionTable) }}
 {% endblock %}

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -2789,7 +2789,7 @@ class TestCollectionExercise(ViewTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("0001".encode(), response.data)
         self.assertIn("0002".encode(), response.data)
-        self.assertIn("Choose a CIR version for each eQ form type".encode(), response.data)
+        self.assertIn("Choose a CIR version for each EQ formtype".encode(), response.data)
         self.assertIn("Choose a version".encode(), response.data)
 
     @patch("response_operations_ui.views.collection_exercise.survey_controllers.get_survey_by_shortname")

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -2767,3 +2767,46 @@ class TestCollectionExercise(ViewTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("There is a problem with this page".encode(), response.data)
+
+    @patch("response_operations_ui.views.collection_exercise.survey_controllers.get_survey_by_shortname")
+    @patch(
+        "response_operations_ui.views.collection_exercise."
+        "collection_exercise_controllers.get_collection_exercises_by_survey"
+    )
+    @patch("response_operations_ui.views.collection_exercise._build_collection_instruments_details")
+    def test_view_sample_ci_summary(
+        self, build_collection_instruments_details, get_ce_by_survey, get_survey_by_shortname
+    ):
+        get_survey_by_shortname.return_value = {"id": survey_id}
+        get_ce_by_survey.return_value = [
+            {"id": "d64cbfd2-20b1-4e10-962e-bd57f4946db7", "surveyId": survey_id, "exerciseRef": period}
+        ]
+        build_collection_instruments_details.return_value = {
+            "EQ": [{"classifiers": {"form_type": "0001"}}, {"classifiers": {"form_type": "0002"}}]
+        }
+        response = self.client.get(f"/surveys/{short_name}/{period}/view-sample-ci/summary")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("0001".encode(), response.data)
+        self.assertIn("0002".encode(), response.data)
+        self.assertIn("Choose a CIR version for each eQ form type".encode(), response.data)
+        self.assertIn("Choose a version".encode(), response.data)
+
+    @patch("response_operations_ui.views.collection_exercise.survey_controllers.get_survey_by_shortname")
+    @patch(
+        "response_operations_ui.views.collection_exercise."
+        "collection_exercise_controllers.get_collection_exercises_by_survey"
+    )
+    @patch("response_operations_ui.views.collection_exercise._build_collection_instruments_details")
+    def test_view_sample_ci_summary_no_cis(
+        self, build_collection_instruments_details, get_collection_exercises_by_survey, get_survey_by_shortname
+    ):
+        get_survey_by_shortname.return_value = {"id": survey_id}
+        get_collection_exercises_by_survey.return_value = [
+            {"id": "d64cbfd2-20b1-4e10-962e-bd57f4946db7", "surveyId": survey_id, "exerciseRef": period}
+        ]
+        build_collection_instruments_details.return_value = {}
+        response = self.client.get(f"/surveys/{short_name}/{period}/view-sample-ci/summary")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Choose a version".encode(), response.data)


### PR DESCRIPTION
# What and why?
Adds in the summary page for CIR 
# How to test?
create a collection exercise in rops, then navigated to http://localhost:8085/surveys/<survey_short_name>/<period_id>/view-sample-ci/summary,  it should be empty, but works. Now add a collection instrument into the exercise and return to the page, it should now show the table populated
# Jira
