### PR TITLE
Introduce ci versions page

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.100
+version: 3.1.101
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.100
+appVersion: 3.1.101

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.101
+version: 3.1.102
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.101
+appVersion: 3.1.102

--- a/response_operations_ui/templates/collection_exercise/ci-versions.html
+++ b/response_operations_ui/templates/collection_exercise/ci-versions.html
@@ -1,0 +1,5 @@
+{% extends "layouts/base.html" %}
+
+{% block main %}
+<h1>Choose CIR version for EQ formtype {{ form_type }}</h1>
+{% endblock %}

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -1108,6 +1108,6 @@ def _add_collection_instrument(short_name, period):
 
 @collection_exercise_bp.route("/<short_name>/<period>/view-sample-ci/summary/<form_type>", methods=["GET"])
 @login_required
-def view_ci_versions(short_name, period, form_type) -> str:
-
+def view_ci_versions(short_name: str, period: str, form_type: str) -> str:
+    
     return render_template("collection_exercise/ci-versions.html", form_type=form_type)

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -1127,10 +1127,9 @@ def view_sample_ci_summary(short_name: str, period: str) -> str:
         collection_instruments=eq_collection_instruments,
     )
 
-  
+
 @collection_exercise_bp.route("/<short_name>/<period>/view-sample-ci/summary/<form_type>", methods=["GET"])
 @login_required
 def view_ci_versions(short_name: str, period: str, form_type: str) -> str:
 
     return render_template("collection_exercise/ci-versions.html", form_type=form_type)
-  

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -1109,5 +1109,5 @@ def _add_collection_instrument(short_name, period):
 @collection_exercise_bp.route("/<short_name>/<period>/view-sample-ci/summary/<form_type>", methods=["GET"])
 @login_required
 def view_ci_versions(short_name: str, period: str, form_type: str) -> str:
-    
+
     return render_template("collection_exercise/ci-versions.html", form_type=form_type)

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -1104,3 +1104,10 @@ def _add_collection_instrument(short_name, period):
 
     form.formtype.data = ""  # Reset the value on successful submission
     return get_view_sample_ci(short_name, period)
+
+
+@collection_exercise_bp.route("/<short_name>/<period>/view-sample-ci/summary/<form_type>", methods=["GET"])
+@login_required
+def view_ci_versions(short_name, period, form_type) -> str:
+
+    return render_template("collection_exercise/ci-versions.html", form_type=form_type)

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -2767,3 +2767,12 @@ class TestCollectionExercise(ViewTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("There is a problem with this page".encode(), response.data)
+
+
+    def test_view_ci_versions(self):
+        form_type = "0001"
+
+        response = self.client.get(f"/surveys/{short_name}/{period}/view-sample-ci/summary/{form_type}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(form_type.encode(), response.data)

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -2768,7 +2768,6 @@ class TestCollectionExercise(ViewTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("There is a problem with this page".encode(), response.data)
 
-
     def test_view_ci_versions(self):
         form_type = "0001"
 

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -2768,7 +2768,6 @@ class TestCollectionExercise(ViewTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("There is a problem with this page".encode(), response.data)
 
-
     @patch("response_operations_ui.views.collection_exercise.survey_controllers.get_survey_by_shortname")
     @patch(
         "response_operations_ui.views.collection_exercise."
@@ -2792,7 +2791,7 @@ class TestCollectionExercise(ViewTestCase):
         self.assertIn("0002".encode(), response.data)
         self.assertIn("Choose a CIR version for each EQ formtype".encode(), response.data)
         self.assertIn("Choose a version".encode(), response.data)
-        
+
     @patch("response_operations_ui.views.collection_exercise.survey_controllers.get_survey_by_shortname")
     @patch(
         "response_operations_ui.views.collection_exercise."
@@ -2811,7 +2810,7 @@ class TestCollectionExercise(ViewTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Choose a version".encode(), response.data)
- 
+
     def test_view_ci_versions(self):
         form_type = "0001"
 

--- a/tests/views/test_collection_exercise.py
+++ b/tests/views/test_collection_exercise.py
@@ -2775,3 +2775,4 @@ class TestCollectionExercise(ViewTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(form_type.encode(), response.data)
+        self.assertIn("Choose CIR version for EQ formtype".encode(), response.data)


### PR DESCRIPTION
# What and why?
This page introduces the CI versions page and displays the title. 
Assumption that the formtype will be passed through on clicking the choose version link on the previous page. 
There is a comment on the jira card that validation of url will be achieved on a separate card so this has been left off. 
Basic test introduced which can be extended with the rest of the functionality
# How to test?
Navigate to http://localhost:8085/surveys/<short_name>/<period_id>/view-sample-ci/summary/0001
# Jira
[RAS-1547](https://jira.ons.gov.uk/browse/RAS-1547)