### PR TITLE
Update cir versions page for view users

### DIFF
--- a/response_operations_ui/templates/errors/no-permission-error.html
+++ b/response_operations_ui/templates/errors/no-permission-error.html
@@ -9,7 +9,7 @@
             "classes": "ons-u-mb-l"
         })
     %}
-      <p>You do not have the required permission to access this function under your current role profile. If you believe this to be a mistake, please contact your SDC champion representative.</p>
+      <p>You do not have permission to access this page. If you believe this is a mistake, contact your SDC champion.</p>
     {% endcall %}
     <p><a href="/surveys">Return to surveys</a></p>
 {% endblock main %}

--- a/response_operations_ui/views/collection_exercise.py
+++ b/response_operations_ui/views/collection_exercise.py
@@ -1168,6 +1168,7 @@ def view_sample_ci_summary(short_name: str, period: str) -> str:
 @collection_exercise_bp.route("/<short_name>/<period>/view-sample-ci/summary/<form_type>", methods=["GET"])
 @login_required
 def view_ci_versions(short_name: str, period: str, form_type: str) -> str:
+    verify_permission("surveys.edit")
     redis_cache = RedisCache()
     survey = redis_cache.get_survey_by_shortname(short_name)
     long_name = survey.get("longName")


### PR DESCRIPTION
# What and why?
This PR updates the CIR versions page to show a no access page if the user does not have edit permissions or if the survey is not editable (It is no longer in created state). In both these scenarios the only way to reach this page is through the URL, so until a view journey is created they shouldn't be able to access the page. 
The text of the page has been updated to reflect the figma and recent UX design. 
# How to test?
Check the CIR versions page is still accessible and usable as an edit user.
Check that view users see the no access page.
Check that surveys that are not in created state also see the no access page. 
# Jira
https://officefornationalstatistics.atlassian.net/browse/RAS-1639