### PR TITLE
remove lodash.template dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -172,7 +172,6 @@
         "lodash": "^4.17.21",
         "lodash._reinterpolate": "^3.0.0",
         "lodash.debounce": "^4.0.8",
-        "lodash.template": "^4.5.0",
         "lodash.templatesettings": "^4.2.0",
         "loud-rejection": "^1.6.0",
         "lru-cache": "^6.0.0",
@@ -4871,15 +4870,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
     },
     "node_modules/lodash.templatesettings": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
     "lodash": "^4.17.21",
     "lodash._reinterpolate": "^3.0.0",
     "lodash.debounce": "^4.0.8",
-    "lodash.template": "^4.5.0",
     "lodash.templatesettings": "^4.2.0",
     "loud-rejection": "^1.6.0",
     "lru-cache": "^6.0.0",


### PR DESCRIPTION
# What and why?
This PR removes the lodash.template dependency, which has been deprecated for 6 years and has not received updates. Its presence in the service was causing an unresolvable dependabot alert.

# How to test?

# Jira
