### PR TITLE
RAS-1877 500 error when date causes validation error in CE

### DIFF
--- a/_infra/helm/response-operations-ui/Chart.yaml
+++ b/_infra/helm/response-operations-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 3.1.161
+version: 3.1.162
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.161
+appVersion: 3.1.162

--- a/response_operations_ui/views/update_event_date.py
+++ b/response_operations_ui/views/update_event_date.py
@@ -130,7 +130,7 @@ def update_event_date_submit(short_name, period, tag):
     try:
         valid_date_for_event(tag, form)
     except ValidationError as exception:
-        flash(exception, "error")
+        flash(str(exception), "error")
         return redirect(
             url_for("collection_exercise_bp.update_event_date", short_name=short_name, period=period, tag=tag)
         )


### PR DESCRIPTION
# What and why?
On changing any event date on the CE page which was correct initially, but then is incorrect, a validation error is raised, which then triggers a serialization error on flash. This fixes the issues
# How to test?
Create a CE and update all event dates to be correct, now pick one and set it to a date that would cause an issue, i.e Go_live before mps and make sure the UI handles it correctly.

# Jira
