### PR TITLE
Add support for Wiremock in non formal envs

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.134
+version: 3.1.135
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.134
+appVersion: 3.1.135

--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.133
+version: 3.1.134
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.133
+appVersion: 3.1.134

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -238,11 +238,11 @@ spec:
           - name: CIR_ENABLED
             value: "{{ .Values.cir.enabled }}"
           - name: CIR_API_URL
-            value: {{- if .Values.cir.apiUrl }}
-              {{ .Values.cir.apiUrl }}
+            {{ if .Values.cir.apiUrl }}
+            value: {{ .Values.cir.apiUrl }}
             {{- else -}}
-              http://wiremock.{{ .Values.namespace }}.svc.cluster.local:8080
-            {{- end }}
+            value: "http://wiremock.{{ .Values.namespace }}.svc.cluster.local:8080"
+            {{- end}}
           - name: CIR_OAUTH2_CLIENT_ID
             value: {{ .Values.cir.oauth2ClientId }}     
           resources:

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -238,7 +238,7 @@ spec:
           - name: CIR_ENABLED
             value: "{{ .Values.cir.enabled }}"
           - name: CIR_API_URL
-            value: {{- if or (eq .Values.env "prod") (eq .Values.env "preprod") -}}
+            value: {{- if .Values.cir.apiUrl }}
               {{ .Values.cir.apiUrl }}
             {{- else -}}
               http://wiremock.{{ .Values.namespace }}.svc.cluster.local:8080

--- a/_infra/helm/response-operations-ui/templates/deployment.yaml
+++ b/_infra/helm/response-operations-ui/templates/deployment.yaml
@@ -238,7 +238,11 @@ spec:
           - name: CIR_ENABLED
             value: "{{ .Values.cir.enabled }}"
           - name: CIR_API_URL
-            value: {{ .Values.cir.apiUrl }}
+            value: {{- if or (eq .Values.env "prod") (eq .Values.env "preprod") -}}
+              {{ .Values.cir.apiUrl }}
+            {{- else -}}
+              http://wiremock.{{ .Values.namespace }}.svc.cluster.local:8080
+            {{- end }}
           - name: CIR_OAUTH2_CLIENT_ID
             value: {{ .Values.cir.oauth2ClientId }}     
           resources:

--- a/_infra/helm/response-operations-ui/values.yaml
+++ b/_infra/helm/response-operations-ui/values.yaml
@@ -65,8 +65,7 @@ notify:
   deleteUserTemplate: delete_user_id
 
 cir:
-  enabled: false
-  apiUrl: http://localhost:5052
+  enabled: true
   oauth2ClientId: dummy_client_id
 
 dashboard:


### PR DESCRIPTION
# What and why?

Adding support to allow Wiremock to be used in non formal env, or the CIR service to be used in prod/preprod

# How to test?

Ensure wiremock is used in dev/sandbox clusters, and that the actual CIR is used in preprod/prod

# Jira

https://jira.ons.gov.uk/browse/RAS-1662